### PR TITLE
Fix build on cmake 3.7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ endif()
 ## cmake -D DETECT_HDF5=true .
 
 if(DETECT_HDF5)
-  find_package(HDF5 QUIET)
+  find_package(HDF5 COMPONENTS CXX QUIET)
 
   if(NOT HDF5_FOUND)
     # On Debian systems, the HDF5 package has been split into multiple packages


### PR DESCRIPTION
Changes in FindHDF5.cmake lead to the following error:
```
    CMake Error at
    cmake-3.7.1/share/cmake-3.7/Modules/FindHDF5.cmake:182
    (try_compile):
    Unknown extension ".c" for file

    /tmp/nix-build-armadillo-7.200.2.drv-0/armadillo-7.200.2/build/CMakeFiles/hdf5/cmake_hdf5_test.c

    try_compile() works only for enabled languages.  Currently these are:

    CXX

    See project() command to enable other languages.
    Call Stack (most recent call first):
    cmake-3.7.1/share/cmake-3.7/Modules/FindHDF5.cmake:468
    (_HDF5_test_regular_compiler_C)
    CMakeLists.txt:227 (find_package)
```
(See e.g. https://hydra.nixos.org/build/45392279 )
This is because armadillo's current CMakeLists.txt searches for the C
component of the HDF5 library, even though it is not actually needed.
As the project is set to:
    project(armadillo CXX)
This does not play well with the new FindHDF5.cmake