### PR TITLE
Revert "Make Mat and Mat::fixed pass Assignable and Semiregular"

### DIFF
--- a/include/armadillo_bits/Col_bones.hpp
+++ b/include/armadillo_bits/Col_bones.hpp
@@ -40,30 +40,30 @@ class Col : public Mat<eT>
   template<typename fill_type> inline Col(const uword in_rows, const uword in_cols, const fill::fill_class<fill_type>& f);
   template<typename fill_type> inline Col(const SizeMat& s,                         const fill::fill_class<fill_type>& f);
   
-  inline            Col(const char*        text);
-  inline Col& operator=(const char*        text);
+  inline                  Col(const char*        text);
+  inline const Col& operator=(const char*        text);
   
-  inline            Col(const std::string& text);
-  inline Col& operator=(const std::string& text);
+  inline                  Col(const std::string& text);
+  inline const Col& operator=(const std::string& text);
   
-  inline            Col(const std::vector<eT>& x);
-  inline Col& operator=(const std::vector<eT>& x);
+  inline                  Col(const std::vector<eT>& x);
+  inline const Col& operator=(const std::vector<eT>& x);
   
   #if defined(ARMA_USE_CXX11)
-  inline            Col(const std::initializer_list<eT>& list);
-  inline Col& operator=(const std::initializer_list<eT>& list);
+  inline                  Col(const std::initializer_list<eT>& list);
+  inline const Col& operator=(const std::initializer_list<eT>& list);
   
-  inline            Col(Col&& m);
-  inline Col& operator=(Col&& m);
+  inline                  Col(Col&& m);
+  inline const Col& operator=(Col&& m);
   #endif
   
   inline explicit Col(const SpCol<eT>& X);
   
-  inline Col& operator=(const eT val);
-  inline Col& operator=(const Col& m);
+  inline const Col& operator=(const eT val);
+  inline const Col& operator=(const Col& m);
   
-  template<typename T1> inline             Col(const Base<eT,T1>& X);
-  template<typename T1> inline Col&  operator=(const Base<eT,T1>& X);
+  template<typename T1> inline                   Col(const Base<eT,T1>& X);
+  template<typename T1> inline const Col&  operator=(const Base<eT,T1>& X);
   
   inline Col(      eT* aux_mem, const uword aux_length, const bool copy_aux_mem = true, const bool strict = false);
   inline Col(const eT* aux_mem, const uword aux_length);
@@ -71,11 +71,11 @@ class Col : public Mat<eT>
   template<typename T1, typename T2>
   inline explicit Col(const Base<pod_type,T1>& A, const Base<pod_type,T2>& B);
   
-  template<typename T1> inline            Col(const BaseCube<eT,T1>& X);
-  template<typename T1> inline Col& operator=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline                  Col(const BaseCube<eT,T1>& X);
+  template<typename T1> inline const Col& operator=(const BaseCube<eT,T1>& X);
   
-  inline            Col(const subview_cube<eT>& X);
-  inline Col& operator=(const subview_cube<eT>& X);
+  inline                  Col(const subview_cube<eT>& X);
+  inline const Col& operator=(const subview_cube<eT>& X);
   
   inline mat_injector<Col> operator<<(const eT val);
   
@@ -201,25 +201,25 @@ class Col<eT>::fixed : public Col<eT>
   inline fixed(const char*        text);
   inline fixed(const std::string& text);
   
-  template<typename T1> inline Col& operator=(const Base<eT,T1>& A);
+  template<typename T1> inline const Col& operator=(const Base<eT,T1>& A);
   
-  inline Col& operator=(const eT val);
-  inline Col& operator=(const char*        text);
-  inline Col& operator=(const std::string& text);
-  inline Col& operator=(const subview_cube<eT>& X);
+  inline const Col& operator=(const eT val);
+  inline const Col& operator=(const char*        text);
+  inline const Col& operator=(const std::string& text);
+  inline const Col& operator=(const subview_cube<eT>& X);
   
   using Col<eT>::operator();
   
   #if defined(ARMA_USE_CXX11)
-    inline          fixed(const std::initializer_list<eT>& list);
-    inline Col& operator=(const std::initializer_list<eT>& list);
+    inline                fixed(const std::initializer_list<eT>& list);
+    inline const Col& operator=(const std::initializer_list<eT>& list);
   #endif
   
-  arma_inline Col& operator=(const fixed<fixed_n_elem>& X);
+  arma_inline const Col& operator=(const fixed<fixed_n_elem>& X);
   
   #if defined(ARMA_GOOD_COMPILER)
-    template<typename T1,              typename   eop_type> inline Col& operator=(const   eOp<T1,       eop_type>& X);
-    template<typename T1, typename T2, typename eglue_type> inline Col& operator=(const eGlue<T1, T2, eglue_type>& X);
+    template<typename T1,              typename   eop_type> inline const Col& operator=(const   eOp<T1,       eop_type>& X);
+    template<typename T1, typename T2, typename eglue_type> inline const Col& operator=(const eGlue<T1, T2, eglue_type>& X);
   #endif
   
   arma_inline const Op< Col_fixed_type, op_htrans >  t() const;

--- a/include/armadillo_bits/Col_meat.hpp
+++ b/include/armadillo_bits/Col_meat.hpp
@@ -140,7 +140,7 @@ Col<eT>::Col(const char* text)
 //! construct a column vector from specified text
 template<typename eT>
 inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -179,7 +179,7 @@ Col<eT>::Col(const std::string& text)
 //! construct a column vector from specified text
 template<typename eT>
 inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -216,7 +216,7 @@ Col<eT>::Col(const std::vector<eT>& x)
 //! create a column vector from std::vector
 template<typename eT>
 inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::operator=(const std::vector<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -254,7 +254,7 @@ Col<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  Col<eT>&
+  const Col<eT>&
   Col<eT>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -314,7 +314,7 @@ Col<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  Col<eT>&
+  const Col<eT>&
   Col<eT>::operator=(Col<eT>&& X)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   X = %x") % this % &X);
@@ -355,7 +355,7 @@ Col<eT>::Col(const SpCol<eT>& X)
 
 template<typename eT>
 inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -369,7 +369,7 @@ Col<eT>::operator=(const eT val)
 
 template<typename eT>
 inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::operator=(const Col<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -397,7 +397,7 @@ Col<eT>::Col(const Base<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::operator=(const Base<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -470,7 +470,7 @@ Col<eT>::Col(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::operator=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -497,7 +497,7 @@ Col<eT>::Col(const subview_cube<eT>& X)
 
 template<typename eT>
 inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1239,7 +1239,7 @@ Col<eT>::fixed<fixed_n_elem>::fixed(const std::string& text)
 template<typename eT>
 template<uword fixed_n_elem>
 template<typename T1>
-Col<eT>&
+const Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const Base<eT,T1>& A)
   {
   arma_extra_debug_sigprint();
@@ -1253,7 +1253,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const Base<eT,T1>& A)
 
 template<typename eT>
 template<uword fixed_n_elem>
-Col<eT>&
+const Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -1267,7 +1267,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const eT val)
 
 template<typename eT>
 template<uword fixed_n_elem>
-Col<eT>&
+const Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -1283,7 +1283,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const char* text)
 
 template<typename eT>
 template<uword fixed_n_elem>
-Col<eT>&
+const Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -1299,7 +1299,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
 
 template<typename eT>
 template<uword fixed_n_elem>
-Col<eT>&
+const Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1329,7 +1329,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
   template<typename eT>
   template<uword fixed_n_elem>
   inline
-  Col<eT>&
+  const Col<eT>&
   Col<eT>::fixed<fixed_n_elem>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -1354,7 +1354,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
 template<typename eT>
 template<uword fixed_n_elem>
 arma_inline
-Col<eT>&
+const Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   {
   arma_extra_debug_sigprint();
@@ -1378,7 +1378,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   template<uword fixed_n_elem>
   template<typename T1, typename eop_type>
   inline
-  Col<eT>&
+  const Col<eT>&
   Col<eT>::fixed<fixed_n_elem>::operator=(const eOp<T1, eop_type>& X)
     {
     arma_extra_debug_sigprint();
@@ -1411,7 +1411,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   template<uword fixed_n_elem>
   template<typename T1, typename T2, typename eglue_type>
   inline
-  Col<eT>&
+  const Col<eT>&
   Col<eT>::fixed<fixed_n_elem>::operator=(const eGlue<T1, T2, eglue_type>& X)
     {
     arma_extra_debug_sigprint();

--- a/include/armadillo_bits/Cube_bones.hpp
+++ b/include/armadillo_bits/Cube_bones.hpp
@@ -72,35 +72,35 @@ class Cube : public BaseCube< eT, Cube<eT> >
   template<typename fill_type> inline Cube(const SizeCube& s,                                               const fill::fill_class<fill_type>& f);
   
   #if defined(ARMA_USE_CXX11)
-  inline            Cube(Cube&& m);
-  inline Cube& operator=(Cube&& m);
+  inline                  Cube(Cube&& m);
+  inline const Cube& operator=(Cube&& m);
   #endif
   
   inline Cube(      eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols, const uword aux_n_slices, const bool copy_aux_mem = true, const bool strict = false, const bool prealloc_mat = false);
   inline Cube(const eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols, const uword aux_n_slices);
   
-  arma_inline Cube&  operator=(const eT val);
-  arma_inline Cube& operator+=(const eT val);
-  arma_inline Cube& operator-=(const eT val);
-  arma_inline Cube& operator*=(const eT val);
-  arma_inline Cube& operator/=(const eT val);
+  arma_inline const Cube&  operator=(const eT val);
+  arma_inline const Cube& operator+=(const eT val);
+  arma_inline const Cube& operator-=(const eT val);
+  arma_inline const Cube& operator*=(const eT val);
+  arma_inline const Cube& operator/=(const eT val);
   
-  inline             Cube(const Cube& m);
-  inline Cube&  operator=(const Cube& m);
-  inline Cube& operator+=(const Cube& m);
-  inline Cube& operator-=(const Cube& m);
-  inline Cube& operator%=(const Cube& m);
-  inline Cube& operator/=(const Cube& m);
+  inline                   Cube(const Cube& m);
+  inline const Cube&  operator=(const Cube& m);
+  inline const Cube& operator+=(const Cube& m);
+  inline const Cube& operator-=(const Cube& m);
+  inline const Cube& operator%=(const Cube& m);
+  inline const Cube& operator/=(const Cube& m);
   
   template<typename T1, typename T2>
   inline explicit Cube(const BaseCube<pod_type,T1>& A, const BaseCube<pod_type,T2>& B);
   
-  inline             Cube(const subview_cube<eT>& X);
-  inline Cube&  operator=(const subview_cube<eT>& X);
-  inline Cube& operator+=(const subview_cube<eT>& X);
-  inline Cube& operator-=(const subview_cube<eT>& X);
-  inline Cube& operator%=(const subview_cube<eT>& X);
-  inline Cube& operator/=(const subview_cube<eT>& X);
+  inline                   Cube(const subview_cube<eT>& X);
+  inline const Cube&  operator=(const subview_cube<eT>& X);
+  inline const Cube& operator+=(const subview_cube<eT>& X);
+  inline const Cube& operator-=(const subview_cube<eT>& X);
+  inline const Cube& operator%=(const subview_cube<eT>& X);
+  inline const Cube& operator/=(const subview_cube<eT>& X);
   
   inline       Mat<eT>& slice(const uword in_slice);
   inline const Mat<eT>& slice(const uword in_slice) const;
@@ -170,54 +170,54 @@ class Cube : public BaseCube< eT, Cube<eT> >
   inline void insert_slices(const uword row_num, const BaseCube<eT,T1>& X);
   
   
-  template<typename gen_type> inline             Cube(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline Cube&  operator=(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline Cube& operator+=(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline Cube& operator-=(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline Cube& operator%=(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline Cube& operator/=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline                   Cube(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline const Cube&  operator=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline const Cube& operator+=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline const Cube& operator-=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline const Cube& operator%=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline const Cube& operator/=(const GenCube<eT, gen_type>& X);
   
-  template<typename T1, typename op_type> inline             Cube(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube&  operator=(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube& operator+=(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube& operator-=(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube& operator%=(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube& operator/=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline                   Cube(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube&  operator=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube& operator+=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube& operator-=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube& operator%=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube& operator/=(const OpCube<T1, op_type>& X);
   
-  template<typename T1, typename eop_type> inline             Cube(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Cube&  operator=(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Cube& operator+=(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Cube& operator-=(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Cube& operator%=(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Cube& operator/=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline                   Cube(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Cube&  operator=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Cube& operator+=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Cube& operator-=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Cube& operator%=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Cube& operator/=(const eOpCube<T1, eop_type>& X);
   
-  template<typename T1, typename op_type> inline             Cube(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube&  operator=(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube& operator+=(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube& operator-=(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube& operator%=(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Cube& operator/=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline                   Cube(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube&  operator=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube& operator+=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube& operator-=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube& operator%=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Cube& operator/=(const mtOpCube<eT, T1, op_type>& X);
   
-  template<typename T1, typename T2, typename glue_type> inline             Cube(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube&  operator=(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube& operator+=(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube& operator-=(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube& operator%=(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube& operator/=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline                   Cube(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube&  operator=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube& operator+=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube& operator-=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube& operator%=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube& operator/=(const GlueCube<T1, T2, glue_type>& X);
   
-  template<typename T1, typename T2, typename eglue_type> inline             Cube(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Cube&  operator=(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Cube& operator+=(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Cube& operator-=(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Cube& operator%=(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Cube& operator/=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline                   Cube(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Cube&  operator=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Cube& operator+=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Cube& operator-=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Cube& operator%=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Cube& operator/=(const eGlueCube<T1, T2, eglue_type>& X);
   
-  template<typename T1, typename T2, typename glue_type> inline             Cube(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube&  operator=(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube& operator+=(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube& operator-=(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube& operator%=(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Cube& operator/=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline                   Cube(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube&  operator=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube& operator+=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube& operator-=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube& operator%=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Cube& operator/=(const mtGlueCube<eT, T1, T2, glue_type>& X);
   
   
   arma_inline arma_warn_unused const eT& at_alt     (const uword i) const;
@@ -426,7 +426,7 @@ class Cube<eT>::fixed : public Cube<eT>
   using Cube<eT>::operator=;
   using Cube<eT>::operator();
   
-  inline Cube& operator=(const fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>& X);
+  inline const Cube& operator=(const fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>& X);
   
   
   arma_inline arma_warn_unused       eT& operator[] (const uword i);

--- a/include/armadillo_bits/Cube_meat.hpp
+++ b/include/armadillo_bits/Cube_meat.hpp
@@ -178,7 +178,7 @@ Cube<eT>::Cube(const SizeCube& s, const fill::fill_class<fill_type>&)
   
   template<typename eT>
   inline
-  Cube<eT>&
+  const Cube<eT>&
   Cube<eT>::operator=(Cube<eT>&& in_cube)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   in_cube = %x") % this % &in_cube);
@@ -483,7 +483,7 @@ Cube<eT>::create_mat()
 //! NOTE: the size of the cube will be 1x1x1
 template<typename eT>
 arma_inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -498,7 +498,7 @@ Cube<eT>::operator=(const eT val)
 //! In-place addition of a scalar to all elements of the cube
 template<typename eT>
 arma_inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -513,7 +513,7 @@ Cube<eT>::operator+=(const eT val)
 //! In-place subtraction of a scalar from all elements of the cube
 template<typename eT>
 arma_inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -528,7 +528,7 @@ Cube<eT>::operator-=(const eT val)
 //! In-place multiplication of all elements of the cube with a scalar
 template<typename eT>
 arma_inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -543,7 +543,7 @@ Cube<eT>::operator*=(const eT val)
 //! In-place division of all elements of the cube with a scalar
 template<typename eT>
 arma_inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -581,7 +581,7 @@ Cube<eT>::Cube(const Cube<eT>& x)
 //! construct a cube from a given cube
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const Cube<eT>& x)
   {
   arma_extra_debug_sigprint(arma_str::format("this = %x   in_cube = %x") % this % &x);
@@ -657,7 +657,7 @@ Cube<eT>::Cube(const eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols
 //! in-place cube addition
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const Cube<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -674,7 +674,7 @@ Cube<eT>::operator+=(const Cube<eT>& m)
 //! in-place cube subtraction
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const Cube<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -691,7 +691,7 @@ Cube<eT>::operator-=(const Cube<eT>& m)
 //! in-place element-wise cube multiplication
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const Cube<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -708,7 +708,7 @@ Cube<eT>::operator%=(const Cube<eT>& m)
 //! in-place element-wise cube division
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const Cube<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -772,7 +772,7 @@ Cube<eT>::Cube(const subview_cube<eT>& X)
 //! construct a cube from a subview_cube instance (e.g. construct a cube from a delayed subcube operation)
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -800,7 +800,7 @@ Cube<eT>::operator=(const subview_cube<eT>& X)
 //! in-place cube addition (using a subcube on the right-hand-side)
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -815,7 +815,7 @@ Cube<eT>::operator+=(const subview_cube<eT>& X)
 //! in-place cube subtraction (using a subcube on the right-hand-side)
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -830,7 +830,7 @@ Cube<eT>::operator-=(const subview_cube<eT>& X)
 //! in-place element-wise cube mutiplication (using a subcube on the right-hand-side)
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -845,7 +845,7 @@ Cube<eT>::operator%=(const subview_cube<eT>& X)
 //! in-place element-wise cube division (using a subcube on the right-hand-side)
 template<typename eT>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1759,7 +1759,7 @@ Cube<eT>::Cube(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1776,7 +1776,7 @@ Cube<eT>::operator=(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1791,7 +1791,7 @@ Cube<eT>::operator+=(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1806,7 +1806,7 @@ Cube<eT>::operator-=(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1821,7 +1821,7 @@ Cube<eT>::operator%=(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1860,7 +1860,7 @@ Cube<eT>::Cube(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1878,7 +1878,7 @@ Cube<eT>::operator=(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1896,7 +1896,7 @@ Cube<eT>::operator+=(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1914,7 +1914,7 @@ Cube<eT>::operator-=(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1932,7 +1932,7 @@ Cube<eT>::operator%=(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1975,7 +1975,7 @@ Cube<eT>::Cube(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2006,7 +2006,7 @@ Cube<eT>::operator=(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2024,7 +2024,7 @@ Cube<eT>::operator+=(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2042,7 +2042,7 @@ Cube<eT>::operator-=(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2060,7 +2060,7 @@ Cube<eT>::operator%=(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2099,7 +2099,7 @@ Cube<eT>::Cube(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2115,7 +2115,7 @@ Cube<eT>::operator=(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2131,7 +2131,7 @@ Cube<eT>::operator+=(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2147,7 +2147,7 @@ Cube<eT>::operator-=(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2163,7 +2163,7 @@ Cube<eT>::operator%=(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2199,7 +2199,7 @@ Cube<eT>::Cube(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2217,7 +2217,7 @@ Cube<eT>::operator=(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2236,7 +2236,7 @@ Cube<eT>::operator+=(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2255,7 +2255,7 @@ Cube<eT>::operator-=(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2274,7 +2274,7 @@ Cube<eT>::operator%=(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2319,7 +2319,7 @@ Cube<eT>::Cube(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2351,7 +2351,7 @@ Cube<eT>::operator=(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2370,7 +2370,7 @@ Cube<eT>::operator+=(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2389,7 +2389,7 @@ Cube<eT>::operator-=(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2408,7 +2408,7 @@ Cube<eT>::operator%=(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2448,7 +2448,7 @@ Cube<eT>::Cube(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2464,7 +2464,7 @@ Cube<eT>::operator=(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator+=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2480,7 +2480,7 @@ Cube<eT>::operator+=(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator-=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2496,7 +2496,7 @@ Cube<eT>::operator-=(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator%=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2512,7 +2512,7 @@ Cube<eT>::operator%=(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::operator/=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4336,7 +4336,7 @@ Cube<eT>::fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>::fixed(const BaseCub
 template<typename eT>
 template<uword fixed_n_rows, uword fixed_n_cols, uword fixed_n_slices>
 inline
-Cube<eT>&
+const Cube<eT>&
 Cube<eT>::fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>::operator=(const fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>& X)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/Mat_bones.hpp
+++ b/include/armadillo_bits/Mat_bones.hpp
@@ -62,63 +62,63 @@ class Mat : public Base< eT, Mat<eT> >
   template<typename fill_type> inline Mat(const uword in_rows, const uword in_cols, const fill::fill_class<fill_type>& f);
   template<typename fill_type> inline Mat(const SizeMat& s,                         const fill::fill_class<fill_type>& f);
   
-  inline            Mat(const char*        text);
-  inline Mat& operator=(const char*        text);
+  inline                  Mat(const char*        text);
+  inline const Mat& operator=(const char*        text);
   
-  inline            Mat(const std::string& text);
-  inline Mat& operator=(const std::string& text);
+  inline                  Mat(const std::string& text);
+  inline const Mat& operator=(const std::string& text);
   
-  inline            Mat(const std::vector<eT>& x);
-  inline Mat& operator=(const std::vector<eT>& x);
+  inline                  Mat(const std::vector<eT>& x);
+  inline const Mat& operator=(const std::vector<eT>& x);
   
   #if defined(ARMA_USE_CXX11)
-  inline            Mat(const std::initializer_list<eT>& list);
-  inline Mat& operator=(const std::initializer_list<eT>& list);
+  inline                  Mat(const std::initializer_list<eT>& list);
+  inline const Mat& operator=(const std::initializer_list<eT>& list);
   
-  inline            Mat(const std::initializer_list< std::initializer_list<eT> >& list);
-  inline Mat& operator=(const std::initializer_list< std::initializer_list<eT> >& list);
+  inline                  Mat(const std::initializer_list< std::initializer_list<eT> >& list);
+  inline const Mat& operator=(const std::initializer_list< std::initializer_list<eT> >& list);
   
-  inline            Mat(Mat&& m);
-  inline Mat& operator=(Mat&& m);
+  inline                  Mat(Mat&& m);
+  inline const Mat& operator=(Mat&& m);
   #endif
   
   inline Mat(      eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols, const bool copy_aux_mem = true, const bool strict = false);
   inline Mat(const eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols);
   
-  arma_inline Mat&  operator=(const eT val);
-  arma_inline Mat& operator+=(const eT val);
-  arma_inline Mat& operator-=(const eT val);
-  arma_inline Mat& operator*=(const eT val);
-  arma_inline Mat& operator/=(const eT val);
+  arma_inline const Mat&  operator=(const eT val);
+  arma_inline const Mat& operator+=(const eT val);
+  arma_inline const Mat& operator-=(const eT val);
+  arma_inline const Mat& operator*=(const eT val);
+  arma_inline const Mat& operator/=(const eT val);
   
-  inline             Mat(const Mat& m);
-  inline Mat&  operator=(const Mat& m);
-  inline Mat& operator+=(const Mat& m);
-  inline Mat& operator-=(const Mat& m);
-  inline Mat& operator*=(const Mat& m);
-  inline Mat& operator%=(const Mat& m);
-  inline Mat& operator/=(const Mat& m);
+  inline                   Mat(const Mat& m);
+  inline const Mat&  operator=(const Mat& m);
+  inline const Mat& operator+=(const Mat& m);
+  inline const Mat& operator-=(const Mat& m);
+  inline const Mat& operator*=(const Mat& m);
+  inline const Mat& operator%=(const Mat& m);
+  inline const Mat& operator/=(const Mat& m);
   
-  template<typename T1> inline             Mat(const BaseCube<eT,T1>& X);
-  template<typename T1> inline Mat&  operator=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline Mat& operator+=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline Mat& operator-=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline Mat& operator*=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline Mat& operator%=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline Mat& operator/=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline                   Mat(const BaseCube<eT,T1>& X);
+  template<typename T1> inline const Mat&  operator=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline const Mat& operator+=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline const Mat& operator-=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline const Mat& operator*=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline const Mat& operator%=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline const Mat& operator/=(const BaseCube<eT,T1>& X);
   
   template<typename T1, typename T2>
   inline explicit Mat(const Base<pod_type,T1>& A, const Base<pod_type,T2>& B);
   
   inline explicit          Mat(const subview<eT>& X, const bool use_colmem);  // only to be used by the quasi_unwrap class
   
-  inline             Mat(const subview<eT>& X);
-  inline Mat&  operator=(const subview<eT>& X);
-  inline Mat& operator+=(const subview<eT>& X);
-  inline Mat& operator-=(const subview<eT>& X);
-  inline Mat& operator*=(const subview<eT>& X);
-  inline Mat& operator%=(const subview<eT>& X);
-  inline Mat& operator/=(const subview<eT>& X);
+  inline                   Mat(const subview<eT>& X);
+  inline const Mat&  operator=(const subview<eT>& X);
+  inline const Mat& operator+=(const subview<eT>& X);
+  inline const Mat& operator-=(const subview<eT>& X);
+  inline const Mat& operator*=(const subview<eT>& X);
+  inline const Mat& operator%=(const subview<eT>& X);
+  inline const Mat& operator/=(const subview<eT>& X);
   
   inline Mat(const subview_row_strans<eT>& X);  // subview_row_strans can only be generated by the Proxy class
   inline Mat(const subview_row_htrans<eT>& X);  // subview_row_htrans can only be generated by the Proxy class
@@ -127,54 +127,54 @@ class Mat : public Base< eT, Mat<eT> >
   template<bool do_conj>
   inline Mat(const xtrans_mat<eT,do_conj>& X);  //        xtrans_mat can only be generated by the Proxy class
   
-  inline             Mat(const subview_cube<eT>& X);
-  inline Mat&  operator=(const subview_cube<eT>& X);
-  inline Mat& operator+=(const subview_cube<eT>& X);
-  inline Mat& operator-=(const subview_cube<eT>& X);
-  inline Mat& operator*=(const subview_cube<eT>& X);
-  inline Mat& operator%=(const subview_cube<eT>& X);
-  inline Mat& operator/=(const subview_cube<eT>& X);
+  inline                   Mat(const subview_cube<eT>& X);
+  inline const Mat&  operator=(const subview_cube<eT>& X);
+  inline const Mat& operator+=(const subview_cube<eT>& X);
+  inline const Mat& operator-=(const subview_cube<eT>& X);
+  inline const Mat& operator*=(const subview_cube<eT>& X);
+  inline const Mat& operator%=(const subview_cube<eT>& X);
+  inline const Mat& operator/=(const subview_cube<eT>& X);
   
-  inline             Mat(const diagview<eT>& X);
-  inline Mat&  operator=(const diagview<eT>& X);
-  inline Mat& operator+=(const diagview<eT>& X);
-  inline Mat& operator-=(const diagview<eT>& X);
-  inline Mat& operator*=(const diagview<eT>& X);
-  inline Mat& operator%=(const diagview<eT>& X);
-  inline Mat& operator/=(const diagview<eT>& X);
+  inline                   Mat(const diagview<eT>& X);
+  inline const Mat&  operator=(const diagview<eT>& X);
+  inline const Mat& operator+=(const diagview<eT>& X);
+  inline const Mat& operator-=(const diagview<eT>& X);
+  inline const Mat& operator*=(const diagview<eT>& X);
+  inline const Mat& operator%=(const diagview<eT>& X);
+  inline const Mat& operator/=(const diagview<eT>& X);
   
-  inline             Mat(const spdiagview<eT>& X);
-  inline Mat&  operator=(const spdiagview<eT>& X);
-  inline Mat& operator+=(const spdiagview<eT>& X);
-  inline Mat& operator-=(const spdiagview<eT>& X);
-  inline Mat& operator*=(const spdiagview<eT>& X);
-  inline Mat& operator%=(const spdiagview<eT>& X);
-  inline Mat& operator/=(const spdiagview<eT>& X);
+  inline                   Mat(const spdiagview<eT>& X);
+  inline const Mat&  operator=(const spdiagview<eT>& X);
+  inline const Mat& operator+=(const spdiagview<eT>& X);
+  inline const Mat& operator-=(const spdiagview<eT>& X);
+  inline const Mat& operator*=(const spdiagview<eT>& X);
+  inline const Mat& operator%=(const spdiagview<eT>& X);
+  inline const Mat& operator/=(const spdiagview<eT>& X);
   
-  template<typename T1> inline             Mat(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline Mat& operator= (const subview_elem1<eT,T1>& X);
-  template<typename T1> inline Mat& operator+=(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline Mat& operator-=(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline Mat& operator*=(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline Mat& operator%=(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline Mat& operator/=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline                   Mat(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline const Mat& operator= (const subview_elem1<eT,T1>& X);
+  template<typename T1> inline const Mat& operator+=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline const Mat& operator-=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline const Mat& operator*=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline const Mat& operator%=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline const Mat& operator/=(const subview_elem1<eT,T1>& X);
   
-  template<typename T1, typename T2> inline             Mat(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline Mat& operator= (const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline Mat& operator+=(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline Mat& operator-=(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline Mat& operator*=(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline Mat& operator%=(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline Mat& operator/=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline                   Mat(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline const Mat& operator= (const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline const Mat& operator+=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline const Mat& operator-=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline const Mat& operator*=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline const Mat& operator%=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline const Mat& operator/=(const subview_elem2<eT,T1,T2>& X);
   
   // Operators on sparse matrices (and subviews)
-  template<typename T1> inline explicit    Mat(const SpBase<eT, T1>& m);
-  template<typename T1> inline Mat&  operator=(const SpBase<eT, T1>& m);
-  template<typename T1> inline Mat& operator+=(const SpBase<eT, T1>& m);
-  template<typename T1> inline Mat& operator-=(const SpBase<eT, T1>& m);
-  template<typename T1> inline Mat& operator*=(const SpBase<eT, T1>& m);
-  template<typename T1> inline Mat& operator%=(const SpBase<eT, T1>& m);
-  template<typename T1> inline Mat& operator/=(const SpBase<eT, T1>& m);
+  template<typename T1> inline explicit          Mat(const SpBase<eT, T1>& m);
+  template<typename T1> inline const Mat&  operator=(const SpBase<eT, T1>& m);
+  template<typename T1> inline const Mat& operator+=(const SpBase<eT, T1>& m);
+  template<typename T1> inline const Mat& operator-=(const SpBase<eT, T1>& m);
+  template<typename T1> inline const Mat& operator*=(const SpBase<eT, T1>& m);
+  template<typename T1> inline const Mat& operator%=(const SpBase<eT, T1>& m);
+  template<typename T1> inline const Mat& operator/=(const SpBase<eT, T1>& m);
   
   inline mat_injector<Mat> operator<<(const eT val);
   inline mat_injector<Mat> operator<<(const injector_end_of_row<>& x);
@@ -302,64 +302,64 @@ class Mat : public Base< eT, Mat<eT> >
   template<typename T1> inline void insert_cols(const uword col_num, const Base<eT,T1>& X);
   
   
-  template<typename T1, typename gen_type> inline             Mat(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline Mat&  operator=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline Mat& operator+=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline Mat& operator-=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline Mat& operator*=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline Mat& operator%=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline Mat& operator/=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline                   Mat(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline const Mat&  operator=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline const Mat& operator+=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline const Mat& operator-=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline const Mat& operator*=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline const Mat& operator%=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline const Mat& operator/=(const Gen<T1, gen_type>& X);
   
-  template<typename T1, typename op_type> inline             Mat(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat&  operator=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator+=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator-=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator*=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator%=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator/=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline                   Mat(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat&  operator=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator+=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator-=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator*=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator%=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator/=(const Op<T1, op_type>& X);
   
-  template<typename T1, typename eop_type> inline             Mat(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Mat&  operator=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Mat& operator+=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Mat& operator-=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Mat& operator*=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Mat& operator%=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline Mat& operator/=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline                   Mat(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Mat&  operator=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Mat& operator+=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Mat& operator-=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Mat& operator*=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Mat& operator%=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline const Mat& operator/=(const eOp<T1, eop_type>& X);
   
-  template<typename T1, typename op_type> inline             Mat(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat&  operator=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator+=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator-=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator*=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator%=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline Mat& operator/=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline                   Mat(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat&  operator=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator+=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator-=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator*=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator%=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline const Mat& operator/=(const mtOp<eT, T1, op_type>& X);
   
-  template<typename T1, typename T2, typename glue_type> inline             Mat(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat&  operator=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator+=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator-=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator*=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator%=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator/=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline                   Mat(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat&  operator=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator+=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator-=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator*=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator%=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator/=(const Glue<T1, T2, glue_type>& X);
   
-  template<typename T1, typename T2>                     inline Mat& operator+=(const Glue<T1, T2, glue_times>& X);
-  template<typename T1, typename T2>                     inline Mat& operator-=(const Glue<T1, T2, glue_times>& X);
+  template<typename T1, typename T2>                     inline const Mat& operator+=(const Glue<T1, T2, glue_times>& X);
+  template<typename T1, typename T2>                     inline const Mat& operator-=(const Glue<T1, T2, glue_times>& X);
   
-  template<typename T1, typename T2, typename eglue_type> inline             Mat(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Mat&  operator=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Mat& operator+=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Mat& operator-=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Mat& operator*=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Mat& operator%=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline Mat& operator/=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline                   Mat(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Mat&  operator=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator+=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator-=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator*=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator%=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator/=(const eGlue<T1, T2, eglue_type>& X);
   
-  template<typename T1, typename T2, typename glue_type> inline             Mat(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat&  operator=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator+=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator-=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator*=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator%=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline Mat& operator/=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline                   Mat(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat&  operator=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator+=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator-=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator*=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator%=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline const Mat& operator/=(const mtGlue<eT, T1, T2, glue_type>& X);
   
   
   arma_inline arma_warn_unused const eT& at_alt     (const uword ii) const;
@@ -767,18 +767,18 @@ class Mat<eT>::fixed : public Mat<eT>
   using Mat<eT>::operator();
   
   #if defined(ARMA_USE_CXX11)
-    inline            fixed(const std::initializer_list<eT>& list);
-    inline fixed& operator=(const std::initializer_list<eT>& list);
+    inline                fixed(const std::initializer_list<eT>& list);
+    inline const Mat& operator=(const std::initializer_list<eT>& list);
     
-    inline            fixed(const std::initializer_list< std::initializer_list<eT> >& list);
-    inline fixed& operator=(const std::initializer_list< std::initializer_list<eT> >& list);
+    inline                fixed(const std::initializer_list< std::initializer_list<eT> >& list);
+    inline const Mat& operator=(const std::initializer_list< std::initializer_list<eT> >& list);
   #endif
   
-  arma_inline fixed& operator=(const fixed<fixed_n_rows, fixed_n_cols>& X);
+  arma_inline const Mat& operator=(const fixed<fixed_n_rows, fixed_n_cols>& X);
   
   #if defined(ARMA_GOOD_COMPILER)
-    template<typename T1,              typename   eop_type> inline fixed& operator=(const   eOp<T1,       eop_type>& X);
-    template<typename T1, typename T2, typename eglue_type> inline fixed& operator=(const eGlue<T1, T2, eglue_type>& X);
+    template<typename T1,              typename   eop_type> inline const Mat& operator=(const   eOp<T1,       eop_type>& X);
+    template<typename T1, typename T2, typename eglue_type> inline const Mat& operator=(const eGlue<T1, T2, eglue_type>& X);
   #endif
   
   arma_inline const Op< Mat_fixed_type, op_htrans >  t() const;

--- a/include/armadillo_bits/Mat_meat.hpp
+++ b/include/armadillo_bits/Mat_meat.hpp
@@ -368,7 +368,7 @@ Mat<eT>::Mat(const char* text)
 //! create the matrix from a textual description
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -400,7 +400,7 @@ Mat<eT>::Mat(const std::string& text)
 //! create the matrix from a textual description
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -551,7 +551,7 @@ Mat<eT>::Mat(const std::vector<eT>& x)
 //! create the matrix from std::vector
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const std::vector<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -589,7 +589,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  Mat<eT>&
+  const Mat<eT>&
   Mat<eT>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -620,7 +620,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  Mat<eT>&
+  const Mat<eT>&
   Mat<eT>::operator=(const std::initializer_list< std::initializer_list<eT> >& list)
     {
     arma_extra_debug_sigprint();
@@ -675,7 +675,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  Mat<eT>&
+  const Mat<eT>&
   Mat<eT>::operator=(Mat<eT>&& X)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   X = %x") % this % &X);
@@ -701,7 +701,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
 //! NOTE: the size of the matrix will be 1x1
 template<typename eT>
 arma_inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -716,7 +716,7 @@ Mat<eT>::operator=(const eT val)
 //! In-place addition of a scalar to all elements of the matrix
 template<typename eT>
 arma_inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -731,7 +731,7 @@ Mat<eT>::operator+=(const eT val)
 //! In-place subtraction of a scalar from all elements of the matrix
 template<typename eT>
 arma_inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -746,7 +746,7 @@ Mat<eT>::operator-=(const eT val)
 //! In-place multiplication of all elements of the matrix with a scalar
 template<typename eT>
 arma_inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -761,7 +761,7 @@ Mat<eT>::operator*=(const eT val)
 //! In-place division of all elements of the matrix with a scalar
 template<typename eT>
 arma_inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -796,7 +796,7 @@ Mat<eT>::Mat(const Mat<eT>& in_mat)
 //! construct a matrix from a given matrix
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const Mat<eT>& in_mat)
   {
   arma_extra_debug_sigprint(arma_str::format("this = %x   in_mat = %x") % this % &in_mat);
@@ -1273,7 +1273,7 @@ Mat<eT>::Mat(const char junk, const eT* aux_mem, const uword aux_n_rows, const u
 //! in-place matrix addition
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1290,7 +1290,7 @@ Mat<eT>::operator+=(const Mat<eT>& m)
 //! in-place matrix subtraction
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1307,7 +1307,7 @@ Mat<eT>::operator-=(const Mat<eT>& m)
 //! in-place matrix multiplication
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1322,7 +1322,7 @@ Mat<eT>::operator*=(const Mat<eT>& m)
 //! in-place element-wise matrix multiplication
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1339,7 +1339,7 @@ Mat<eT>::operator%=(const Mat<eT>& m)
 //! in-place element-wise matrix division
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1374,7 +1374,7 @@ Mat<eT>::Mat(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1461,7 +1461,7 @@ Mat<eT>::operator=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1542,7 +1542,7 @@ Mat<eT>::operator+=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1623,7 +1623,7 @@ Mat<eT>::operator-=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1640,7 +1640,7 @@ Mat<eT>::operator*=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1721,7 +1721,7 @@ Mat<eT>::operator%=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1871,7 +1871,7 @@ Mat<eT>::Mat(const subview<eT>& X)
 //! construct a matrix from subview (e.g. construct a matrix from a delayed submatrix operation)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1898,7 +1898,7 @@ Mat<eT>::operator=(const subview<eT>& X)
 //! in-place matrix addition (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1912,7 +1912,7 @@ Mat<eT>::operator+=(const subview<eT>& X)
 //! in-place matrix subtraction (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1927,7 +1927,7 @@ Mat<eT>::operator-=(const subview<eT>& X)
 //! in-place matrix mutiplication (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1942,7 +1942,7 @@ Mat<eT>::operator*=(const subview<eT>& X)
 //! in-place element-wise matrix mutiplication (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1957,7 +1957,7 @@ Mat<eT>::operator%=(const subview<eT>& X)
 //! in-place element-wise matrix division (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2067,7 +2067,7 @@ Mat<eT>::Mat(const subview_cube<eT>& x)
 //! construct a matrix from a subview_cube instance
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2082,7 +2082,7 @@ Mat<eT>::operator=(const subview_cube<eT>& X)
 //! in-place matrix addition (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2097,7 +2097,7 @@ Mat<eT>::operator+=(const subview_cube<eT>& X)
 //! in-place matrix subtraction (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2112,7 +2112,7 @@ Mat<eT>::operator-=(const subview_cube<eT>& X)
 //! in-place matrix mutiplication (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2128,7 +2128,7 @@ Mat<eT>::operator*=(const subview_cube<eT>& X)
 //! in-place element-wise matrix mutiplication (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2143,7 +2143,7 @@ Mat<eT>::operator%=(const subview_cube<eT>& X)
 //! in-place element-wise matrix division (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2178,7 +2178,7 @@ Mat<eT>::Mat(const diagview<eT>& X)
 //! construct a matrix from diagview (e.g. construct a matrix from a delayed diag operation)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2206,7 +2206,7 @@ Mat<eT>::operator=(const diagview<eT>& X)
 //! in-place matrix addition (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2221,7 +2221,7 @@ Mat<eT>::operator+=(const diagview<eT>& X)
 //! in-place matrix subtraction (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2236,7 +2236,7 @@ Mat<eT>::operator-=(const diagview<eT>& X)
 //! in-place matrix mutiplication (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2251,7 +2251,7 @@ Mat<eT>::operator*=(const diagview<eT>& X)
 //! in-place element-wise matrix mutiplication (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2266,7 +2266,7 @@ Mat<eT>::operator%=(const diagview<eT>& X)
 //! in-place element-wise matrix division (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2299,7 +2299,7 @@ Mat<eT>::Mat(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2315,7 +2315,7 @@ Mat<eT>::operator=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2331,7 +2331,7 @@ Mat<eT>::operator+=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2347,7 +2347,7 @@ Mat<eT>::operator-=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2363,7 +2363,7 @@ Mat<eT>::operator*=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2379,7 +2379,7 @@ Mat<eT>::operator%=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2414,7 +2414,7 @@ Mat<eT>::Mat(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2429,7 +2429,7 @@ Mat<eT>::operator=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2444,7 +2444,7 @@ Mat<eT>::operator+=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2459,7 +2459,7 @@ Mat<eT>::operator-=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2474,7 +2474,7 @@ Mat<eT>::operator*=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2489,7 +2489,7 @@ Mat<eT>::operator%=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2522,7 +2522,7 @@ Mat<eT>::Mat(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2537,7 +2537,7 @@ Mat<eT>::operator=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2552,7 +2552,7 @@ Mat<eT>::operator+=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2567,7 +2567,7 @@ Mat<eT>::operator-=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2582,7 +2582,7 @@ Mat<eT>::operator*=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2597,7 +2597,7 @@ Mat<eT>::operator%=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2647,7 +2647,7 @@ Mat<eT>::Mat(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2675,7 +2675,7 @@ Mat<eT>::operator=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2701,7 +2701,7 @@ Mat<eT>::operator+=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2727,7 +2727,7 @@ Mat<eT>::operator-=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2744,7 +2744,7 @@ Mat<eT>::operator*=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2782,7 +2782,7 @@ Mat<eT>::operator%=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -4472,7 +4472,7 @@ Mat<eT>::Mat(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4491,7 +4491,7 @@ Mat<eT>::operator=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4508,7 +4508,7 @@ Mat<eT>::operator+=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4525,7 +4525,7 @@ Mat<eT>::operator-=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4542,7 +4542,7 @@ Mat<eT>::operator*=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4559,7 +4559,7 @@ Mat<eT>::operator%=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4598,7 +4598,7 @@ Mat<eT>::Mat(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4616,7 +4616,7 @@ Mat<eT>::operator=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4634,7 +4634,7 @@ Mat<eT>::operator+=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4652,7 +4652,7 @@ Mat<eT>::operator-=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4670,7 +4670,7 @@ Mat<eT>::operator*=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4688,7 +4688,7 @@ Mat<eT>::operator%=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4729,7 +4729,7 @@ Mat<eT>::Mat(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4761,7 +4761,7 @@ Mat<eT>::operator=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4778,7 +4778,7 @@ Mat<eT>::operator+=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4795,7 +4795,7 @@ Mat<eT>::operator-=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4812,7 +4812,7 @@ Mat<eT>::operator*=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4829,7 +4829,7 @@ Mat<eT>::operator%=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4866,7 +4866,7 @@ Mat<eT>::Mat(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4882,7 +4882,7 @@ Mat<eT>::operator=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4898,7 +4898,7 @@ Mat<eT>::operator+=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4914,7 +4914,7 @@ Mat<eT>::operator-=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4930,7 +4930,7 @@ Mat<eT>::operator*=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4946,7 +4946,7 @@ Mat<eT>::operator%=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4984,7 +4984,7 @@ Mat<eT>::Mat(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5003,7 +5003,7 @@ Mat<eT>::operator=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5022,7 +5022,7 @@ Mat<eT>::operator+=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5041,7 +5041,7 @@ Mat<eT>::operator-=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5060,7 +5060,7 @@ Mat<eT>::operator*=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5079,7 +5079,7 @@ Mat<eT>::operator%=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5097,7 +5097,7 @@ Mat<eT>::operator/=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const Glue<T1, T2, glue_times>& X)
   {
   arma_extra_debug_sigprint();
@@ -5112,7 +5112,7 @@ Mat<eT>::operator+=(const Glue<T1, T2, glue_times>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const Glue<T1, T2, glue_times>& X)
   {
   arma_extra_debug_sigprint();
@@ -5152,7 +5152,7 @@ Mat<eT>::Mat(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5191,7 +5191,7 @@ Mat<eT>::operator=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5210,7 +5210,7 @@ Mat<eT>::operator+=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5228,7 +5228,7 @@ Mat<eT>::operator-=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5245,7 +5245,7 @@ Mat<eT>::operator*=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5262,7 +5262,7 @@ Mat<eT>::operator%=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5299,7 +5299,7 @@ Mat<eT>::Mat(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5315,7 +5315,7 @@ Mat<eT>::operator=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator+=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5331,7 +5331,7 @@ Mat<eT>::operator+=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator-=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5347,7 +5347,7 @@ Mat<eT>::operator-=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator*=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5365,7 +5365,7 @@ Mat<eT>::operator*=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator%=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5381,7 +5381,7 @@ Mat<eT>::operator%=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-Mat<eT>&
+const Mat<eT>&
 Mat<eT>::operator/=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -8200,7 +8200,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::fixed(const std::string& text)
   template<typename eT>
   template<uword fixed_n_rows, uword fixed_n_cols>
   inline
-  Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
+  const Mat<eT>&
   Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -8236,7 +8236,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::fixed(const std::string& text)
   template<typename eT>
   template<uword fixed_n_rows, uword fixed_n_cols>
   inline
-  Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
+  const Mat<eT>&
   Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const std::initializer_list< std::initializer_list<eT> >& list)
     {
     arma_extra_debug_sigprint();
@@ -8253,7 +8253,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::fixed(const std::string& text)
 template<typename eT>
 template<uword fixed_n_rows, uword fixed_n_cols>
 arma_inline
-Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
+const Mat<eT>&
 Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const fixed<fixed_n_rows, fixed_n_cols>& X)
   {
   arma_extra_debug_sigprint();
@@ -8277,7 +8277,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const fixed<fixed_n_rows, 
   template<uword fixed_n_rows, uword fixed_n_cols>
   template<typename T1, typename eop_type>
   inline
-  Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
+  const Mat<eT>&
   Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const eOp<T1, eop_type>& X)
     {
     arma_extra_debug_sigprint();
@@ -8310,7 +8310,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const fixed<fixed_n_rows, 
   template<uword fixed_n_rows, uword fixed_n_cols>
   template<typename T1, typename T2, typename eglue_type>
   inline
-  Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
+  const Mat<eT>&
   Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const eGlue<T1, T2, eglue_type>& X)
     {
     arma_extra_debug_sigprint();

--- a/include/armadillo_bits/Row_bones.hpp
+++ b/include/armadillo_bits/Row_bones.hpp
@@ -40,30 +40,30 @@ class Row : public Mat<eT>
   template<typename fill_type> inline Row(const uword in_rows, const uword in_cols, const fill::fill_class<fill_type>& f);
   template<typename fill_type> inline Row(const SizeMat& s,                         const fill::fill_class<fill_type>& f);
   
-  inline            Row(const char*        text);
-  inline Row& operator=(const char*        text);
+  inline                  Row(const char*        text);
+  inline const Row& operator=(const char*        text);
   
-  inline            Row(const std::string& text);
-  inline Row& operator=(const std::string& text);
+  inline                  Row(const std::string& text);
+  inline const Row& operator=(const std::string& text);
   
-  inline            Row(const std::vector<eT>& x);
-  inline Row& operator=(const std::vector<eT>& x);
+  inline                  Row(const std::vector<eT>& x);
+  inline const Row& operator=(const std::vector<eT>& x);
   
   #if defined(ARMA_USE_CXX11)
-  inline            Row(const std::initializer_list<eT>& list);
-  inline Row& operator=(const std::initializer_list<eT>& list);
+  inline                  Row(const std::initializer_list<eT>& list);
+  inline const Row& operator=(const std::initializer_list<eT>& list);
   
-  inline            Row(Row&& m);
-  inline Row& operator=(Row&& m);
+  inline                  Row(Row&& m);
+  inline const Row& operator=(Row&& m);
   #endif
   
   inline explicit Row(const SpRow<eT>& X);
   
-  inline Row& operator=(const eT val);
-  inline Row& operator=(const Row& X);
+  inline const Row& operator=(const eT val);
+  inline const Row& operator=(const Row& X);
   
-  template<typename T1> inline             Row(const Base<eT,T1>& X);
-  template<typename T1> inline Row&  operator=(const Base<eT,T1>& X);
+  template<typename T1> inline                   Row(const Base<eT,T1>& X);
+  template<typename T1> inline const Row&  operator=(const Base<eT,T1>& X);
   
   inline Row(      eT* aux_mem, const uword aux_length, const bool copy_aux_mem = true, const bool strict = false);
   inline Row(const eT* aux_mem, const uword aux_length);
@@ -71,11 +71,11 @@ class Row : public Mat<eT>
   template<typename T1, typename T2>
   inline explicit Row(const Base<pod_type,T1>& A, const Base<pod_type,T2>& B);
   
-  template<typename T1> inline            Row(const BaseCube<eT,T1>& X);
-  template<typename T1> inline Row& operator=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline                  Row(const BaseCube<eT,T1>& X);
+  template<typename T1> inline const Row& operator=(const BaseCube<eT,T1>& X);
   
-  inline            Row(const subview_cube<eT>& X);
-  inline Row& operator=(const subview_cube<eT>& X);
+  inline                  Row(const subview_cube<eT>& X);
+  inline const Row& operator=(const subview_cube<eT>& X);
   
   inline mat_injector<Row> operator<<(const eT val);
   
@@ -199,25 +199,25 @@ class Row<eT>::fixed : public Row<eT>
   inline fixed(const char*        text);
   inline fixed(const std::string& text);
   
-  template<typename T1> inline Row& operator=(const Base<eT,T1>& A);
+  template<typename T1> inline const Row& operator=(const Base<eT,T1>& A);
   
-  inline Row& operator=(const eT val);
-  inline Row& operator=(const char*        text);
-  inline Row& operator=(const std::string& text);
-  inline Row& operator=(const subview_cube<eT>& X);
+  inline const Row& operator=(const eT val);
+  inline const Row& operator=(const char*        text);
+  inline const Row& operator=(const std::string& text);
+  inline const Row& operator=(const subview_cube<eT>& X);
   
   using Row<eT>::operator();
   
   #if defined(ARMA_USE_CXX11)
-    inline          fixed(const std::initializer_list<eT>& list);
-    inline Row& operator=(const std::initializer_list<eT>& list);
+    inline                fixed(const std::initializer_list<eT>& list);
+    inline const Row& operator=(const std::initializer_list<eT>& list);
   #endif
   
-  arma_inline Row& operator=(const fixed<fixed_n_elem>& X);
+  arma_inline const Row& operator=(const fixed<fixed_n_elem>& X);
   
   #if defined(ARMA_GOOD_COMPILER)
-    template<typename T1,              typename   eop_type> inline Row& operator=(const   eOp<T1,       eop_type>& X);
-    template<typename T1, typename T2, typename eglue_type> inline Row& operator=(const eGlue<T1, T2, eglue_type>& X);
+    template<typename T1,              typename   eop_type> inline const Row& operator=(const   eOp<T1,       eop_type>& X);
+    template<typename T1, typename T2, typename eglue_type> inline const Row& operator=(const eGlue<T1, T2, eglue_type>& X);
   #endif
   
   arma_inline const Op< Row_fixed_type, op_htrans >  t() const;

--- a/include/armadillo_bits/Row_meat.hpp
+++ b/include/armadillo_bits/Row_meat.hpp
@@ -134,7 +134,7 @@ Row<eT>::Row(const char* text)
 
 template<typename eT>
 inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -161,7 +161,7 @@ Row<eT>::Row(const std::string& text)
 
 template<typename eT>
 inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -192,7 +192,7 @@ Row<eT>::Row(const std::vector<eT>& x)
 //! create a row vector from std::vector
 template<typename eT>
 inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::operator=(const std::vector<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -226,7 +226,7 @@ Row<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  Row<eT>&
+  const Row<eT>&
   Row<eT>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -280,7 +280,7 @@ Row<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  Row<eT>&
+  const Row<eT>&
   Row<eT>::operator=(Row<eT>&& X)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   X = %x") % this % &X);
@@ -321,7 +321,7 @@ Row<eT>::Row(const SpRow<eT>& X)
 
 template<typename eT>
 inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -335,7 +335,7 @@ Row<eT>::operator=(const eT val)
 
 template<typename eT>
 inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::operator=(const Row<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -363,7 +363,7 @@ Row<eT>::Row(const Base<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::operator=(const Base<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -436,7 +436,7 @@ Row<eT>::Row(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::operator=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -463,7 +463,7 @@ Row<eT>::Row(const subview_cube<eT>& X)
 
 template<typename eT>
 inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1181,7 +1181,7 @@ Row<eT>::fixed<fixed_n_elem>::fixed(const std::string& text)
 template<typename eT>
 template<uword fixed_n_elem>
 template<typename T1>
-Row<eT>&
+const Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const Base<eT,T1>& A)
   {
   arma_extra_debug_sigprint();
@@ -1195,7 +1195,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const Base<eT,T1>& A)
 
 template<typename eT>
 template<uword fixed_n_elem>
-Row<eT>&
+const Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -1209,7 +1209,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const eT val)
 
 template<typename eT>
 template<uword fixed_n_elem>
-Row<eT>&
+const Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -1223,7 +1223,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const char* text)
 
 template<typename eT>
 template<uword fixed_n_elem>
-Row<eT>&
+const Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -1237,7 +1237,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
 
 template<typename eT>
 template<uword fixed_n_elem>
-Row<eT>&
+const Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1267,7 +1267,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
   template<typename eT>
   template<uword fixed_n_elem>
   inline
-  Row<eT>&
+  const Row<eT>&
   Row<eT>::fixed<fixed_n_elem>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -1292,7 +1292,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
 template<typename eT>
 template<uword fixed_n_elem>
 arma_inline
-Row<eT>&
+const Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   {
   arma_extra_debug_sigprint();
@@ -1316,7 +1316,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   template<uword fixed_n_elem>
   template<typename T1, typename eop_type>
   inline
-  Row<eT>&
+  const Row<eT>&
   Row<eT>::fixed<fixed_n_elem>::operator=(const eOp<T1, eop_type>& X)
     {
     arma_extra_debug_sigprint();
@@ -1349,7 +1349,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   template<uword fixed_n_elem>
   template<typename T1, typename T2, typename eglue_type>
   inline
-  Row<eT>&
+  const Row<eT>&
   Row<eT>::fixed<fixed_n_elem>::operator=(const eGlue<T1, T2, eglue_type>& X)
     {
     arma_extra_debug_sigprint();

--- a/include/armadillo_bits/SpCol_bones.hpp
+++ b/include/armadillo_bits/SpCol_bones.hpp
@@ -35,19 +35,19 @@ class SpCol : public SpMat<eT>
   inline explicit SpCol(const uword n_elem);
   inline          SpCol(const uword in_rows, const uword in_cols);
   
-  inline            SpCol(const char*        text);
-  inline SpCol& operator=(const char*        text);
+  inline                  SpCol(const char*        text);
+  inline const SpCol& operator=(const char*        text);
   
-  inline            SpCol(const std::string& text);
-  inline SpCol& operator=(const std::string& text);
+  inline                  SpCol(const std::string& text);
+  inline const SpCol& operator=(const std::string& text);
   
-  inline SpCol& operator=(const eT val);
+  inline const SpCol& operator=(const eT val);
   
-  template<typename T1> inline            SpCol(const Base<eT,T1>& X);
-  template<typename T1> inline SpCol& operator=(const Base<eT,T1>& X);
+  template<typename T1> inline                  SpCol(const Base<eT,T1>& X);
+  template<typename T1> inline const SpCol& operator=(const Base<eT,T1>& X);
   
-  template<typename T1> inline            SpCol(const SpBase<eT,T1>& X);
-  template<typename T1> inline SpCol& operator=(const SpBase<eT,T1>& X);
+  template<typename T1> inline                  SpCol(const SpBase<eT,T1>& X);
+  template<typename T1> inline const SpCol& operator=(const SpBase<eT,T1>& X);
   
   template<typename T1, typename T2>
   inline explicit SpCol(const SpBase<pod_type,T1>& A, const SpBase<pod_type,T2>& B);

--- a/include/armadillo_bits/SpCol_meat.hpp
+++ b/include/armadillo_bits/SpCol_meat.hpp
@@ -76,7 +76,7 @@ SpCol<eT>::SpCol(const char* text)
 //! construct a column vector from specified text
 template<typename eT>
 inline
-SpCol<eT>&
+const SpCol<eT>&
 SpCol<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -108,7 +108,7 @@ SpCol<eT>::SpCol(const std::string& text)
 //! construct a column vector from specified text
 template<typename eT>
 inline
-SpCol<eT>&
+const SpCol<eT>&
 SpCol<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -122,7 +122,7 @@ SpCol<eT>::operator=(const std::string& text)
 
 template<typename eT>
 inline
-SpCol<eT>&
+const SpCol<eT>&
 SpCol<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -151,7 +151,7 @@ SpCol<eT>::SpCol(const Base<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-SpCol<eT>&
+const SpCol<eT>&
 SpCol<eT>::operator=(const Base<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -182,7 +182,7 @@ SpCol<eT>::SpCol(const SpBase<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-SpCol<eT>&
+const SpCol<eT>&
 SpCol<eT>::operator=(const SpBase<eT,T1>& X)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/SpMat_bones.hpp
+++ b/include/armadillo_bits/SpMat_bones.hpp
@@ -85,16 +85,16 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   inline explicit SpMat(const uword in_rows, const uword in_cols);
   inline explicit SpMat(const SizeMat& s);
   
-  inline            SpMat(const char*        text);
-  inline SpMat& operator=(const char*        text);
-  inline            SpMat(const std::string& text);
-  inline SpMat& operator=(const std::string& text);
-  inline            SpMat(const SpMat<eT>&   x);
+  inline                  SpMat(const char*        text);
+  inline const SpMat& operator=(const char*        text);
+  inline                  SpMat(const std::string& text);
+  inline const SpMat& operator=(const std::string& text);
+  inline                  SpMat(const SpMat<eT>&   x);
   
   
   #if defined(ARMA_USE_CXX11)
-  inline            SpMat(SpMat&& m);
-  inline SpMat& operator=(SpMat&& m);
+  inline                  SpMat(SpMat&& m);
+  inline const SpMat& operator=(SpMat&& m);
   #endif
   
   template<typename T1, typename T2, typename T3>
@@ -109,65 +109,65 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   template<typename T1, typename T2>
   inline SpMat(const bool add_values, const Base<uword,T1>& locations, const Base<eT,T2>& values, const uword n_rows, const uword n_cols, const bool sort_locations = true, const bool check_for_zeros = true);
   
-  inline SpMat&  operator=(const eT val); //! sets size to 1x1
-  inline SpMat& operator*=(const eT val);
-  inline SpMat& operator/=(const eT val);
+  inline const SpMat&  operator=(const eT val); //! sets size to 1x1
+  inline const SpMat& operator*=(const eT val);
+  inline const SpMat& operator/=(const eT val);
   // operator+=(val) and operator-=(val) are not defined as they don't make sense for sparse matrices
   
-  inline SpMat&  operator=(const SpMat& m);
-  inline SpMat& operator+=(const SpMat& m);
-  inline SpMat& operator-=(const SpMat& m);
-  inline SpMat& operator*=(const SpMat& m);
-  inline SpMat& operator%=(const SpMat& m);
-  inline SpMat& operator/=(const SpMat& m);
+  inline const SpMat&  operator=(const SpMat& m);
+  inline const SpMat& operator+=(const SpMat& m);
+  inline const SpMat& operator-=(const SpMat& m);
+  inline const SpMat& operator*=(const SpMat& m);
+  inline const SpMat& operator%=(const SpMat& m);
+  inline const SpMat& operator/=(const SpMat& m);
   
-  template<typename T1> inline explicit    SpMat(const Base<eT, T1>& m);
-  template<typename T1> inline SpMat&  operator=(const Base<eT, T1>& m);
-  template<typename T1> inline SpMat& operator+=(const Base<eT, T1>& m);
-  template<typename T1> inline SpMat& operator-=(const Base<eT, T1>& m);
-  template<typename T1> inline SpMat& operator*=(const Base<eT, T1>& m);
-  template<typename T1> inline SpMat& operator/=(const Base<eT, T1>& m);
-  template<typename T1> inline SpMat& operator%=(const Base<eT, T1>& m);
+  template<typename T1> inline explicit          SpMat(const Base<eT, T1>& m);
+  template<typename T1> inline const SpMat&  operator=(const Base<eT, T1>& m);
+  template<typename T1> inline const SpMat& operator+=(const Base<eT, T1>& m);
+  template<typename T1> inline const SpMat& operator-=(const Base<eT, T1>& m);
+  template<typename T1> inline const SpMat& operator*=(const Base<eT, T1>& m);
+  template<typename T1> inline const SpMat& operator/=(const Base<eT, T1>& m);
+  template<typename T1> inline const SpMat& operator%=(const Base<eT, T1>& m);
   
   
   //! construction of complex matrix out of two non-complex matrices
   template<typename T1, typename T2>
   inline explicit SpMat(const SpBase<pod_type, T1>& A, const SpBase<pod_type, T2>& B);
   
-  inline             SpMat(const SpSubview<eT>& X);
-  inline SpMat&  operator=(const SpSubview<eT>& X);
-  inline SpMat& operator+=(const SpSubview<eT>& X);
-  inline SpMat& operator-=(const SpSubview<eT>& X);
-  inline SpMat& operator*=(const SpSubview<eT>& X);
-  inline SpMat& operator%=(const SpSubview<eT>& X);
-  inline SpMat& operator/=(const SpSubview<eT>& X);
+  inline                   SpMat(const SpSubview<eT>& X);
+  inline const SpMat&  operator=(const SpSubview<eT>& X);
+  inline const SpMat& operator+=(const SpSubview<eT>& X);
+  inline const SpMat& operator-=(const SpSubview<eT>& X);
+  inline const SpMat& operator*=(const SpSubview<eT>& X);
+  inline const SpMat& operator%=(const SpSubview<eT>& X);
+  inline const SpMat& operator/=(const SpSubview<eT>& X);
   
   // delayed unary ops
-  template<typename T1, typename spop_type> inline             SpMat(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat&  operator=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator+=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator-=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator*=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator%=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator/=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline                   SpMat(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat&  operator=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator+=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator-=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator*=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator%=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator/=(const SpOp<T1, spop_type>& X);
   
   // delayed binary ops
-  template<typename T1, typename T2, typename spglue_type> inline             SpMat(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline SpMat&  operator=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator+=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator-=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator*=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator%=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator/=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline                   SpMat(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline const SpMat&  operator=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator+=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator-=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator*=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator%=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator/=(const SpGlue<T1, T2, spglue_type>& X);
   
   // delayed mixed-type unary ops
-  template<typename T1, typename spop_type> inline             SpMat(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat&  operator=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator+=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator-=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator*=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator%=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline SpMat& operator/=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline                   SpMat(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat&  operator=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator+=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator-=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator*=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator%=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline const SpMat& operator/=(const mtSpOp<eT, T1, spop_type>& X);
   
   
   arma_inline       SpSubview<eT> row(const uword row_num);

--- a/include/armadillo_bits/SpMat_meat.hpp
+++ b/include/armadillo_bits/SpMat_meat.hpp
@@ -125,7 +125,7 @@ SpMat<eT>::SpMat(const char* text)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -158,7 +158,7 @@ SpMat<eT>::SpMat(const std::string& text)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -213,7 +213,7 @@ SpMat<eT>::SpMat(const SpMat<eT>& x)
   
   template<typename eT>
   inline
-  SpMat<eT>&
+  const SpMat<eT>&
   SpMat<eT>::operator=(SpMat<eT>&& in_mat)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   in_mat = %x") % this % &in_mat);
@@ -514,7 +514,7 @@ SpMat<eT>::SpMat
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -542,7 +542,7 @@ SpMat<eT>::operator=(const eT val)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -566,7 +566,7 @@ SpMat<eT>::operator*=(const eT val)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator/=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -584,7 +584,7 @@ SpMat<eT>::operator/=(const eT val)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -598,7 +598,7 @@ SpMat<eT>::operator=(const SpMat<eT>& x)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator+=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -614,7 +614,7 @@ SpMat<eT>::operator+=(const SpMat<eT>& x)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator-=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -630,7 +630,7 @@ SpMat<eT>::operator-=(const SpMat<eT>& x)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator*=(const SpMat<eT>& y)
   {
   arma_extra_debug_sigprint();
@@ -647,7 +647,7 @@ SpMat<eT>::operator*=(const SpMat<eT>& y)
 // This is in-place element-wise matrix multiplication.
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator%=(const SpMat<eT>& y)
   {
   arma_extra_debug_sigprint();
@@ -760,7 +760,7 @@ SpMat<eT>::SpMat
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator/=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -805,7 +805,7 @@ SpMat<eT>::SpMat(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const Base<eT, T1>& expr)
   {
   arma_extra_debug_sigprint();
@@ -861,7 +861,7 @@ SpMat<eT>::operator=(const Base<eT, T1>& expr)
 template<typename eT>
 template<typename T1>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator+=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -874,7 +874,7 @@ SpMat<eT>::operator+=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator-=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -887,7 +887,7 @@ SpMat<eT>::operator-=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator*=(const Base<eT, T1>& y)
   {
   arma_extra_debug_sigprint();
@@ -985,7 +985,7 @@ SpMat<eT>::operator*=(const Base<eT, T1>& y)
 template<typename eT>
 template<typename T1>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator/=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -1002,7 +1002,7 @@ SpMat<eT>::operator/=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator%=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -1083,7 +1083,7 @@ SpMat<eT>::SpMat(const SpSubview<eT>& X)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1133,7 +1133,7 @@ SpMat<eT>::operator=(const SpSubview<eT>& X)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator+=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1149,7 +1149,7 @@ SpMat<eT>::operator+=(const SpSubview<eT>& X)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator-=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1165,7 +1165,7 @@ SpMat<eT>::operator-=(const SpSubview<eT>& X)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator*=(const SpSubview<eT>& y)
   {
   arma_extra_debug_sigprint();
@@ -1181,7 +1181,7 @@ SpMat<eT>::operator*=(const SpSubview<eT>& y)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator%=(const SpSubview<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -1197,7 +1197,7 @@ SpMat<eT>::operator%=(const SpSubview<eT>& x)
 
 template<typename eT>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator/=(const SpSubview<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -1240,7 +1240,7 @@ SpMat<eT>::SpMat(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1257,7 +1257,7 @@ SpMat<eT>::operator=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator+=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1274,7 +1274,7 @@ SpMat<eT>::operator+=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator-=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1291,7 +1291,7 @@ SpMat<eT>::operator-=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator*=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1308,7 +1308,7 @@ SpMat<eT>::operator*=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator%=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1325,7 +1325,7 @@ SpMat<eT>::operator%=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator/=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1384,7 +1384,7 @@ SpMat<eT>::SpMat(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1399,7 +1399,7 @@ SpMat<eT>::operator=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator+=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1414,7 +1414,7 @@ SpMat<eT>::operator+=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator-=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1429,7 +1429,7 @@ SpMat<eT>::operator-=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator*=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1444,7 +1444,7 @@ SpMat<eT>::operator*=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator%=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1459,7 +1459,7 @@ SpMat<eT>::operator%=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator/=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1474,7 +1474,7 @@ SpMat<eT>::operator/=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1491,7 +1491,7 @@ SpMat<eT>::operator=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator+=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1508,7 +1508,7 @@ SpMat<eT>::operator+=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator-=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1525,7 +1525,7 @@ SpMat<eT>::operator-=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator*=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1542,7 +1542,7 @@ SpMat<eT>::operator*=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator%=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1559,7 +1559,7 @@ SpMat<eT>::operator%=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-SpMat<eT>&
+const SpMat<eT>&
 SpMat<eT>::operator/=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/SpRow_bones.hpp
+++ b/include/armadillo_bits/SpRow_bones.hpp
@@ -35,19 +35,19 @@ class SpRow : public SpMat<eT>
   inline explicit SpRow(const uword N);
   inline          SpRow(const uword in_rows, const uword in_cols);
   
-  inline            SpRow(const char*        text);
-  inline SpRow& operator=(const char*        text);
+  inline                  SpRow(const char*        text);
+  inline const SpRow& operator=(const char*        text);
   
-  inline            SpRow(const std::string& text);
-  inline SpRow& operator=(const std::string& text);
+  inline                  SpRow(const std::string& text);
+  inline const SpRow& operator=(const std::string& text);
   
-  inline SpRow& operator=(const eT val);
+  inline const SpRow& operator=(const eT val);
   
-  template<typename T1> inline            SpRow(const Base<eT,T1>& X);
-  template<typename T1> inline SpRow& operator=(const Base<eT,T1>& X);
+  template<typename T1> inline                  SpRow(const Base<eT,T1>& X);
+  template<typename T1> inline const SpRow& operator=(const Base<eT,T1>& X);
   
-  template<typename T1> inline            SpRow(const SpBase<eT,T1>& X);
-  template<typename T1> inline SpRow& operator=(const SpBase<eT,T1>& X);
+  template<typename T1> inline                  SpRow(const SpBase<eT,T1>& X);
+  template<typename T1> inline const SpRow& operator=(const SpBase<eT,T1>& X);
   
   template<typename T1, typename T2>
   inline explicit SpRow(const SpBase<pod_type,T1>& A, const SpBase<pod_type,T2>& B);

--- a/include/armadillo_bits/SpRow_meat.hpp
+++ b/include/armadillo_bits/SpRow_meat.hpp
@@ -73,7 +73,7 @@ SpRow<eT>::SpRow(const char* text)
 
 template<typename eT>
 inline
-SpRow<eT>&
+const SpRow<eT>&
 SpRow<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -103,7 +103,7 @@ SpRow<eT>::SpRow(const std::string& text)
 
 template<typename eT>
 inline
-SpRow<eT>&
+const SpRow<eT>&
 SpRow<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -117,7 +117,7 @@ SpRow<eT>::operator=(const std::string& text)
 
 template<typename eT>
 inline
-SpRow<eT>&
+const SpRow<eT>&
 SpRow<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -146,7 +146,7 @@ SpRow<eT>::SpRow(const Base<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-SpRow<eT>&
+const SpRow<eT>&
 SpRow<eT>::operator=(const Base<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -175,7 +175,7 @@ SpRow<eT>::SpRow(const SpBase<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-SpRow<eT>&
+const SpRow<eT>&
 SpRow<eT>::operator=(const SpBase<eT,T1>& X)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/SpSubview_bones.hpp
+++ b/include/armadillo_bits/SpSubview_bones.hpp
@@ -50,28 +50,28 @@ class SpSubview : public SpBase<eT, SpSubview<eT> >
 
   inline ~SpSubview();
 
-  inline SpSubview& operator+= (const eT val);
-  inline SpSubview& operator-= (const eT val);
-  inline SpSubview& operator*= (const eT val);
-  inline SpSubview& operator/= (const eT val);
+  inline const SpSubview& operator+= (const eT val);
+  inline const SpSubview& operator-= (const eT val);
+  inline const SpSubview& operator*= (const eT val);
+  inline const SpSubview& operator/= (const eT val);
 
-  inline SpSubview& operator=(const SpSubview& x);
+  inline const SpSubview& operator=(const SpSubview& x);
 
-  template<typename T1> inline SpSubview& operator= (const Base<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator+=(const Base<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator-=(const Base<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator*=(const Base<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator%=(const Base<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator/=(const Base<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator= (const Base<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator+=(const Base<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator-=(const Base<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator*=(const Base<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator%=(const Base<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator/=(const Base<eT, T1>& x);
 
-  template<typename T1> inline SpSubview& operator_equ_common(const SpBase<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator_equ_common(const SpBase<eT, T1>& x);
   
-  template<typename T1> inline SpSubview& operator= (const SpBase<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator+=(const SpBase<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator-=(const SpBase<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator*=(const SpBase<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator%=(const SpBase<eT, T1>& x);
-  template<typename T1> inline SpSubview& operator/=(const SpBase<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator= (const SpBase<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator+=(const SpBase<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator-=(const SpBase<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator*=(const SpBase<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator%=(const SpBase<eT, T1>& x);
+  template<typename T1> inline const SpSubview& operator/=(const SpBase<eT, T1>& x);
 
   /*
   inline static void extract(SpMat<eT>& out, const SpSubview& in);

--- a/include/armadillo_bits/SpSubview_meat.hpp
+++ b/include/armadillo_bits/SpSubview_meat.hpp
@@ -93,7 +93,7 @@ SpSubview<eT>::~SpSubview()
 
 template<typename eT>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator+=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -114,7 +114,7 @@ SpSubview<eT>::operator+=(const eT val)
 
 template<typename eT>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator-=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -135,7 +135,7 @@ SpSubview<eT>::operator-=(const eT val)
 
 template<typename eT>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -181,7 +181,7 @@ SpSubview<eT>::operator*=(const eT val)
 
 template<typename eT>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator/=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -230,7 +230,7 @@ SpSubview<eT>::operator/=(const eT val)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator=(const Base<eT, T1>& in)
   {
   arma_extra_debug_sigprint();
@@ -431,7 +431,7 @@ SpSubview<eT>::operator=(const Base<eT, T1>& in)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator+=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -444,7 +444,7 @@ SpSubview<eT>::operator+=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator-=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -457,7 +457,7 @@ SpSubview<eT>::operator-=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator*=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -474,7 +474,7 @@ SpSubview<eT>::operator*=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator%=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -487,7 +487,7 @@ SpSubview<eT>::operator%=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator/=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -499,7 +499,7 @@ SpSubview<eT>::operator/=(const Base<eT, T1>& x)
 
 template<typename eT>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator=(const SpSubview<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -512,7 +512,7 @@ SpSubview<eT>::operator=(const SpSubview<eT>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -525,7 +525,7 @@ SpSubview<eT>::operator=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator_equ_common(const SpBase<eT, T1>& in)
   {
   arma_extra_debug_sigprint();
@@ -721,7 +721,7 @@ SpSubview<eT>::operator_equ_common(const SpBase<eT, T1>& in)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator+=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -735,7 +735,7 @@ SpSubview<eT>::operator+=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator-=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -749,7 +749,7 @@ SpSubview<eT>::operator-=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator*=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -762,7 +762,7 @@ SpSubview<eT>::operator*=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator%=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -777,7 +777,7 @@ SpSubview<eT>::operator%=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-SpSubview<eT>&
+const SpSubview<eT>&
 SpSubview<eT>::operator/=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/field_bones.hpp
+++ b/include/armadillo_bits/field_bones.hpp
@@ -53,11 +53,11 @@ class field
   inline ~field();
   inline  field();
   
-  inline            field(const field& x);
-  inline field& operator=(const field& x);
+  inline                  field(const field& x);
+  inline const field& operator=(const field& x);
   
-  inline            field(const subview_field<oT>& x);
-  inline field& operator=(const subview_field<oT>& x);
+  inline                  field(const subview_field<oT>& x);
+  inline const field& operator=(const subview_field<oT>& x);
   
   inline explicit field(const uword n_elem_in);
   inline explicit field(const uword n_rows_in, const uword n_cols_in);
@@ -72,14 +72,14 @@ class field
   inline void  set_size(const SizeCube& s);
   
   #if defined(ARMA_USE_CXX11)
-  inline            field(const std::initializer_list<oT>& list);
-  inline field& operator=(const std::initializer_list<oT>& list);
+  inline                  field(const std::initializer_list<oT>& list);
+  inline const field& operator=(const std::initializer_list<oT>& list);
   
-  inline            field(const std::initializer_list< std::initializer_list<oT> >& list);
-  inline field& operator=(const std::initializer_list< std::initializer_list<oT> >& list);
+  inline                  field(const std::initializer_list< std::initializer_list<oT> >& list);
+  inline const field& operator=(const std::initializer_list< std::initializer_list<oT> >& list);
   
-  inline            field(field&& X);
-  inline field& operator=(field&& X);
+  inline                  field(field&& X);
+  inline const field& operator=(field&& X);
   #endif
   
   template<typename oT2>

--- a/include/armadillo_bits/field_meat.hpp
+++ b/include/armadillo_bits/field_meat.hpp
@@ -74,7 +74,7 @@ field<oT>::field(const field& x)
 //! construct a field from a given field
 template<typename oT>
 inline
-field<oT>&
+const field<oT>&
 field<oT>::operator=(const field& x)
   {
   arma_extra_debug_sigprint();
@@ -105,7 +105,7 @@ field<oT>::field(const subview_field<oT>& X)
 //! construct a field from subview_field (e.g. construct a field from a delayed subfield operation)
 template<typename oT>
 inline
-field<oT>&
+const field<oT>&
 field<oT>::operator=(const subview_field<oT>& X)
   {
   arma_extra_debug_sigprint();
@@ -279,7 +279,7 @@ field<oT>::set_size(const SizeCube& s)
   
   template<typename oT>
   inline
-  field<oT>&
+  const field<oT>&
   field<oT>::operator=(const std::initializer_list<oT>& list)
     {
     arma_extra_debug_sigprint();
@@ -317,7 +317,7 @@ field<oT>::set_size(const SizeCube& s)
   
   template<typename oT>
   inline
-  field<oT>&
+  const field<oT>&
   field<oT>::operator=(const std::initializer_list< std::initializer_list<oT> >& list)
     {
     arma_extra_debug_sigprint();
@@ -404,7 +404,7 @@ field<oT>::set_size(const SizeCube& s)
   
   template<typename oT>
   inline
-  field<oT>&
+  const field<oT>&
   field<oT>::operator=(field<oT>&& X)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   X = %x") % this % &X);

--- a/include/armadillo_bits/gmm_diag_bones.hpp
+++ b/include/armadillo_bits/gmm_diag_bones.hpp
@@ -86,8 +86,8 @@ class gmm_diag
   inline ~gmm_diag();
   inline  gmm_diag();
   
-  inline            gmm_diag(const gmm_diag& x);
-  inline gmm_diag& operator=(const gmm_diag& x);
+  inline                  gmm_diag(const gmm_diag& x);
+  inline const gmm_diag& operator=(const gmm_diag& x);
   
   inline      gmm_diag(const uword in_n_dims, const uword in_n_gaus);
   inline void    reset(const uword in_n_dims, const uword in_n_gaus);

--- a/include/armadillo_bits/gmm_diag_meat.hpp
+++ b/include/armadillo_bits/gmm_diag_meat.hpp
@@ -55,7 +55,7 @@ gmm_diag<eT>::gmm_diag(const gmm_diag<eT>& x)
 
 template<typename eT>
 inline
-gmm_diag<eT>&
+const gmm_diag<eT>&
 gmm_diag<eT>::operator=(const gmm_diag<eT>& x)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/gmm_misc_bones.hpp
+++ b/include/armadillo_bits/gmm_misc_bones.hpp
@@ -32,7 +32,7 @@ class running_mean_scalar
   inline running_mean_scalar();
   inline running_mean_scalar(const running_mean_scalar& in_rms);
   
-  inline running_mean_scalar& operator=(const running_mean_scalar& in_rms);
+  inline const running_mean_scalar& operator=(const running_mean_scalar& in_rms);
   
   arma_hot inline void operator() (const eT X);
   
@@ -60,7 +60,7 @@ class running_mean_vec
   inline running_mean_vec();
   inline running_mean_vec(const running_mean_vec& in_rmv);
   
-  inline running_mean_vec& operator=(const running_mean_vec& in_rmv);
+  inline const running_mean_vec& operator=(const running_mean_vec& in_rmv);
   
   arma_hot inline void operator() (const Col<eT>& X, const uword index);
   

--- a/include/armadillo_bits/gmm_misc_meat.hpp
+++ b/include/armadillo_bits/gmm_misc_meat.hpp
@@ -46,7 +46,7 @@ running_mean_scalar<eT>::running_mean_scalar(const running_mean_scalar<eT>& in)
 
 template<typename eT>
 inline
-running_mean_scalar<eT>&
+const running_mean_scalar<eT>&
 running_mean_scalar<eT>::operator=(const running_mean_scalar<eT>& in)
   {
   arma_extra_debug_sigprint();
@@ -147,7 +147,7 @@ running_mean_vec<eT>::running_mean_vec(const running_mean_vec<eT>& in)
 
 template<typename eT>
 inline
-running_mean_vec<eT>&
+const running_mean_vec<eT>&
 running_mean_vec<eT>::operator=(const running_mean_vec<eT>& in)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/podarray_bones.hpp
+++ b/include/armadillo_bits/podarray_bones.hpp
@@ -46,8 +46,8 @@ class podarray
   inline ~podarray();
   inline  podarray();
   
-  inline           podarray (const podarray& x);
-  inline podarray& operator=(const podarray& x);
+  inline                 podarray (const podarray& x);
+  inline const podarray& operator=(const podarray& x);
   
   arma_inline explicit podarray(const uword new_N);
   

--- a/include/armadillo_bits/podarray_meat.hpp
+++ b/include/armadillo_bits/podarray_meat.hpp
@@ -62,7 +62,7 @@ podarray<eT>::podarray(const podarray& x)
 
 template<typename eT>
 inline
-podarray<eT>&
+const podarray<eT>&
 podarray<eT>::operator=(const podarray& x)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/running_stat_vec_bones.hpp
+++ b/include/armadillo_bits/running_stat_vec_bones.hpp
@@ -60,7 +60,7 @@ class running_stat_vec
   
   inline running_stat_vec(const running_stat_vec& in_rsv);
   
-  inline running_stat_vec& operator=(const running_stat_vec& in_rsv);
+  inline const running_stat_vec& operator=(const running_stat_vec& in_rsv);
   
   template<typename T1> arma_hot inline void operator() (const Base<              T, T1>& X);
   template<typename T1> arma_hot inline void operator() (const Base<std::complex<T>, T1>& X);

--- a/include/armadillo_bits/running_stat_vec_meat.hpp
+++ b/include/armadillo_bits/running_stat_vec_meat.hpp
@@ -58,7 +58,7 @@ running_stat_vec<obj_type>::running_stat_vec(const running_stat_vec<obj_type>& i
 
 template<typename obj_type>
 inline
-running_stat_vec<obj_type>&
+const running_stat_vec<obj_type>&
 running_stat_vec<obj_type>::operator=(const running_stat_vec<obj_type>& in_rsv)
   {
   arma_extra_debug_sigprint();


### PR DESCRIPTION
Reverts conradsnicta/armadillo-code#7
As this is a large change, it's now in the new 7.900.x branch.
The 7.800.x branch is for bug fixes only.
