### PR TITLE
Fixed a missing mirrored promotion where T1 is s32 and T2 is s64

### DIFF
--- a/include/armadillo_bits/promote_type.hpp
+++ b/include/armadillo_bits/promote_type.hpp
@@ -190,6 +190,7 @@ template<> struct is_promotable<u8,  u64> : public is_promotable_ok { typedef u6
 
 #if defined(ARMA_USE_U64S64)
 template<> struct is_promotable<u64, s64> : public is_promotable_ok { typedef s64 result; };  // float ?  
+template<> struct is_promotable<s32, s64> : public is_promotable_ok { typedef s64 result; };
 template<> struct is_promotable<u32, s64> : public is_promotable_ok { typedef s64 result; };
 template<> struct is_promotable<s16, s64> : public is_promotable_ok { typedef s64 result; };
 template<> struct is_promotable<u16, s64> : public is_promotable_ok { typedef s64 result; };


### PR DESCRIPTION
I was writing code that generated every combination of types for matrix addition, but this combination didn't compile. I thought that was strange because the commutative version (s64 + s32) worked fine; that led me to this missing line of code.