### PR TITLE
Add include directories to cmake target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,7 @@ message(STATUS "CMAKE_REQUIRED_INCLUDES   = ${CMAKE_REQUIRED_INCLUDES}"  )
 
 add_library( armadillo ${PROJECT_SOURCE_DIR}/src/wrapper.cpp )
 target_link_libraries( armadillo ${ARMA_LIBS} )
+target_include_directories(armadillo INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> $<INSTALL_INTERFACE:include>)
 set_target_properties(armadillo PROPERTIES VERSION ${ARMA_VERSION_MAJOR}.${ARMA_VERSION_MINOR_ALT}.${ARMA_VERSION_PATCH} SOVERSION ${ARMA_VERSION_MAJOR})
 
 


### PR DESCRIPTION
This PR adds include directories to the cmake target so that the project can be used (included/imported) from other cmake projects.

This fixes an issue where `target_link_libraries(otherApp armadillo)` couldn't find the corresponding armadillo header files.

A more complete cmake project would look like
```cmake
add_subdirectory("armadillo-code") # all armadillo code is in a directory called 'armadillo-code'
add_executable(MyApp main.cpp) # main.cpp makes use of <armadillo> header
target_link_libraries(MyApp armadillo) # armadillo library is linked to current project
```