### PR TITLE
Improve the accuracy of eigs_sym() and eigs_gen()

### DIFF
--- a/include/armadillo_bits/arma_cmath.hpp
+++ b/include/armadillo_bits/arma_cmath.hpp
@@ -1,10 +1,10 @@
-// Copyright (C) 2008-2014 National ICT Australia (NICTA)
-// 
+// Copyright (C) 2008-2016 National ICT Australia (NICTA)
+//
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 // -------------------------------------------------------------------
-// 
+//
 // Written by Conrad Sanderson - http://conradsanderson.id.au
 
 
@@ -24,7 +24,7 @@ bool
 arma_isfinite(eT val)
   {
   arma_ignore(val);
-    
+
   return true;
   }
 
@@ -50,9 +50,9 @@ arma_isfinite(float x)
   #else
     {
     const float y = (std::numeric_limits<float>::max)();
-    
+
     const volatile float xx = x;
-    
+
     return (xx == xx) && (x >= -y) && (x <= y);
     }
   #endif
@@ -80,9 +80,9 @@ arma_isfinite(double x)
   #else
     {
     const double y = (std::numeric_limits<double>::max)();
-    
+
     const volatile double xx = x;
-    
+
     return (xx == xx) && (x >= -y) && (x <= y);
     }
   #endif
@@ -117,7 +117,7 @@ bool
 arma_isinf(eT val)
   {
   arma_ignore(val);
-    
+
   return false;
   }
 
@@ -139,9 +139,9 @@ arma_isinf(float x)
   #else
     {
     const float y = (std::numeric_limits<float>::max)();
-    
+
     const volatile float xx = x;
-    
+
     return (xx == xx) && ((x < -y) || (x > y));
     }
   #endif
@@ -165,9 +165,9 @@ arma_isinf(double x)
   #else
     {
     const double y = (std::numeric_limits<double>::max)();
-    
+
     const volatile double xx = x;
-    
+
     return (xx == xx) && ((x < -y) || (x > y));
     }
   #endif
@@ -195,7 +195,7 @@ bool
 arma_isnan(eT val)
   {
   arma_ignore(val);
-    
+
   return false;
   }
 
@@ -217,7 +217,7 @@ arma_isnan(float x)
   #else
     {
     const volatile float xx = x;
-    
+
     return (xx != xx);
     }
   #endif
@@ -241,7 +241,7 @@ arma_isnan(double x)
   #else
     {
     const volatile double xx = x;
-    
+
     return (xx != xx);
     }
   #endif
@@ -327,9 +327,9 @@ arma_log1p(const double x)
 
 //
 // wrappers for trigonometric functions
-// 
+//
 // wherever possible, try to use C++11 or TR1 versions of the following functions:
-// 
+//
 // complex acos
 // complex asin
 // complex atan
@@ -341,10 +341,10 @@ arma_log1p(const double x)
 // complex acosh
 // complex asinh
 // complex atanh
-// 
-// 
+//
+//
 // if C++11 or TR1 are not available, we have rudimentary versions of:
-// 
+//
 // real    acosh
 // real    asinh
 // real    atanh
@@ -368,7 +368,7 @@ arma_acos(const std::complex<T>& x)
     {
     arma_ignore(x);
     arma_stop_logic_error("acos(): need C++11 compiler");
-    
+
     return std::complex<T>(0);
     }
   #endif
@@ -393,7 +393,7 @@ arma_asin(const std::complex<T>& x)
     {
     arma_ignore(x);
     arma_stop_logic_error("asin(): need C++11 compiler");
-    
+
     return std::complex<T>(0);
     }
   #endif
@@ -418,7 +418,7 @@ arma_atan(const std::complex<T>& x)
     {
     arma_ignore(x);
     arma_stop_logic_error("atan(): need C++11 compiler");
-    
+
     return std::complex<T>(0);
     }
   #endif
@@ -540,7 +540,7 @@ arma_acosh(const std::complex<T>& x)
     {
     arma_ignore(x);
     arma_stop_logic_error("acosh(): need C++11 compiler");
-    
+
     return std::complex<T>(0);
     }
   #endif
@@ -565,7 +565,7 @@ arma_asinh(const std::complex<T>& x)
     {
     arma_ignore(x);
     arma_stop_logic_error("asinh(): need C++11 compiler");
-    
+
     return std::complex<T>(0);
     }
   #endif
@@ -590,8 +590,48 @@ arma_atanh(const std::complex<T>& x)
     {
     arma_ignore(x);
     arma_stop_logic_error("atanh(): need C++11 compiler");
-    
+
     return std::complex<T>(0);
+    }
+  #endif
+  }
+
+
+
+//
+// wrappers for hypot(x, y) = sqrt(x^2 + y^2)
+
+
+template<typename eT>
+arma_inline
+eT
+arma_hypot(const eT x, const eT y)
+  {
+  #if defined(ARMA_USE_CXX11)
+    {
+    return std::hypot(x, y);
+    }
+  #elif defined(ARMA_HAVE_TR1)
+    {
+    return std::tr1::hypot(x, y);
+    }
+  #else
+    {
+    eT xabs = std::abs(x);
+    eT yabs = std::abs(y);
+    eT larger, ratio;
+    if(xabs > yabs)
+      {
+      larger = xabs;
+      ratio = yabs / xabs;
+      }
+    else
+      {
+      larger = yabs;
+      ratio = xabs / yabs;
+      }
+    if(larger == eT(0))  return eT(0);
+    return larger * std:sqrt(eT(1) + ratio * ratio);
     }
   #endif
   }

--- a/include/armadillo_bits/arma_cmath.hpp
+++ b/include/armadillo_bits/arma_cmath.hpp
@@ -630,7 +630,7 @@ arma_hypot(const eT x, const eT y)
       larger = yabs;
       ratio = xabs / yabs;
       }
-    if(larger == eT(0))  return eT(0);
+    if(larger == eT(0)) { return eT(0); }
     return larger * std:sqrt(eT(1) + ratio * ratio);
     }
   #endif

--- a/include/armadillo_bits/newarp_DoubleShiftQR_meat.hpp
+++ b/include/armadillo_bits/newarp_DoubleShiftQR_meat.hpp
@@ -18,9 +18,10 @@ void
 DoubleShiftQR<eT>::compute_reflector(const eT& x1, const eT& x2, const eT& x3, uword ind)
   {
   arma_extra_debug_sigprint();
-  
+
   // In general case the reflector affects 3 rows
   ref_nr(ind) = 3;
+  eT x2x3 = eT(0);
   // If x3 is zero, decrease nr by 1
   if(std::abs(x3) < prec)
     {
@@ -34,13 +35,17 @@ DoubleShiftQR<eT>::compute_reflector(const eT& x1, const eT& x2, const eT& x3, u
       {
       ref_nr(ind) = 2;
       }
+    x2x3 = std::abs(x2);
+    }
+  else
+    {
+    x2x3 = arma_hypot(x2, x3);
     }
 
   // x1' = x1 - rho * ||x||
   // rho = -sign(x1), if x1 == 0, we choose rho = 1
-  eT tmp = x2 * x2 + x3 * x3;
-  eT x1_new = x1 - ((x1 <= 0) - (x1 > 0)) * std::sqrt(x1 * x1 + tmp);
-  eT x_norm = std::sqrt(x1_new * x1_new + tmp);
+  eT x1_new = x1 - ((x1 <= 0) - (x1 > 0)) * arma_hypot(x1, x2x3);
+  eT x_norm = arma_hypot(x1_new, x2x3);
   // Double check the norm of new x
   if(x_norm < prec)
     {
@@ -59,7 +64,7 @@ void
 DoubleShiftQR<eT>::compute_reflector(const eT* x, uword ind)
   {
   arma_extra_debug_sigprint();
-  
+
   compute_reflector(x[0], x[1], x[2], ind);
   }
 
@@ -71,7 +76,7 @@ void
 DoubleShiftQR<eT>::update_block(uword il, uword iu)
   {
   arma_extra_debug_sigprint();
-  
+
   // Block size
   uword bsize = iu - il + 1;
 
@@ -142,7 +147,7 @@ void
 DoubleShiftQR<eT>::apply_PX(Mat<eT>& X, uword oi, uword oj, uword nrow, uword ncol, uword u_ind)
   {
   arma_extra_debug_sigprint();
-  
+
   if(ref_nr(u_ind) == 1) { return; }
 
   // Householder reflectors at index u_ind
@@ -183,7 +188,7 @@ void
 DoubleShiftQR<eT>::apply_PX(eT* x, uword u_ind)
   {
   arma_extra_debug_sigprint();
-  
+
   if(ref_nr(u_ind) == 1) { return; }
 
   eT u0 = ref_u(0, u_ind),
@@ -207,7 +212,7 @@ void
 DoubleShiftQR<eT>::apply_XP(Mat<eT>& X, uword oi, uword oj, uword nrow, uword ncol, uword u_ind)
   {
   arma_extra_debug_sigprint();
-  
+
   if(ref_nr(u_ind) == 1) { return; }
 
   // Householder reflectors at index u_ind
@@ -275,7 +280,7 @@ DoubleShiftQR<eT>::DoubleShiftQR(const Mat<eT>& mat_obj, eT s, eT t)
   , computed(false)
   {
   arma_extra_debug_sigprint();
-  
+
   compute(mat_obj, s, t);
   }
 
@@ -286,7 +291,7 @@ void
 DoubleShiftQR<eT>::compute(const Mat<eT>& mat_obj, eT s, eT t)
   {
   arma_extra_debug_sigprint();
-  
+
   arma_debug_check( (mat_obj.is_square() == false), "newarp::DoubleShiftQR::compute(): matrix must be square" );
 
   n = mat_obj.n_rows;
@@ -338,7 +343,7 @@ Mat<eT>
 DoubleShiftQR<eT>::matrix_QtHQ()
   {
   arma_extra_debug_sigprint();
-  
+
   arma_debug_check( (computed == false), "newarp::DoubleShiftQR::matrix_QtHQ(): need to call compute() first" );
 
   return mat_H;
@@ -352,7 +357,7 @@ void
 DoubleShiftQR<eT>::apply_QtY(Col<eT>& y)
   {
   arma_extra_debug_sigprint();
-  
+
   arma_debug_check( (computed == false), "newarp::DoubleShiftQR::apply_QtY(): need to call compute() first" );
 
   eT* y_ptr = y.memptr();
@@ -370,7 +375,7 @@ void
 DoubleShiftQR<eT>::apply_YQ(Mat<eT>& Y)
   {
   arma_extra_debug_sigprint();
-  
+
   arma_debug_check( (computed == false), "newarp::DoubleShiftQR::apply_YQ(): need to call compute() first" );
 
   uword nrow = Y.n_rows;
@@ -378,7 +383,7 @@ DoubleShiftQR<eT>::apply_YQ(Mat<eT>& Y)
     {
     apply_XP(Y, 0, i, nrow, 3, i);
     }
-  
+
   apply_XP(Y, 0, n - 2, nrow, 2, n - 2);
   }
 

--- a/include/armadillo_bits/newarp_DoubleShiftQR_meat.hpp
+++ b/include/armadillo_bits/newarp_DoubleShiftQR_meat.hpp
@@ -256,8 +256,8 @@ inline
 DoubleShiftQR<eT>::DoubleShiftQR(uword size)
   : n(size)
   , prec(std::numeric_limits<eT>::epsilon())
-  , eps_rel(std::pow(prec, eT(0.75)))
-  , eps_abs(std::min(std::pow(prec, eT(0.75)), n * prec))
+  , eps_rel(prec)
+  , eps_abs(prec)
   , computed(false)
   {
   arma_extra_debug_sigprint();
@@ -275,8 +275,8 @@ DoubleShiftQR<eT>::DoubleShiftQR(const Mat<eT>& mat_obj, eT s, eT t)
   , ref_u(3, n)
   , ref_nr(n)
   , prec(std::numeric_limits<eT>::epsilon())
-  , eps_rel(std::pow(prec, eT(0.75)))
-  , eps_abs(std::min(std::pow(prec, eT(0.75)), n * prec))
+  , eps_rel(prec)
+  , eps_abs(prec)
   , computed(false)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/newarp_GenEigsSolver_bones.hpp
+++ b/include/armadillo_bits/newarp_GenEigsSolver_bones.hpp
@@ -37,11 +37,15 @@ class GenEigsSolver
   Mat<eT>                 fac_H;     // H matrix in the Arnoldi factorisation
   Col<eT>                 fac_f;     // residual in the Arnoldi factorisation
   Mat< std::complex<eT> > ritz_vec;  // ritz vectors
+  Col< std::complex<eT> > ritz_est;  // last row of ritz_vec
   std::vector<bool>       ritz_conv; // indicator of the convergence of ritz values
-  const eT                prec;      // precision parameter used to test convergence
-                                     // prec = epsilon^(2/3)
-                                     // epsilon is the machine precision,
-                                     // e.g. ~= 1e-16 for the "double" type
+  const eT                eps;       // the machine precision
+                                     // e.g. ~= 1e-16 for double type
+  const eT                approx0;   // a number that is approximately zero
+                                     // approx0 = eps^(2/3)
+                                     // used to test the orthogonality of vectors,
+                                     // and in convergence test, tol*approx0 is
+                                     // the absolute tolerance
 
   // Arnoldi factorisation starting from step-k
   inline void factorise_from(uword from_k, uword to_m, const Col<eT>& fk);
@@ -84,7 +88,7 @@ class GenEigsSolver
 
   //! Returning the eigenvectors associated with the converged eigenvalues.
   inline Mat< std::complex<eT> > eigenvectors(uword nvec);
-  
+
   //! Returning all converged eigenvectors.
   inline Mat< std::complex<eT> > eigenvectors() { return eigenvectors(nev); }
   };

--- a/include/armadillo_bits/newarp_SymEigsSolver_bones.hpp
+++ b/include/armadillo_bits/newarp_SymEigsSolver_bones.hpp
@@ -37,6 +37,7 @@ class SymEigsSolver
   Mat<eT>           fac_H;     // H matrix in the Arnoldi factorisation
   Col<eT>           fac_f;     // residual in the Arnoldi factorisation
   Mat<eT>           ritz_vec;  // ritz vectors
+  Col<eT>           ritz_est;  // last row of ritz_vec
   std::vector<bool> ritz_conv; // indicator of the convergence of ritz values
   const eT          eps;       // the machine precision
                                // e.g. ~= 1e-16 for double type

--- a/include/armadillo_bits/newarp_SymEigsSolver_bones.hpp
+++ b/include/armadillo_bits/newarp_SymEigsSolver_bones.hpp
@@ -38,10 +38,13 @@ class SymEigsSolver
   Col<eT>           fac_f;     // residual in the Arnoldi factorisation
   Mat<eT>           ritz_vec;  // ritz vectors
   std::vector<bool> ritz_conv; // indicator of the convergence of ritz values
-  const eT          prec;      // precision parameter used to test convergence
-                               // prec = epsilon^(2/3)
-                               // epsilon is the machine precision,
-                               // e.g. ~= 1e-16 for the "double" type
+  const eT          eps;       // the machine precision
+                               // e.g. ~= 1e-16 for double type
+  const eT          approx0;   // a number that is approximately zero
+                               // approx0 = eps^(2/3)
+                               // used to test the orthogonality of vectors,
+                               // and in convergence test, tol*approx0 is
+                               // the absolute tolerance
 
   // Arnoldi factorisation starting from step-k
   inline void factorise_from(uword from_k, uword to_m, const Col<eT>& fk);

--- a/include/armadillo_bits/newarp_SymEigsSolver_meat.hpp
+++ b/include/armadillo_bits/newarp_SymEigsSolver_meat.hpp
@@ -18,7 +18,7 @@ void
 SymEigsSolver<eT, SelectionRule, OpType>::factorise_from(uword from_k, uword to_m, const Col<eT>& fk)
   {
   arma_extra_debug_sigprint();
-  
+
   if(to_m <= from_k) { return; }
 
   fac_f = fk;
@@ -34,7 +34,7 @@ SymEigsSolver<eT, SelectionRule, OpType>::factorise_from(uword from_k, uword to_
     // If beta = 0, then the next V is not full rank
     // We need to generate a new residual vector that is orthogonal
     // to the current V, which we call a restart
-    if(beta < prec)
+    if(beta < eps)
       {
       // Generate new random vector for fac_f
       blas_int idist = 2;
@@ -86,7 +86,7 @@ SymEigsSolver<eT, SelectionRule, OpType>::factorise_from(uword from_k, uword to_
     Col<eT> Vf = Vs.t() * fac_f;
     // If not, iteratively correct the residual
     uword count = 0;
-    while(count < 5 && abs(Vf).max() > prec * beta)
+    while(count < 5 && abs(Vf).max() > approx0 * beta)
       {
       // f <- f - V * Vf
       fac_f -= Vs * Vf;
@@ -111,7 +111,7 @@ void
 SymEigsSolver<eT, SelectionRule, OpType>::restart(uword k)
   {
   arma_extra_debug_sigprint();
-  
+
   if(k >= ncv) { return; }
 
   TridiagQR<eT> decomp;
@@ -161,12 +161,12 @@ uword
 SymEigsSolver<eT, SelectionRule, OpType>::num_converged(eT tol)
   {
   arma_extra_debug_sigprint();
-  
-  // thresh = tol * max(prec, abs(theta)), theta for ritz value
+
+  // thresh = tol * max(approx0, abs(theta)), theta for ritz value
   const eT f_norm = norm(fac_f);
   for(uword i = 0; i < nev; i++)
     {
-    eT thresh = tol * std::max(prec, std::abs(ritz_val(i)));
+    eT thresh = tol * std::max(approx0, std::abs(ritz_val(i)));
     eT resid = std::abs(ritz_vec(ncv - 1, i)) * f_norm;
     ritz_conv[i] = (resid < thresh);
     }
@@ -182,7 +182,7 @@ uword
 SymEigsSolver<eT, SelectionRule, OpType>::nev_adjusted(uword nconv)
   {
   arma_extra_debug_sigprint();
-  
+
   uword nev_new = nev;
 
   // Adjust nev_new, according to dsaup2.f line 677~684 in ARPACK
@@ -208,7 +208,7 @@ void
 SymEigsSolver<eT, SelectionRule, OpType>::retrieve_ritzpair()
   {
   arma_extra_debug_sigprint();
-  
+
   TridiagEigen<eT> decomp(fac_H);
   Col<eT> evals = decomp.eigenvalues();
   Mat<eT> evecs = decomp.eigenvectors();
@@ -254,25 +254,25 @@ void
 SymEigsSolver<eT, SelectionRule, OpType>::sort_ritzpair()
   {
   arma_extra_debug_sigprint();
-  
+
   // SortEigenvalue<eT, EigsSelect::LARGEST_MAGN> sorting(ritz_val.memptr(), nev);
-  
+
   // sort Ritz values in ascending algebraic, to be consistent with ARPACK
   SortEigenvalue<eT, EigsSelect::SMALLEST_ALGE> sorting(ritz_val.memptr(), nev);
-  
+
   std::vector<uword> ind = sorting.index();
-  
+
   Col<eT>           new_ritz_val(ncv);
   Mat<eT>           new_ritz_vec(ncv, nev);
   std::vector<bool> new_ritz_conv(nev);
-  
+
   for(uword i = 0; i < nev; i++)
     {
     new_ritz_val(i) = ritz_val(ind[i]);
     new_ritz_vec.col(i) = ritz_vec.col(ind[i]);
     new_ritz_conv[i] = ritz_conv[ind[i]];
     }
-  
+
   ritz_val.swap(new_ritz_val);
   ritz_vec.swap(new_ritz_vec);
   ritz_conv.swap(new_ritz_conv);
@@ -289,10 +289,11 @@ SymEigsSolver<eT, SelectionRule, OpType>::SymEigsSolver(const OpType& op_, uword
   , ncv(ncv_ > dim_n ? dim_n : ncv_)
   , nmatop(0)
   , niter(0)
-  , prec(std::pow(std::numeric_limits<eT>::epsilon(), eT(2.0) / 3))
+  , eps(std::numeric_limits<eT>::epsilon())
+  , approx0(std::pow(eps, eT(2.0) / 3))
   {
   arma_extra_debug_sigprint();
-  
+
   arma_debug_check( (nev_ < 1 || nev_ > dim_n - 1), "newarp::SymEigsSolver: nev must satisfy 1 <= nev <= n - 1, n is the size of matrix" );
   arma_debug_check( (ncv_ <= nev_ || ncv_ > dim_n), "newarp::SymEigsSolver: ncv must satisfy nev < ncv <= n, n is the size of matrix" );
   }
@@ -305,7 +306,7 @@ void
 SymEigsSolver<eT, SelectionRule, OpType>::init(eT* init_resid)
   {
   arma_extra_debug_sigprint();
-  
+
   // Reset all matrices/vectors to zero
   fac_V.zeros(dim_n, ncv);
   fac_H.zeros(ncv, ncv);
@@ -321,7 +322,7 @@ SymEigsSolver<eT, SelectionRule, OpType>::init(eT* init_resid)
   // The first column of fac_V
   Col<eT> v(fac_V.colptr(0), dim_n, false);
   eT rnorm = norm(r);
-  arma_debug_check( (rnorm < prec), "newarp::SymEigsSolver::init(): initial residual vector cannot be zero" );
+  arma_debug_check( (rnorm < eps), "newarp::SymEigsSolver::init(): initial residual vector cannot be zero" );
   v = r / rnorm;
 
   Col<eT> w(dim_n);
@@ -340,7 +341,7 @@ void
 SymEigsSolver<eT, SelectionRule, OpType>::init()
   {
   arma_extra_debug_sigprint();
-  
+
   podarray<eT> init_resid(dim_n);
   blas_int idist = 2;                // Uniform(-1, 1)
   blas_int iseed[4] = {1, 3, 5, 7};  // Fixed random seed
@@ -357,7 +358,7 @@ uword
 SymEigsSolver<eT, SelectionRule, OpType>::compute(uword maxit, eT tol)
   {
   arma_extra_debug_sigprint();
-  
+
   // The m-step Arnoldi factorisation
   factorise_from(1, ncv, fac_f);
   retrieve_ritzpair();
@@ -387,7 +388,7 @@ Col<eT>
 SymEigsSolver<eT, SelectionRule, OpType>::eigenvalues()
   {
   arma_extra_debug_sigprint();
-  
+
   uword nconv = std::count(ritz_conv.begin(), ritz_conv.end(), true);
   Col<eT> res(nconv);
 
@@ -414,7 +415,7 @@ Mat<eT>
 SymEigsSolver<eT, SelectionRule, OpType>::eigenvectors(uword nvec)
   {
   arma_extra_debug_sigprint();
-  
+
   uword nconv = std::count(ritz_conv.begin(), ritz_conv.end(), true);
   nvec = std::min(nvec, nconv);
   Mat<eT> res(dim_n, nvec);

--- a/include/armadillo_bits/newarp_UpperHessenbergQR_meat.hpp
+++ b/include/armadillo_bits/newarp_UpperHessenbergQR_meat.hpp
@@ -33,7 +33,7 @@ UpperHessenbergQR<eT>::UpperHessenbergQR(const Mat<eT>& mat_obj)
   , computed(false)
   {
   arma_extra_debug_sigprint();
-  
+
   compute(mat_obj);
   }
 
@@ -44,7 +44,7 @@ void
 UpperHessenbergQR<eT>::compute(const Mat<eT>& mat_obj)
   {
   arma_extra_debug_sigprint();
-  
+
   n = mat_obj.n_rows;
   mat_T.set_size(n, n);
   rot_cos.set_size(n - 1);
@@ -63,7 +63,7 @@ UpperHessenbergQR<eT>::compute(const Mat<eT>& mat_obj)
 
     xi = mat_T(i,     i);  // mat_T(i, i)
     xj = mat_T(i + 1, i);  // mat_T(i + 1, i)
-    r = std::sqrt(xi * xi + xj * xj);
+    r = arma_hypot(xi, xj);
     if(r <= eps)
       {
       r = 0;
@@ -104,7 +104,7 @@ Mat<eT>
 UpperHessenbergQR<eT>::matrix_RQ()
   {
   arma_extra_debug_sigprint();
-  
+
   arma_debug_check( (computed == false), "newarp::UpperHessenbergQR::matrix_RQ(): need to call compute() first" );
 
   // Make a copy of the R matrix
@@ -143,7 +143,7 @@ void
 UpperHessenbergQR<eT>::apply_YQ(Mat<eT>& Y)
   {
   arma_extra_debug_sigprint();
-  
+
   arma_debug_check( (computed == false), "newarp::UpperHessenbergQR::apply_YQ(): need to call compute() first" );
 
   eT *Y_col_i, *Y_col_i1;
@@ -181,7 +181,7 @@ TridiagQR<eT>::TridiagQR(const Mat<eT>& mat_obj)
   : UpperHessenbergQR<eT>()
   {
   arma_extra_debug_sigprint();
-  
+
   this->compute(mat_obj);
   }
 
@@ -193,7 +193,7 @@ void
 TridiagQR<eT>::compute(const Mat<eT>& mat_obj)
   {
   arma_extra_debug_sigprint();
-  
+
   this->n = mat_obj.n_rows;
   this->mat_T.set_size(this->n, this->n);
   this->rot_cos.set_size(this->n - 1);
@@ -210,7 +210,7 @@ TridiagQR<eT>::compute(const Mat<eT>& mat_obj)
     {
     xi = this->mat_T(i,     i);  // mat_T(i, i)
     xj = this->mat_T(i + 1, i);  // mat_T(i + 1, i)
-    r = std::sqrt(xi * xi + xj * xj);
+    r = arma_hypot(xi, xj);
     if(r <= eps)
       {
       r = 0;
@@ -263,7 +263,7 @@ Mat<eT>
 TridiagQR<eT>::matrix_RQ()
   {
   arma_extra_debug_sigprint();
-  
+
   arma_debug_check( (this->computed == false), "newarp::TridiagQR::matrix_RQ(): need to call compute() first" );
 
   // Make a copy of the R matrix


### PR DESCRIPTION
This PR improves the accuracy of `eigs_sym()` and `eigs_gen()` with the C++ implementation backend (newarp), by taking care of the following aspects:

- Add a numerically stable function `arma_hypot()` to calculate `sqrt(x^2 + y^2)`
- More careful use of near-zero values in some numerical tests
- Improve the algorithm of eigen solvers to accelerate convergence