### PR TITLE
Use GNUInstallDirs to allow changing target directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 project(armadillo CXX C)
 include(CheckIncludeFileCXX)
 include(CheckLibraryExists)
+# Adhere to GNU filesystem layout conventions
+include(GNUInstallDirs)
 
 ## Set ARMA_USE_WRAPPER to false if you're getting linking errors when compiling your programs,
 ## or if you prefer to directly link with BLAS and/or LAPACK.
@@ -66,8 +68,6 @@ else()
   option(BUILD_SHARED_LIBS "build shared library" ON)
 endif()
 
-option(DETECT_PKG_CONFIG "Detect pkg-config and install pkg-config data, if found" ON)
-
 option(DETECT_HDF5 "Detect HDF5 and include HDF5 support, if found" OFF)
 
 
@@ -92,7 +92,6 @@ message(STATUS "CMAKE_CXX_COMPILER_ID      = ${CMAKE_CXX_COMPILER_ID}"     )
 message(STATUS "CMAKE_CXX_COMPILER_VERSION = ${CMAKE_CXX_COMPILER_VERSION}")
 message(STATUS "CMAKE_COMPILER_IS_GNUCXX   = ${CMAKE_COMPILER_IS_GNUCXX}"  )
 message(STATUS "BUILD_SHARED_LIBS          = ${BUILD_SHARED_LIBS}"         )
-message(STATUS "DETECT_PKG_CONFIG          = ${DETECT_PKG_CONFIG}"         )
 message(STATUS "DETECT_HDF5                = ${DETECT_HDF5}"               )
 
 
@@ -232,9 +231,7 @@ else()
 endif()
 
 
-if(DETECT_PKG_CONFIG)
-  find_package(PkgConfig)
-endif()
+find_package(PkgConfig)
 
 
 # set(DETECT_HDF5 true)
@@ -379,59 +376,16 @@ if(NOT APPLE)
   endif()
 endif()
 
-# Allow for the "lib" directory to be specified on the command line
-if(NOT INSTALL_LIB_DIR)
-  set(INSTALL_LIB_DIR "lib")
-  if(UNIX AND NOT APPLE)   # I don't know how Mac OS handles 64 bit systems
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      message(STATUS "*** Detected 64 bit system")
-      # use "lib64" only on systems that have it (eg. Fedora, Red Hat).
-      # if installing in /usr/local/, the use of lib64 might be unreliable on systems which have /usr/local/lib64 but don't use it
-      if(IS_DIRECTORY "${CMAKE_INSTALL_PREFIX}/lib64")
-        unset(INSTALL_LIB_DIR)
-        set(INSTALL_LIB_DIR "lib64")
-        message(STATUS "*** ${CMAKE_INSTALL_PREFIX}/lib64/ exists, so destination directory for the run-time library changed to ${CMAKE_INSTALL_PREFIX}/lib64/")
-        message(STATUS "*** Your system and/or compiler must search ${CMAKE_INSTALL_PREFIX}/lib64/ during linking")
-      endif()
-    endif()
-  endif()
-endif()
-
-# Allow for the "include" directory to be specified on the command line
-
-if(NOT INSTALL_INCLUDE_DIR)
-  set(INSTALL_INCLUDE_DIR "include")
-endif()
-
-# We use data dir to store files shared with other programs 
-# like the ArmadilloConfig.cmake file.
-if(NOT INSTALL_DATA_DIR)
-  set(INSTALL_DATA_DIR "share")
-endif()
-
-# executables destination
-if(NOT INSTALL_BIN_DIR)
-  set(INSTALL_BIN_DIR "bin")
-endif()
-
-# Make relative paths absolute so we can write them in Config.cmake files
-foreach(p LIB INCLUDE DATA BIN)
-  set(var INSTALL_${p}_DIR)
-  if(NOT IS_ABSOLUTE "${${var}}")
-    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
-  endif()
-endforeach()
-
-message(STATUS "CMAKE_INSTALL_PREFIX = ${CMAKE_INSTALL_PREFIX}")
-message(STATUS "INSTALL_LIB_DIR      = ${INSTALL_LIB_DIR}"     )
-message(STATUS "INSTALL_INCLUDE_DIR  = ${INSTALL_INCLUDE_DIR}" )
-message(STATUS "INSTALL_DATA_DIR     = ${INSTALL_DATA_DIR}"    )
-message(STATUS "INSTALL_BIN_DIR      = ${INSTALL_BIN_DIR}"    )
+message(STATUS "CMAKE_INSTALL_PREFIX     = ${CMAKE_INSTALL_PREFIX}"    )
+message(STATUS "CMAKE_INSTALL_LIBDIR     = ${CMAKE_INSTALL_LIBDIR}"    )
+message(STATUS "CMAKE_INSTALL_INCLUDEDIR = ${CMAKE_INSTALL_INCLUDEDIR}")
+message(STATUS "CMAKE_INSTALL_DATADIR    = ${CMAKE_INSTALL_DATADIR}"   )
+message(STATUS "CMAKE_INSTALL_BINDIR     = ${CMAKE_INSTALL_BINDIR}"    )
 
 
 # Note that the trailing / character in "include/" is critical
 
-install(DIRECTORY ${PROJECT_BINARY_DIR}/tmp/include/ DESTINATION ${INSTALL_INCLUDE_DIR}
+install(DIRECTORY ${PROJECT_BINARY_DIR}/tmp/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 PATTERN ".svn" EXCLUDE
 PATTERN "*.cmake" EXCLUDE
 PATTERN "*~" EXCLUDE
@@ -439,9 +393,9 @@ PATTERN "*orig" EXCLUDE
 )
 
 install(TARGETS armadillo EXPORT ArmadilloLibraryDepends
-  ARCHIVE DESTINATION ${INSTALL_LIB_DIR}
-  LIBRARY DESTINATION ${INSTALL_LIB_DIR}
-  RUNTIME DESTINATION ${INSTALL_BIN_DIR})
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
   
 # Export the package for use from the build-tree
 # (this registers the build-tree with a global CMake-registry)
@@ -465,16 +419,16 @@ configure_file(${PROJECT_SOURCE_DIR}/cmake_aux/InstallFiles/ArmadilloConfigVersi
 
 # Install the export set for use with the install-tree
 install(EXPORT ArmadilloLibraryDepends DESTINATION
-  "${INSTALL_DATA_DIR}/Armadillo/CMake"
+  "${CMAKE_INSTALL_DATADIR}/Armadillo/CMake"
   COMPONENT dev)
 
 
 ## GLOBAL INSTALL FILES
 # Create ArmadilloConfig.cmake file for the use from the install tree
 # and install it
-set(ARMADILLO_INCLUDE_DIRS "${INSTALL_INCLUDE_DIR}")
-set(ARMADILLO_LIB_DIR      "${INSTALL_LIB_DIR}")
-set(ARMADILLO_CMAKE_DIR    "${INSTALL_DATA_DIR}/Armadillo/CMake")
+set(ARMADILLO_INCLUDE_DIRS "${CMAKE_INSTALL_INCLUDEDIR}")
+set(ARMADILLO_LIB_DIR      "${CMAKE_INSTALL_LIBDIR}")
+set(ARMADILLO_CMAKE_DIR    "${CMAKE_INSTALL_DATADIR}/Armadillo/CMake")
 
 
 message(STATUS "Generating '${PROJECT_BINARY_DIR}/InstallFiles/ArmadilloConfig.cmake'")
@@ -492,17 +446,7 @@ install(FILES
   "${PROJECT_BINARY_DIR}/InstallFiles/ArmadilloConfigVersion.cmake"
   DESTINATION "${ARMADILLO_CMAKE_DIR}" COMPONENT dev)
 
-
-if(PKG_CONFIG_FOUND)
-  message(STATUS "Copying ${PROJECT_SOURCE_DIR}/misc/ to ${PROJECT_BINARY_DIR}/tmp/misc/")
-  file(COPY ${PROJECT_SOURCE_DIR}/misc/ DESTINATION ${PROJECT_BINARY_DIR}/tmp/misc/)
-
-  message(STATUS "Generating '${PROJECT_BINARY_DIR}/tmp/misc/armadillo.pc'")
-  configure_file(${PROJECT_BINARY_DIR}/tmp/misc/armadillo.pc.in "${PROJECT_BINARY_DIR}/tmp/misc/armadillo.pc" @ONLY)
+message(STATUS "Generating '${PROJECT_BINARY_DIR}/armadillo.pc'")
+configure_file(misc/armadillo.pc.in armadillo.pc @ONLY)
   
-  if(NOT PKG_CONFIG_DIR)
-    set(PKG_CONFIG_DIR "${INSTALL_LIB_DIR}/pkgconfig")
-  endif()
-  
-  install(FILES "${PROJECT_BINARY_DIR}/tmp/misc/armadillo.pc" DESTINATION ${PKG_CONFIG_DIR})
-endif()
+install(FILES ${PROJECT_BINARY_DIR}/armadillo.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,42 @@ cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 project(armadillo CXX C)
 include(CheckIncludeFileCXX)
 include(CheckLibraryExists)
+
+# As Red Hat Enterprise Linux (and related systems such as Fedora)
+# does not search /usr/local/lib by default, we need to place the
+# library in either /usr/lib or /usr/lib64
+
+if(NOT APPLE)
+  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    message(STATUS "*** CMAKE_INSTALL_PREFIX was initalised by cmake to the default value of ${CMAKE_INSTALL_PREFIX}")
+    message(STATUS "*** CMAKE_INSTALL_PREFIX changed to /usr")
+    set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "Standard install prefix" FORCE)
+  endif()
+endif()
+
 # Adhere to GNU filesystem layout conventions
 include(GNUInstallDirs)
+
+# deprecated options
+set(INSTALL_LIB_DIR "" CACHE STRING "Deprecated old-style libdir path (retained for backwards compatibility, use CMAKE_INSTALL_LIBDIR instead)")
+set(INSTALL_INCLUDE_DIR "" CACHE STRING "Deprecated old-style includedir path (retained for backwards compatibility, use CMAKE_INSTALL_INCLUDEDIR instead)")
+set(INSTALL_DATA_DIR "" CACHE STRING "Deprecated old-style datadir path (retained for backwards compatibility, use CMAKE_INSTALL_DATADIR instead)")
+set(INSTALL_BIN_DIR "" CACHE STRING "Deprecated old-style bindir path (retained for backwards compatibility, use CMAKE_INSTALL_BINDIR instead)")
+
+if(INSTALL_LIB_DIR)
+  set(CMAKE_INSTALL_LIBDIR "${INSTALL_LIB_DIR}")
+  GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_LIBDIR CMAKE_INSTALL_LIBDIR)
+endif()
+if(INSTALL_INCLUDE_DIR)
+  set(CMAKE_INSTALL_INCLUDEDIR "${INSTALL_INCLUDE_DIR}")
+  GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_INCLUDEDIR CMAKE_INSTALL_INCLUDEDIR)
+endif()
+if(INSTALL_DATA_DIR)
+  set(CMAKE_INSTALL_DATADIR "${INSTALL_DATA_DIR}")
+endif()
+if(INSTALL_BIN_DIR)
+  set(CMAKE_INSTALL_BINDIR "${INSTALL_BIN_DIR}")
+endif()
 
 ## Set ARMA_USE_WRAPPER to false if you're getting linking errors when compiling your programs,
 ## or if you prefer to directly link with BLAS and/or LAPACK.
@@ -360,21 +394,6 @@ set_target_properties(armadillo PROPERTIES VERSION ${ARMA_VERSION_MAJOR}.${ARMA_
 
 ################################################################################
 # INSTALL CONFIGURATION
-
-
-# As Red Hat Enterprise Linux (and related systems such as Fedora)
-# does not search /usr/local/lib by default, we need to place the
-# library in either /usr/lib or /usr/lib64
-
-if(NOT APPLE)
-  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    message(STATUS "*** CMAKE_INSTALL_PREFIX was initalised by cmake to the default value of ${CMAKE_INSTALL_PREFIX}")
-    message(STATUS "*** CMAKE_INSTALL_PREFIX changed to /usr")
-    unset(CMAKE_INSTALL_PREFIX)
-    set(CMAKE_INSTALL_PREFIX "/usr")
-    #set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "install prefix" FORCE)
-  endif()
-endif()
 
 message(STATUS "CMAKE_INSTALL_PREFIX     = ${CMAKE_INSTALL_PREFIX}"    )
 message(STATUS "CMAKE_INSTALL_LIBDIR     = ${CMAKE_INSTALL_LIBDIR}"    )

--- a/README.txt
+++ b/README.txt
@@ -26,10 +26,11 @@ Contents
 11: Support for C++11/C++14 Features
 
 12: API Documentation
-13: Bug Reports and Frequently Asked Questions
+13: API Stability and Versioning
+14: Bug Reports and Frequently Asked Questions
 
-14: MEX Interface to Octave/Matlab
-15: Related Software
+15: MEX Interface to Octave/Matlab
+16: Related Software
 
 
 
@@ -391,7 +392,43 @@ which can be viewed with a web browser.
 
 
 
-13: Bug Reports and Frequently Asked Questions
+13: API Stability and Versioning
+================================
+
+Each release of Armadillo has its public API (functions, classes, constants)
+described in the accompanying API documentation (docs.html) specific
+to that release.
+
+Each release of Armadillo has its full version specified as A.B.C,
+where A is a major version number, B is a minor version number,
+and C is a patch level (indicating bug fixes).
+
+Within a major version (eg. 7), each minor version has a public API that
+strongly strives to be backwards compatible (at the source level) with the
+public API of preceding minor versions. For example, user code written for
+version 7.100 should work with version 7.200, 7.300, 7.400, etc. However,
+as later minor versions may have more features (API extensions) than
+preceding minor versions, user code specifically written for version 7.400
+may not work with 7.300.
+
+An increase in the patch level, while the major and minor versions are retained,
+indicates modifications to the code and/or documentation which aim to fix bugs
+without altering the public API.
+
+We don't like changes to existing public API and strongly prefer not to break
+any user software. However, to allow evolution, we reserve the right to
+alter the public API in future major versions of Armadillo while remaining
+backwards compatible in as many cases as possible (eg. major version 8 may
+have slightly different public API than major version 7).
+
+CAVEAT: any function, class, constant or other code _not_ explicitly described
+in the public API documentation is considered as part of the underlying internal
+implementation details, and may change or be removed without notice.
+(In other words, don't use internal functionality).
+
+
+
+14: Bug Reports and Frequently Asked Questions
 ==============================================
 
 Armadillo has gone through extensive testing and
@@ -414,7 +451,7 @@ answers to frequently asked questions are at:
 
 
 
-14: MEX Interface to Octave/Matlab
+15: MEX Interface to Octave/Matlab
 ==================================
 
 The "mex_interface" folder contains examples of how to interface
@@ -422,7 +459,7 @@ Octave/Matlab with C++ code that uses Armadillo matrices.
 
 
 
-15: Related Software
+16: Related Software
 ====================
 
 * MLPACK: C++ library for machine learning and pattern recognition, built on top of Armadillo.

--- a/docs.html
+++ b/docs.html
@@ -9190,7 +9190,7 @@ For matrix <i>X</i>, generate a copy of the matrix with the elements shifted by 
 </li>
 <br>
 <li>
-<i>N</i> can be positive of negative
+<i>N</i> can be positive or negative
 </li>
 <br>
 <li>

--- a/docs.html
+++ b/docs.html
@@ -16128,7 +16128,6 @@ However, as later minor versions may have more features (API extensions) than pr
 <br>
 <li>
 An increase in the patch level, while the major and minor versions are retained, indicates modifications to the code and/or documentation which aim to fix bugs without altering the public API.
-In a rare instance the public API may need to be tweaked if a bug fix absolutely requires it.
 </li>
 <br>
 <li>

--- a/docs.html
+++ b/docs.html
@@ -16138,7 +16138,7 @@ However, to allow evolution, we reserve the right to alter the public API in fut
 <br>
 <li>
 <b>Caveat:</b> any function, class, constant or other code <u>not</u> explicitly described in the public API documentation is considered as part of the underlying internal implementation details,
-and may change or be removed between consecutive minor versions or patch levels.
+and may change or be removed without notice.
 (In other words, don't use internal functionality).
 </li>
 </ul>

--- a/docs.html
+++ b/docs.html
@@ -16129,7 +16129,7 @@ Each release of Armadillo has its full version specified as <i>A.B.C</i>, where 
 </li>
 <br>
 <li>
-Within a major version (eg. 7), minor versions have public API that strongly strives to be <b>backwards compatible</b> (at the source level) with the public API of preceding minor versions.
+Within a major version (eg. 7), each minor version has a public API that strongly strives to be <b>backwards compatible</b> (at the source level) with the public API of preceding minor versions.
 For example, user code written for version 7.100 should work with version 7.200, 7.300, 7.400, etc.
 However, as later minor versions may have more features (API extensions) than preceding minor versions, user code specifically written for version 7.400 may not work with 7.300.
 </li>

--- a/docs.html
+++ b/docs.html
@@ -4434,6 +4434,14 @@ Member functions:
 </li>
 <br>
 <li>
+Iterators for dense matrices and vectors traverse over all elements
+</li>
+<br>
+<li>
+Iterators for sparse matrices traverse over non-zero elements
+</li>
+<br>
+<li>
 Iterator types:
 <br>
 <br>

--- a/docs.html
+++ b/docs.html
@@ -16138,7 +16138,7 @@ However, to allow evolution, we reserve the right to alter the public API in fut
 </li>
 <br>
 <li>
-<b>Caveat:</b> any function, class, constant or other code <i>not</i> explicitly described in the public API documentation is considered as part of the underlying internal implementation details,
+<b>Caveat:</b> any function, class, constant or other code <u>not</u> explicitly described in the public API documentation is considered as part of the underlying internal implementation details,
 and may change or be removed between consecutive minor versions or patch levels.
 (In other words, don't use internal functionality).
 </li>

--- a/include/armadillo
+++ b/include/armadillo
@@ -14,45 +14,6 @@
 // ------------------------------------------------------------------------
 
 
-
-// API Stability and Versioning
-// ----------------------------
-// 
-// * Each release of Armadillo has its public API (functions, classes, constants)
-//   described in the accompanying API documentation (docs.html) specific
-//   to that release.
-// 
-// * Each release of Armadillo has its full version specified as A.B.C,
-//   where A is a major version number, B is a minor version number,
-//   and C is a patch level (indicating bug fixes).
-// 
-// * Within a major version (eg. 7), each minor version has a public API that
-//   strongly strives to be backwards compatible (at the source level) with the
-//   public API of preceding minor versions. For example, user code written for
-//   version 7.100 should work with version 7.200, 7.300, 7.400, etc. However,
-//   as later minor versions may have more features (API extensions) than
-//   preceding minor versions, user code specifically written for version 7.400
-//   may not work with 7.300.
-// 
-// * An increase in the patch level, while the major and minor versions are retained,
-//   indicates modifications to the code and/or documentation which aim to fix bugs
-//   without altering the public API.
-// 
-// * We don't like changes to existing public API and strongly prefer not to break
-//   any user software. However, to allow evolution, we reserve the right to
-//   alter the public API in future major versions of Armadillo while remaining
-//   backwards compatible in as many cases as possible (eg. major version 8 may
-//   have slightly different public API than major version 7).
-// 
-// * CAVEAT: any function, class, constant or other code _not_ explicitly described
-//   in the public API documentation is considered as part of the underlying internal
-//   implementation details, and may change or be removed without notice.
-//   (In other words, don't use internal functionality).
-// 
-// * The above statements do not modify the License.
-
-
-
 #ifndef ARMA_INCLUDES
 #define ARMA_INCLUDES
 

--- a/include/armadillo
+++ b/include/armadillo
@@ -46,8 +46,8 @@
 // 
 // * CAVEAT: any function, class, constant or other code _not_ explicitly described
 //   in the public API documentation is considered as part of the underlying internal
-//   implementation details, and may change or be removed between consecutive minor
-//   versions or patch levels. (In other words, don't use internal functionality).
+//   implementation details, and may change or be removed without notice.
+//   (In other words, don't use internal functionality).
 // 
 // * The above statements do not modify the License.
 

--- a/include/armadillo
+++ b/include/armadillo
@@ -36,8 +36,7 @@
 // 
 // * An increase in the patch level, while the major and minor versions are retained,
 //   indicates modifications to the code and/or documentation which aim to fix bugs
-//   without altering the public API. In a rare instance the public API may need
-//   to be tweaked if a bug fix absolutely requires it.
+//   without altering the public API.
 // 
 // * We don't like changes to existing public API and strongly prefer not to break
 //   any user software. However, to allow evolution, we reserve the right to

--- a/include/armadillo
+++ b/include/armadillo
@@ -26,7 +26,7 @@
 //   where A is a major version number, B is a minor version number,
 //   and C is a patch level (indicating bug fixes).
 // 
-// * Within a major version (eg. 7), minor versions have public API that
+// * Within a major version (eg. 7), each minor version has a public API that
 //   strongly strives to be backwards compatible (at the source level) with the
 //   public API of preceding minor versions. For example, user code written for
 //   version 7.100 should work with version 7.200, 7.300, 7.400, etc. However,

--- a/include/armadillo_bits/Col_bones.hpp
+++ b/include/armadillo_bits/Col_bones.hpp
@@ -40,30 +40,30 @@ class Col : public Mat<eT>
   template<typename fill_type> inline Col(const uword in_rows, const uword in_cols, const fill::fill_class<fill_type>& f);
   template<typename fill_type> inline Col(const SizeMat& s,                         const fill::fill_class<fill_type>& f);
   
-  inline                  Col(const char*        text);
-  inline const Col& operator=(const char*        text);
+  inline            Col(const char*        text);
+  inline Col& operator=(const char*        text);
   
-  inline                  Col(const std::string& text);
-  inline const Col& operator=(const std::string& text);
+  inline            Col(const std::string& text);
+  inline Col& operator=(const std::string& text);
   
-  inline                  Col(const std::vector<eT>& x);
-  inline const Col& operator=(const std::vector<eT>& x);
+  inline            Col(const std::vector<eT>& x);
+  inline Col& operator=(const std::vector<eT>& x);
   
   #if defined(ARMA_USE_CXX11)
-  inline                  Col(const std::initializer_list<eT>& list);
-  inline const Col& operator=(const std::initializer_list<eT>& list);
+  inline            Col(const std::initializer_list<eT>& list);
+  inline Col& operator=(const std::initializer_list<eT>& list);
   
-  inline                  Col(Col&& m);
-  inline const Col& operator=(Col&& m);
+  inline            Col(Col&& m);
+  inline Col& operator=(Col&& m);
   #endif
   
   inline explicit Col(const SpCol<eT>& X);
   
-  inline const Col& operator=(const eT val);
-  inline const Col& operator=(const Col& m);
+  inline Col& operator=(const eT val);
+  inline Col& operator=(const Col& m);
   
-  template<typename T1> inline                   Col(const Base<eT,T1>& X);
-  template<typename T1> inline const Col&  operator=(const Base<eT,T1>& X);
+  template<typename T1> inline             Col(const Base<eT,T1>& X);
+  template<typename T1> inline Col&  operator=(const Base<eT,T1>& X);
   
   inline Col(      eT* aux_mem, const uword aux_length, const bool copy_aux_mem = true, const bool strict = false);
   inline Col(const eT* aux_mem, const uword aux_length);
@@ -71,11 +71,11 @@ class Col : public Mat<eT>
   template<typename T1, typename T2>
   inline explicit Col(const Base<pod_type,T1>& A, const Base<pod_type,T2>& B);
   
-  template<typename T1> inline                  Col(const BaseCube<eT,T1>& X);
-  template<typename T1> inline const Col& operator=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline            Col(const BaseCube<eT,T1>& X);
+  template<typename T1> inline Col& operator=(const BaseCube<eT,T1>& X);
   
-  inline                  Col(const subview_cube<eT>& X);
-  inline const Col& operator=(const subview_cube<eT>& X);
+  inline            Col(const subview_cube<eT>& X);
+  inline Col& operator=(const subview_cube<eT>& X);
   
   inline mat_injector<Col> operator<<(const eT val);
   
@@ -201,25 +201,25 @@ class Col<eT>::fixed : public Col<eT>
   inline fixed(const char*        text);
   inline fixed(const std::string& text);
   
-  template<typename T1> inline const Col& operator=(const Base<eT,T1>& A);
+  template<typename T1> inline Col& operator=(const Base<eT,T1>& A);
   
-  inline const Col& operator=(const eT val);
-  inline const Col& operator=(const char*        text);
-  inline const Col& operator=(const std::string& text);
-  inline const Col& operator=(const subview_cube<eT>& X);
+  inline Col& operator=(const eT val);
+  inline Col& operator=(const char*        text);
+  inline Col& operator=(const std::string& text);
+  inline Col& operator=(const subview_cube<eT>& X);
   
   using Col<eT>::operator();
   
   #if defined(ARMA_USE_CXX11)
-    inline                fixed(const std::initializer_list<eT>& list);
-    inline const Col& operator=(const std::initializer_list<eT>& list);
+    inline          fixed(const std::initializer_list<eT>& list);
+    inline Col& operator=(const std::initializer_list<eT>& list);
   #endif
   
-  arma_inline const Col& operator=(const fixed<fixed_n_elem>& X);
+  arma_inline Col& operator=(const fixed<fixed_n_elem>& X);
   
   #if defined(ARMA_GOOD_COMPILER)
-    template<typename T1,              typename   eop_type> inline const Col& operator=(const   eOp<T1,       eop_type>& X);
-    template<typename T1, typename T2, typename eglue_type> inline const Col& operator=(const eGlue<T1, T2, eglue_type>& X);
+    template<typename T1,              typename   eop_type> inline Col& operator=(const   eOp<T1,       eop_type>& X);
+    template<typename T1, typename T2, typename eglue_type> inline Col& operator=(const eGlue<T1, T2, eglue_type>& X);
   #endif
   
   arma_inline const Op< Col_fixed_type, op_htrans >  t() const;

--- a/include/armadillo_bits/Col_meat.hpp
+++ b/include/armadillo_bits/Col_meat.hpp
@@ -140,7 +140,7 @@ Col<eT>::Col(const char* text)
 //! construct a column vector from specified text
 template<typename eT>
 inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -179,7 +179,7 @@ Col<eT>::Col(const std::string& text)
 //! construct a column vector from specified text
 template<typename eT>
 inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -216,7 +216,7 @@ Col<eT>::Col(const std::vector<eT>& x)
 //! create a column vector from std::vector
 template<typename eT>
 inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::operator=(const std::vector<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -254,7 +254,7 @@ Col<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  const Col<eT>&
+  Col<eT>&
   Col<eT>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -314,7 +314,7 @@ Col<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  const Col<eT>&
+  Col<eT>&
   Col<eT>::operator=(Col<eT>&& X)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   X = %x") % this % &X);
@@ -355,7 +355,7 @@ Col<eT>::Col(const SpCol<eT>& X)
 
 template<typename eT>
 inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -369,7 +369,7 @@ Col<eT>::operator=(const eT val)
 
 template<typename eT>
 inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::operator=(const Col<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -397,7 +397,7 @@ Col<eT>::Col(const Base<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::operator=(const Base<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -470,7 +470,7 @@ Col<eT>::Col(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::operator=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -497,7 +497,7 @@ Col<eT>::Col(const subview_cube<eT>& X)
 
 template<typename eT>
 inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1239,7 +1239,7 @@ Col<eT>::fixed<fixed_n_elem>::fixed(const std::string& text)
 template<typename eT>
 template<uword fixed_n_elem>
 template<typename T1>
-const Col<eT>&
+Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const Base<eT,T1>& A)
   {
   arma_extra_debug_sigprint();
@@ -1253,7 +1253,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const Base<eT,T1>& A)
 
 template<typename eT>
 template<uword fixed_n_elem>
-const Col<eT>&
+Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -1267,7 +1267,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const eT val)
 
 template<typename eT>
 template<uword fixed_n_elem>
-const Col<eT>&
+Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -1283,7 +1283,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const char* text)
 
 template<typename eT>
 template<uword fixed_n_elem>
-const Col<eT>&
+Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -1299,7 +1299,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
 
 template<typename eT>
 template<uword fixed_n_elem>
-const Col<eT>&
+Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1329,7 +1329,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
   template<typename eT>
   template<uword fixed_n_elem>
   inline
-  const Col<eT>&
+  Col<eT>&
   Col<eT>::fixed<fixed_n_elem>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -1354,7 +1354,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
 template<typename eT>
 template<uword fixed_n_elem>
 arma_inline
-const Col<eT>&
+Col<eT>&
 Col<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   {
   arma_extra_debug_sigprint();
@@ -1378,7 +1378,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   template<uword fixed_n_elem>
   template<typename T1, typename eop_type>
   inline
-  const Col<eT>&
+  Col<eT>&
   Col<eT>::fixed<fixed_n_elem>::operator=(const eOp<T1, eop_type>& X)
     {
     arma_extra_debug_sigprint();
@@ -1411,7 +1411,7 @@ Col<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   template<uword fixed_n_elem>
   template<typename T1, typename T2, typename eglue_type>
   inline
-  const Col<eT>&
+  Col<eT>&
   Col<eT>::fixed<fixed_n_elem>::operator=(const eGlue<T1, T2, eglue_type>& X)
     {
     arma_extra_debug_sigprint();

--- a/include/armadillo_bits/Cube_bones.hpp
+++ b/include/armadillo_bits/Cube_bones.hpp
@@ -72,35 +72,35 @@ class Cube : public BaseCube< eT, Cube<eT> >
   template<typename fill_type> inline Cube(const SizeCube& s,                                               const fill::fill_class<fill_type>& f);
   
   #if defined(ARMA_USE_CXX11)
-  inline                  Cube(Cube&& m);
-  inline const Cube& operator=(Cube&& m);
+  inline            Cube(Cube&& m);
+  inline Cube& operator=(Cube&& m);
   #endif
   
   inline Cube(      eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols, const uword aux_n_slices, const bool copy_aux_mem = true, const bool strict = false, const bool prealloc_mat = false);
   inline Cube(const eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols, const uword aux_n_slices);
   
-  arma_inline const Cube&  operator=(const eT val);
-  arma_inline const Cube& operator+=(const eT val);
-  arma_inline const Cube& operator-=(const eT val);
-  arma_inline const Cube& operator*=(const eT val);
-  arma_inline const Cube& operator/=(const eT val);
+  arma_inline Cube&  operator=(const eT val);
+  arma_inline Cube& operator+=(const eT val);
+  arma_inline Cube& operator-=(const eT val);
+  arma_inline Cube& operator*=(const eT val);
+  arma_inline Cube& operator/=(const eT val);
   
-  inline                   Cube(const Cube& m);
-  inline const Cube&  operator=(const Cube& m);
-  inline const Cube& operator+=(const Cube& m);
-  inline const Cube& operator-=(const Cube& m);
-  inline const Cube& operator%=(const Cube& m);
-  inline const Cube& operator/=(const Cube& m);
+  inline             Cube(const Cube& m);
+  inline Cube&  operator=(const Cube& m);
+  inline Cube& operator+=(const Cube& m);
+  inline Cube& operator-=(const Cube& m);
+  inline Cube& operator%=(const Cube& m);
+  inline Cube& operator/=(const Cube& m);
   
   template<typename T1, typename T2>
   inline explicit Cube(const BaseCube<pod_type,T1>& A, const BaseCube<pod_type,T2>& B);
   
-  inline                   Cube(const subview_cube<eT>& X);
-  inline const Cube&  operator=(const subview_cube<eT>& X);
-  inline const Cube& operator+=(const subview_cube<eT>& X);
-  inline const Cube& operator-=(const subview_cube<eT>& X);
-  inline const Cube& operator%=(const subview_cube<eT>& X);
-  inline const Cube& operator/=(const subview_cube<eT>& X);
+  inline             Cube(const subview_cube<eT>& X);
+  inline Cube&  operator=(const subview_cube<eT>& X);
+  inline Cube& operator+=(const subview_cube<eT>& X);
+  inline Cube& operator-=(const subview_cube<eT>& X);
+  inline Cube& operator%=(const subview_cube<eT>& X);
+  inline Cube& operator/=(const subview_cube<eT>& X);
   
   inline       Mat<eT>& slice(const uword in_slice);
   inline const Mat<eT>& slice(const uword in_slice) const;
@@ -170,54 +170,54 @@ class Cube : public BaseCube< eT, Cube<eT> >
   inline void insert_slices(const uword row_num, const BaseCube<eT,T1>& X);
   
   
-  template<typename gen_type> inline                   Cube(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline const Cube&  operator=(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline const Cube& operator+=(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline const Cube& operator-=(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline const Cube& operator%=(const GenCube<eT, gen_type>& X);
-  template<typename gen_type> inline const Cube& operator/=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline             Cube(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline Cube&  operator=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline Cube& operator+=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline Cube& operator-=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline Cube& operator%=(const GenCube<eT, gen_type>& X);
+  template<typename gen_type> inline Cube& operator/=(const GenCube<eT, gen_type>& X);
   
-  template<typename T1, typename op_type> inline                   Cube(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube&  operator=(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube& operator+=(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube& operator-=(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube& operator%=(const OpCube<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube& operator/=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline             Cube(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube&  operator=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube& operator+=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube& operator-=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube& operator%=(const OpCube<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube& operator/=(const OpCube<T1, op_type>& X);
   
-  template<typename T1, typename eop_type> inline                   Cube(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Cube&  operator=(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Cube& operator+=(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Cube& operator-=(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Cube& operator%=(const eOpCube<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Cube& operator/=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline             Cube(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Cube&  operator=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Cube& operator+=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Cube& operator-=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Cube& operator%=(const eOpCube<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Cube& operator/=(const eOpCube<T1, eop_type>& X);
   
-  template<typename T1, typename op_type> inline                   Cube(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube&  operator=(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube& operator+=(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube& operator-=(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube& operator%=(const mtOpCube<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Cube& operator/=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline             Cube(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube&  operator=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube& operator+=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube& operator-=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube& operator%=(const mtOpCube<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Cube& operator/=(const mtOpCube<eT, T1, op_type>& X);
   
-  template<typename T1, typename T2, typename glue_type> inline                   Cube(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube&  operator=(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube& operator+=(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube& operator-=(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube& operator%=(const GlueCube<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube& operator/=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline             Cube(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube&  operator=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube& operator+=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube& operator-=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube& operator%=(const GlueCube<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube& operator/=(const GlueCube<T1, T2, glue_type>& X);
   
-  template<typename T1, typename T2, typename eglue_type> inline                   Cube(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Cube&  operator=(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Cube& operator+=(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Cube& operator-=(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Cube& operator%=(const eGlueCube<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Cube& operator/=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline             Cube(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Cube&  operator=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Cube& operator+=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Cube& operator-=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Cube& operator%=(const eGlueCube<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Cube& operator/=(const eGlueCube<T1, T2, eglue_type>& X);
   
-  template<typename T1, typename T2, typename glue_type> inline                   Cube(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube&  operator=(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube& operator+=(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube& operator-=(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube& operator%=(const mtGlueCube<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Cube& operator/=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline             Cube(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube&  operator=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube& operator+=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube& operator-=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube& operator%=(const mtGlueCube<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Cube& operator/=(const mtGlueCube<eT, T1, T2, glue_type>& X);
   
   
   arma_inline arma_warn_unused const eT& at_alt     (const uword i) const;
@@ -426,7 +426,7 @@ class Cube<eT>::fixed : public Cube<eT>
   using Cube<eT>::operator=;
   using Cube<eT>::operator();
   
-  inline const Cube& operator=(const fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>& X);
+  inline Cube& operator=(const fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>& X);
   
   
   arma_inline arma_warn_unused       eT& operator[] (const uword i);

--- a/include/armadillo_bits/Cube_meat.hpp
+++ b/include/armadillo_bits/Cube_meat.hpp
@@ -178,7 +178,7 @@ Cube<eT>::Cube(const SizeCube& s, const fill::fill_class<fill_type>&)
   
   template<typename eT>
   inline
-  const Cube<eT>&
+  Cube<eT>&
   Cube<eT>::operator=(Cube<eT>&& in_cube)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   in_cube = %x") % this % &in_cube);
@@ -483,7 +483,7 @@ Cube<eT>::create_mat()
 //! NOTE: the size of the cube will be 1x1x1
 template<typename eT>
 arma_inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -498,7 +498,7 @@ Cube<eT>::operator=(const eT val)
 //! In-place addition of a scalar to all elements of the cube
 template<typename eT>
 arma_inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -513,7 +513,7 @@ Cube<eT>::operator+=(const eT val)
 //! In-place subtraction of a scalar from all elements of the cube
 template<typename eT>
 arma_inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -528,7 +528,7 @@ Cube<eT>::operator-=(const eT val)
 //! In-place multiplication of all elements of the cube with a scalar
 template<typename eT>
 arma_inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -543,7 +543,7 @@ Cube<eT>::operator*=(const eT val)
 //! In-place division of all elements of the cube with a scalar
 template<typename eT>
 arma_inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -581,7 +581,7 @@ Cube<eT>::Cube(const Cube<eT>& x)
 //! construct a cube from a given cube
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const Cube<eT>& x)
   {
   arma_extra_debug_sigprint(arma_str::format("this = %x   in_cube = %x") % this % &x);
@@ -657,7 +657,7 @@ Cube<eT>::Cube(const eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols
 //! in-place cube addition
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const Cube<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -674,7 +674,7 @@ Cube<eT>::operator+=(const Cube<eT>& m)
 //! in-place cube subtraction
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const Cube<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -691,7 +691,7 @@ Cube<eT>::operator-=(const Cube<eT>& m)
 //! in-place element-wise cube multiplication
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const Cube<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -708,7 +708,7 @@ Cube<eT>::operator%=(const Cube<eT>& m)
 //! in-place element-wise cube division
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const Cube<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -772,7 +772,7 @@ Cube<eT>::Cube(const subview_cube<eT>& X)
 //! construct a cube from a subview_cube instance (e.g. construct a cube from a delayed subcube operation)
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -800,7 +800,7 @@ Cube<eT>::operator=(const subview_cube<eT>& X)
 //! in-place cube addition (using a subcube on the right-hand-side)
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -815,7 +815,7 @@ Cube<eT>::operator+=(const subview_cube<eT>& X)
 //! in-place cube subtraction (using a subcube on the right-hand-side)
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -830,7 +830,7 @@ Cube<eT>::operator-=(const subview_cube<eT>& X)
 //! in-place element-wise cube mutiplication (using a subcube on the right-hand-side)
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -845,7 +845,7 @@ Cube<eT>::operator%=(const subview_cube<eT>& X)
 //! in-place element-wise cube division (using a subcube on the right-hand-side)
 template<typename eT>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1759,7 +1759,7 @@ Cube<eT>::Cube(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1776,7 +1776,7 @@ Cube<eT>::operator=(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1791,7 +1791,7 @@ Cube<eT>::operator+=(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1806,7 +1806,7 @@ Cube<eT>::operator-=(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1821,7 +1821,7 @@ Cube<eT>::operator%=(const GenCube<eT, gen_type>& X)
 template<typename eT>
 template<typename gen_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const GenCube<eT, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1860,7 +1860,7 @@ Cube<eT>::Cube(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1878,7 +1878,7 @@ Cube<eT>::operator=(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1896,7 +1896,7 @@ Cube<eT>::operator+=(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1914,7 +1914,7 @@ Cube<eT>::operator-=(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1932,7 +1932,7 @@ Cube<eT>::operator%=(const OpCube<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const OpCube<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1975,7 +1975,7 @@ Cube<eT>::Cube(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2006,7 +2006,7 @@ Cube<eT>::operator=(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2024,7 +2024,7 @@ Cube<eT>::operator+=(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2042,7 +2042,7 @@ Cube<eT>::operator-=(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2060,7 +2060,7 @@ Cube<eT>::operator%=(const eOpCube<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const eOpCube<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2099,7 +2099,7 @@ Cube<eT>::Cube(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2115,7 +2115,7 @@ Cube<eT>::operator=(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2131,7 +2131,7 @@ Cube<eT>::operator+=(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2147,7 +2147,7 @@ Cube<eT>::operator-=(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2163,7 +2163,7 @@ Cube<eT>::operator%=(const mtOpCube<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const mtOpCube<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2199,7 +2199,7 @@ Cube<eT>::Cube(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2217,7 +2217,7 @@ Cube<eT>::operator=(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2236,7 +2236,7 @@ Cube<eT>::operator+=(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2255,7 +2255,7 @@ Cube<eT>::operator-=(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2274,7 +2274,7 @@ Cube<eT>::operator%=(const GlueCube<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const GlueCube<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2319,7 +2319,7 @@ Cube<eT>::Cube(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2351,7 +2351,7 @@ Cube<eT>::operator=(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2370,7 +2370,7 @@ Cube<eT>::operator+=(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2389,7 +2389,7 @@ Cube<eT>::operator-=(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2408,7 +2408,7 @@ Cube<eT>::operator%=(const eGlueCube<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const eGlueCube<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2448,7 +2448,7 @@ Cube<eT>::Cube(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2464,7 +2464,7 @@ Cube<eT>::operator=(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator+=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2480,7 +2480,7 @@ Cube<eT>::operator+=(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator-=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2496,7 +2496,7 @@ Cube<eT>::operator-=(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator%=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -2512,7 +2512,7 @@ Cube<eT>::operator%=(const mtGlueCube<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::operator/=(const mtGlueCube<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4336,7 +4336,7 @@ Cube<eT>::fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>::fixed(const BaseCub
 template<typename eT>
 template<uword fixed_n_rows, uword fixed_n_cols, uword fixed_n_slices>
 inline
-const Cube<eT>&
+Cube<eT>&
 Cube<eT>::fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>::operator=(const fixed<fixed_n_rows, fixed_n_cols, fixed_n_slices>& X)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/Mat_bones.hpp
+++ b/include/armadillo_bits/Mat_bones.hpp
@@ -62,63 +62,63 @@ class Mat : public Base< eT, Mat<eT> >
   template<typename fill_type> inline Mat(const uword in_rows, const uword in_cols, const fill::fill_class<fill_type>& f);
   template<typename fill_type> inline Mat(const SizeMat& s,                         const fill::fill_class<fill_type>& f);
   
-  inline                  Mat(const char*        text);
-  inline const Mat& operator=(const char*        text);
+  inline            Mat(const char*        text);
+  inline Mat& operator=(const char*        text);
   
-  inline                  Mat(const std::string& text);
-  inline const Mat& operator=(const std::string& text);
+  inline            Mat(const std::string& text);
+  inline Mat& operator=(const std::string& text);
   
-  inline                  Mat(const std::vector<eT>& x);
-  inline const Mat& operator=(const std::vector<eT>& x);
+  inline            Mat(const std::vector<eT>& x);
+  inline Mat& operator=(const std::vector<eT>& x);
   
   #if defined(ARMA_USE_CXX11)
-  inline                  Mat(const std::initializer_list<eT>& list);
-  inline const Mat& operator=(const std::initializer_list<eT>& list);
+  inline            Mat(const std::initializer_list<eT>& list);
+  inline Mat& operator=(const std::initializer_list<eT>& list);
   
-  inline                  Mat(const std::initializer_list< std::initializer_list<eT> >& list);
-  inline const Mat& operator=(const std::initializer_list< std::initializer_list<eT> >& list);
+  inline            Mat(const std::initializer_list< std::initializer_list<eT> >& list);
+  inline Mat& operator=(const std::initializer_list< std::initializer_list<eT> >& list);
   
-  inline                  Mat(Mat&& m);
-  inline const Mat& operator=(Mat&& m);
+  inline            Mat(Mat&& m);
+  inline Mat& operator=(Mat&& m);
   #endif
   
   inline Mat(      eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols, const bool copy_aux_mem = true, const bool strict = false);
   inline Mat(const eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols);
   
-  arma_inline const Mat&  operator=(const eT val);
-  arma_inline const Mat& operator+=(const eT val);
-  arma_inline const Mat& operator-=(const eT val);
-  arma_inline const Mat& operator*=(const eT val);
-  arma_inline const Mat& operator/=(const eT val);
+  arma_inline Mat&  operator=(const eT val);
+  arma_inline Mat& operator+=(const eT val);
+  arma_inline Mat& operator-=(const eT val);
+  arma_inline Mat& operator*=(const eT val);
+  arma_inline Mat& operator/=(const eT val);
   
-  inline                   Mat(const Mat& m);
-  inline const Mat&  operator=(const Mat& m);
-  inline const Mat& operator+=(const Mat& m);
-  inline const Mat& operator-=(const Mat& m);
-  inline const Mat& operator*=(const Mat& m);
-  inline const Mat& operator%=(const Mat& m);
-  inline const Mat& operator/=(const Mat& m);
+  inline             Mat(const Mat& m);
+  inline Mat&  operator=(const Mat& m);
+  inline Mat& operator+=(const Mat& m);
+  inline Mat& operator-=(const Mat& m);
+  inline Mat& operator*=(const Mat& m);
+  inline Mat& operator%=(const Mat& m);
+  inline Mat& operator/=(const Mat& m);
   
-  template<typename T1> inline                   Mat(const BaseCube<eT,T1>& X);
-  template<typename T1> inline const Mat&  operator=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline const Mat& operator+=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline const Mat& operator-=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline const Mat& operator*=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline const Mat& operator%=(const BaseCube<eT,T1>& X);
-  template<typename T1> inline const Mat& operator/=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline             Mat(const BaseCube<eT,T1>& X);
+  template<typename T1> inline Mat&  operator=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline Mat& operator+=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline Mat& operator-=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline Mat& operator*=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline Mat& operator%=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline Mat& operator/=(const BaseCube<eT,T1>& X);
   
   template<typename T1, typename T2>
   inline explicit Mat(const Base<pod_type,T1>& A, const Base<pod_type,T2>& B);
   
   inline explicit          Mat(const subview<eT>& X, const bool use_colmem);  // only to be used by the quasi_unwrap class
   
-  inline                   Mat(const subview<eT>& X);
-  inline const Mat&  operator=(const subview<eT>& X);
-  inline const Mat& operator+=(const subview<eT>& X);
-  inline const Mat& operator-=(const subview<eT>& X);
-  inline const Mat& operator*=(const subview<eT>& X);
-  inline const Mat& operator%=(const subview<eT>& X);
-  inline const Mat& operator/=(const subview<eT>& X);
+  inline             Mat(const subview<eT>& X);
+  inline Mat&  operator=(const subview<eT>& X);
+  inline Mat& operator+=(const subview<eT>& X);
+  inline Mat& operator-=(const subview<eT>& X);
+  inline Mat& operator*=(const subview<eT>& X);
+  inline Mat& operator%=(const subview<eT>& X);
+  inline Mat& operator/=(const subview<eT>& X);
   
   inline Mat(const subview_row_strans<eT>& X);  // subview_row_strans can only be generated by the Proxy class
   inline Mat(const subview_row_htrans<eT>& X);  // subview_row_htrans can only be generated by the Proxy class
@@ -127,54 +127,54 @@ class Mat : public Base< eT, Mat<eT> >
   template<bool do_conj>
   inline Mat(const xtrans_mat<eT,do_conj>& X);  //        xtrans_mat can only be generated by the Proxy class
   
-  inline                   Mat(const subview_cube<eT>& X);
-  inline const Mat&  operator=(const subview_cube<eT>& X);
-  inline const Mat& operator+=(const subview_cube<eT>& X);
-  inline const Mat& operator-=(const subview_cube<eT>& X);
-  inline const Mat& operator*=(const subview_cube<eT>& X);
-  inline const Mat& operator%=(const subview_cube<eT>& X);
-  inline const Mat& operator/=(const subview_cube<eT>& X);
+  inline             Mat(const subview_cube<eT>& X);
+  inline Mat&  operator=(const subview_cube<eT>& X);
+  inline Mat& operator+=(const subview_cube<eT>& X);
+  inline Mat& operator-=(const subview_cube<eT>& X);
+  inline Mat& operator*=(const subview_cube<eT>& X);
+  inline Mat& operator%=(const subview_cube<eT>& X);
+  inline Mat& operator/=(const subview_cube<eT>& X);
   
-  inline                   Mat(const diagview<eT>& X);
-  inline const Mat&  operator=(const diagview<eT>& X);
-  inline const Mat& operator+=(const diagview<eT>& X);
-  inline const Mat& operator-=(const diagview<eT>& X);
-  inline const Mat& operator*=(const diagview<eT>& X);
-  inline const Mat& operator%=(const diagview<eT>& X);
-  inline const Mat& operator/=(const diagview<eT>& X);
+  inline             Mat(const diagview<eT>& X);
+  inline Mat&  operator=(const diagview<eT>& X);
+  inline Mat& operator+=(const diagview<eT>& X);
+  inline Mat& operator-=(const diagview<eT>& X);
+  inline Mat& operator*=(const diagview<eT>& X);
+  inline Mat& operator%=(const diagview<eT>& X);
+  inline Mat& operator/=(const diagview<eT>& X);
   
-  inline                   Mat(const spdiagview<eT>& X);
-  inline const Mat&  operator=(const spdiagview<eT>& X);
-  inline const Mat& operator+=(const spdiagview<eT>& X);
-  inline const Mat& operator-=(const spdiagview<eT>& X);
-  inline const Mat& operator*=(const spdiagview<eT>& X);
-  inline const Mat& operator%=(const spdiagview<eT>& X);
-  inline const Mat& operator/=(const spdiagview<eT>& X);
+  inline             Mat(const spdiagview<eT>& X);
+  inline Mat&  operator=(const spdiagview<eT>& X);
+  inline Mat& operator+=(const spdiagview<eT>& X);
+  inline Mat& operator-=(const spdiagview<eT>& X);
+  inline Mat& operator*=(const spdiagview<eT>& X);
+  inline Mat& operator%=(const spdiagview<eT>& X);
+  inline Mat& operator/=(const spdiagview<eT>& X);
   
-  template<typename T1> inline                   Mat(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline const Mat& operator= (const subview_elem1<eT,T1>& X);
-  template<typename T1> inline const Mat& operator+=(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline const Mat& operator-=(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline const Mat& operator*=(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline const Mat& operator%=(const subview_elem1<eT,T1>& X);
-  template<typename T1> inline const Mat& operator/=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline             Mat(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline Mat& operator= (const subview_elem1<eT,T1>& X);
+  template<typename T1> inline Mat& operator+=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline Mat& operator-=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline Mat& operator*=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline Mat& operator%=(const subview_elem1<eT,T1>& X);
+  template<typename T1> inline Mat& operator/=(const subview_elem1<eT,T1>& X);
   
-  template<typename T1, typename T2> inline                   Mat(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline const Mat& operator= (const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline const Mat& operator+=(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline const Mat& operator-=(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline const Mat& operator*=(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline const Mat& operator%=(const subview_elem2<eT,T1,T2>& X);
-  template<typename T1, typename T2> inline const Mat& operator/=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline             Mat(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline Mat& operator= (const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline Mat& operator+=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline Mat& operator-=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline Mat& operator*=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline Mat& operator%=(const subview_elem2<eT,T1,T2>& X);
+  template<typename T1, typename T2> inline Mat& operator/=(const subview_elem2<eT,T1,T2>& X);
   
   // Operators on sparse matrices (and subviews)
-  template<typename T1> inline explicit          Mat(const SpBase<eT, T1>& m);
-  template<typename T1> inline const Mat&  operator=(const SpBase<eT, T1>& m);
-  template<typename T1> inline const Mat& operator+=(const SpBase<eT, T1>& m);
-  template<typename T1> inline const Mat& operator-=(const SpBase<eT, T1>& m);
-  template<typename T1> inline const Mat& operator*=(const SpBase<eT, T1>& m);
-  template<typename T1> inline const Mat& operator%=(const SpBase<eT, T1>& m);
-  template<typename T1> inline const Mat& operator/=(const SpBase<eT, T1>& m);
+  template<typename T1> inline explicit    Mat(const SpBase<eT, T1>& m);
+  template<typename T1> inline Mat&  operator=(const SpBase<eT, T1>& m);
+  template<typename T1> inline Mat& operator+=(const SpBase<eT, T1>& m);
+  template<typename T1> inline Mat& operator-=(const SpBase<eT, T1>& m);
+  template<typename T1> inline Mat& operator*=(const SpBase<eT, T1>& m);
+  template<typename T1> inline Mat& operator%=(const SpBase<eT, T1>& m);
+  template<typename T1> inline Mat& operator/=(const SpBase<eT, T1>& m);
   
   inline mat_injector<Mat> operator<<(const eT val);
   inline mat_injector<Mat> operator<<(const injector_end_of_row<>& x);
@@ -302,64 +302,64 @@ class Mat : public Base< eT, Mat<eT> >
   template<typename T1> inline void insert_cols(const uword col_num, const Base<eT,T1>& X);
   
   
-  template<typename T1, typename gen_type> inline                   Mat(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline const Mat&  operator=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline const Mat& operator+=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline const Mat& operator-=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline const Mat& operator*=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline const Mat& operator%=(const Gen<T1, gen_type>& X);
-  template<typename T1, typename gen_type> inline const Mat& operator/=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline             Mat(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline Mat&  operator=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline Mat& operator+=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline Mat& operator-=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline Mat& operator*=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline Mat& operator%=(const Gen<T1, gen_type>& X);
+  template<typename T1, typename gen_type> inline Mat& operator/=(const Gen<T1, gen_type>& X);
   
-  template<typename T1, typename op_type> inline                   Mat(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat&  operator=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator+=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator-=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator*=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator%=(const Op<T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator/=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline             Mat(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat&  operator=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator+=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator-=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator*=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator%=(const Op<T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator/=(const Op<T1, op_type>& X);
   
-  template<typename T1, typename eop_type> inline                   Mat(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Mat&  operator=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Mat& operator+=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Mat& operator-=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Mat& operator*=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Mat& operator%=(const eOp<T1, eop_type>& X);
-  template<typename T1, typename eop_type> inline const Mat& operator/=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline             Mat(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Mat&  operator=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Mat& operator+=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Mat& operator-=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Mat& operator*=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Mat& operator%=(const eOp<T1, eop_type>& X);
+  template<typename T1, typename eop_type> inline Mat& operator/=(const eOp<T1, eop_type>& X);
   
-  template<typename T1, typename op_type> inline                   Mat(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat&  operator=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator+=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator-=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator*=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator%=(const mtOp<eT, T1, op_type>& X);
-  template<typename T1, typename op_type> inline const Mat& operator/=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline             Mat(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat&  operator=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator+=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator-=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator*=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator%=(const mtOp<eT, T1, op_type>& X);
+  template<typename T1, typename op_type> inline Mat& operator/=(const mtOp<eT, T1, op_type>& X);
   
-  template<typename T1, typename T2, typename glue_type> inline                   Mat(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat&  operator=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator+=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator-=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator*=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator%=(const Glue<T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator/=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline             Mat(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat&  operator=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator+=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator-=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator*=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator%=(const Glue<T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator/=(const Glue<T1, T2, glue_type>& X);
   
-  template<typename T1, typename T2>                     inline const Mat& operator+=(const Glue<T1, T2, glue_times>& X);
-  template<typename T1, typename T2>                     inline const Mat& operator-=(const Glue<T1, T2, glue_times>& X);
+  template<typename T1, typename T2>                     inline Mat& operator+=(const Glue<T1, T2, glue_times>& X);
+  template<typename T1, typename T2>                     inline Mat& operator-=(const Glue<T1, T2, glue_times>& X);
   
-  template<typename T1, typename T2, typename eglue_type> inline                   Mat(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Mat&  operator=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator+=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator-=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator*=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator%=(const eGlue<T1, T2, eglue_type>& X);
-  template<typename T1, typename T2, typename eglue_type> inline const Mat& operator/=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline             Mat(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Mat&  operator=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Mat& operator+=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Mat& operator-=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Mat& operator*=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Mat& operator%=(const eGlue<T1, T2, eglue_type>& X);
+  template<typename T1, typename T2, typename eglue_type> inline Mat& operator/=(const eGlue<T1, T2, eglue_type>& X);
   
-  template<typename T1, typename T2, typename glue_type> inline                   Mat(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat&  operator=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator+=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator-=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator*=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator%=(const mtGlue<eT, T1, T2, glue_type>& X);
-  template<typename T1, typename T2, typename glue_type> inline const Mat& operator/=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline             Mat(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat&  operator=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator+=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator-=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator*=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator%=(const mtGlue<eT, T1, T2, glue_type>& X);
+  template<typename T1, typename T2, typename glue_type> inline Mat& operator/=(const mtGlue<eT, T1, T2, glue_type>& X);
   
   
   arma_inline arma_warn_unused const eT& at_alt     (const uword ii) const;
@@ -767,18 +767,18 @@ class Mat<eT>::fixed : public Mat<eT>
   using Mat<eT>::operator();
   
   #if defined(ARMA_USE_CXX11)
-    inline                fixed(const std::initializer_list<eT>& list);
-    inline const Mat& operator=(const std::initializer_list<eT>& list);
+    inline            fixed(const std::initializer_list<eT>& list);
+    inline fixed& operator=(const std::initializer_list<eT>& list);
     
-    inline                fixed(const std::initializer_list< std::initializer_list<eT> >& list);
-    inline const Mat& operator=(const std::initializer_list< std::initializer_list<eT> >& list);
+    inline            fixed(const std::initializer_list< std::initializer_list<eT> >& list);
+    inline fixed& operator=(const std::initializer_list< std::initializer_list<eT> >& list);
   #endif
   
-  arma_inline const Mat& operator=(const fixed<fixed_n_rows, fixed_n_cols>& X);
+  arma_inline fixed& operator=(const fixed<fixed_n_rows, fixed_n_cols>& X);
   
   #if defined(ARMA_GOOD_COMPILER)
-    template<typename T1,              typename   eop_type> inline const Mat& operator=(const   eOp<T1,       eop_type>& X);
-    template<typename T1, typename T2, typename eglue_type> inline const Mat& operator=(const eGlue<T1, T2, eglue_type>& X);
+    template<typename T1,              typename   eop_type> inline fixed& operator=(const   eOp<T1,       eop_type>& X);
+    template<typename T1, typename T2, typename eglue_type> inline fixed& operator=(const eGlue<T1, T2, eglue_type>& X);
   #endif
   
   arma_inline const Op< Mat_fixed_type, op_htrans >  t() const;

--- a/include/armadillo_bits/Mat_bones.hpp
+++ b/include/armadillo_bits/Mat_bones.hpp
@@ -85,11 +85,11 @@ class Mat : public Base< eT, Mat<eT> >
   inline Mat(      eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols, const bool copy_aux_mem = true, const bool strict = false);
   inline Mat(const eT* aux_mem, const uword aux_n_rows, const uword aux_n_cols);
   
-  arma_inline Mat&  operator=(const eT val);
-  arma_inline Mat& operator+=(const eT val);
-  arma_inline Mat& operator-=(const eT val);
-  arma_inline Mat& operator*=(const eT val);
-  arma_inline Mat& operator/=(const eT val);
+  inline Mat&  operator=(const eT val);
+  inline Mat& operator+=(const eT val);
+  inline Mat& operator-=(const eT val);
+  inline Mat& operator*=(const eT val);
+  inline Mat& operator/=(const eT val);
   
   inline             Mat(const Mat& m);
   inline Mat&  operator=(const Mat& m);
@@ -818,17 +818,17 @@ class Mat_aux
   {
   public:
 
-  template<typename eT> arma_inline static void prefix_pp(Mat<eT>& x);
-  template<typename T>  arma_inline static void prefix_pp(Mat< std::complex<T> >& x);
+  template<typename eT> inline static void prefix_pp(Mat<eT>& x);
+  template<typename T>  inline static void prefix_pp(Mat< std::complex<T> >& x);
   
-  template<typename eT> arma_inline static void postfix_pp(Mat<eT>& x);
-  template<typename T>  arma_inline static void postfix_pp(Mat< std::complex<T> >& x);
+  template<typename eT> inline static void postfix_pp(Mat<eT>& x);
+  template<typename T>  inline static void postfix_pp(Mat< std::complex<T> >& x);
   
-  template<typename eT> arma_inline static void prefix_mm(Mat<eT>& x);
-  template<typename T>  arma_inline static void prefix_mm(Mat< std::complex<T> >& x);
+  template<typename eT> inline static void prefix_mm(Mat<eT>& x);
+  template<typename T>  inline static void prefix_mm(Mat< std::complex<T> >& x);
   
-  template<typename eT> arma_inline static void postfix_mm(Mat<eT>& x);
-  template<typename T>  arma_inline static void postfix_mm(Mat< std::complex<T> >& x);
+  template<typename eT> inline static void postfix_mm(Mat<eT>& x);
+  template<typename T>  inline static void postfix_mm(Mat< std::complex<T> >& x);
   
   template<typename eT, typename T1> inline static void set_real(Mat<eT>&                out, const Base<eT,T1>& X);
   template<typename T,  typename T1> inline static void set_real(Mat< std::complex<T> >& out, const Base< T,T1>& X);

--- a/include/armadillo_bits/Mat_meat.hpp
+++ b/include/armadillo_bits/Mat_meat.hpp
@@ -368,7 +368,7 @@ Mat<eT>::Mat(const char* text)
 //! create the matrix from a textual description
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -400,7 +400,7 @@ Mat<eT>::Mat(const std::string& text)
 //! create the matrix from a textual description
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -551,7 +551,7 @@ Mat<eT>::Mat(const std::vector<eT>& x)
 //! create the matrix from std::vector
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const std::vector<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -589,7 +589,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  const Mat<eT>&
+  Mat<eT>&
   Mat<eT>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -620,7 +620,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  const Mat<eT>&
+  Mat<eT>&
   Mat<eT>::operator=(const std::initializer_list< std::initializer_list<eT> >& list)
     {
     arma_extra_debug_sigprint();
@@ -675,7 +675,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  const Mat<eT>&
+  Mat<eT>&
   Mat<eT>::operator=(Mat<eT>&& X)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   X = %x") % this % &X);
@@ -701,7 +701,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
 //! NOTE: the size of the matrix will be 1x1
 template<typename eT>
 arma_inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -716,7 +716,7 @@ Mat<eT>::operator=(const eT val)
 //! In-place addition of a scalar to all elements of the matrix
 template<typename eT>
 arma_inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -731,7 +731,7 @@ Mat<eT>::operator+=(const eT val)
 //! In-place subtraction of a scalar from all elements of the matrix
 template<typename eT>
 arma_inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -746,7 +746,7 @@ Mat<eT>::operator-=(const eT val)
 //! In-place multiplication of all elements of the matrix with a scalar
 template<typename eT>
 arma_inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -761,7 +761,7 @@ Mat<eT>::operator*=(const eT val)
 //! In-place division of all elements of the matrix with a scalar
 template<typename eT>
 arma_inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -796,7 +796,7 @@ Mat<eT>::Mat(const Mat<eT>& in_mat)
 //! construct a matrix from a given matrix
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const Mat<eT>& in_mat)
   {
   arma_extra_debug_sigprint(arma_str::format("this = %x   in_mat = %x") % this % &in_mat);
@@ -1273,7 +1273,7 @@ Mat<eT>::Mat(const char junk, const eT* aux_mem, const uword aux_n_rows, const u
 //! in-place matrix addition
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1290,7 +1290,7 @@ Mat<eT>::operator+=(const Mat<eT>& m)
 //! in-place matrix subtraction
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1307,7 +1307,7 @@ Mat<eT>::operator-=(const Mat<eT>& m)
 //! in-place matrix multiplication
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1322,7 +1322,7 @@ Mat<eT>::operator*=(const Mat<eT>& m)
 //! in-place element-wise matrix multiplication
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1339,7 +1339,7 @@ Mat<eT>::operator%=(const Mat<eT>& m)
 //! in-place element-wise matrix division
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const Mat<eT>& m)
   {
   arma_extra_debug_sigprint();
@@ -1374,7 +1374,7 @@ Mat<eT>::Mat(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1461,7 +1461,7 @@ Mat<eT>::operator=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1542,7 +1542,7 @@ Mat<eT>::operator+=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1623,7 +1623,7 @@ Mat<eT>::operator-=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1640,7 +1640,7 @@ Mat<eT>::operator*=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1721,7 +1721,7 @@ Mat<eT>::operator%=(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -1871,7 +1871,7 @@ Mat<eT>::Mat(const subview<eT>& X)
 //! construct a matrix from subview (e.g. construct a matrix from a delayed submatrix operation)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1898,7 +1898,7 @@ Mat<eT>::operator=(const subview<eT>& X)
 //! in-place matrix addition (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1912,7 +1912,7 @@ Mat<eT>::operator+=(const subview<eT>& X)
 //! in-place matrix subtraction (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1927,7 +1927,7 @@ Mat<eT>::operator-=(const subview<eT>& X)
 //! in-place matrix mutiplication (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1942,7 +1942,7 @@ Mat<eT>::operator*=(const subview<eT>& X)
 //! in-place element-wise matrix mutiplication (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1957,7 +1957,7 @@ Mat<eT>::operator%=(const subview<eT>& X)
 //! in-place element-wise matrix division (using a submatrix on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const subview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2067,7 +2067,7 @@ Mat<eT>::Mat(const subview_cube<eT>& x)
 //! construct a matrix from a subview_cube instance
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2082,7 +2082,7 @@ Mat<eT>::operator=(const subview_cube<eT>& X)
 //! in-place matrix addition (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2097,7 +2097,7 @@ Mat<eT>::operator+=(const subview_cube<eT>& X)
 //! in-place matrix subtraction (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2112,7 +2112,7 @@ Mat<eT>::operator-=(const subview_cube<eT>& X)
 //! in-place matrix mutiplication (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2128,7 +2128,7 @@ Mat<eT>::operator*=(const subview_cube<eT>& X)
 //! in-place element-wise matrix mutiplication (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2143,7 +2143,7 @@ Mat<eT>::operator%=(const subview_cube<eT>& X)
 //! in-place element-wise matrix division (using a single-slice subcube on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2178,7 +2178,7 @@ Mat<eT>::Mat(const diagview<eT>& X)
 //! construct a matrix from diagview (e.g. construct a matrix from a delayed diag operation)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2206,7 +2206,7 @@ Mat<eT>::operator=(const diagview<eT>& X)
 //! in-place matrix addition (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2221,7 +2221,7 @@ Mat<eT>::operator+=(const diagview<eT>& X)
 //! in-place matrix subtraction (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2236,7 +2236,7 @@ Mat<eT>::operator-=(const diagview<eT>& X)
 //! in-place matrix mutiplication (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2251,7 +2251,7 @@ Mat<eT>::operator*=(const diagview<eT>& X)
 //! in-place element-wise matrix mutiplication (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2266,7 +2266,7 @@ Mat<eT>::operator%=(const diagview<eT>& X)
 //! in-place element-wise matrix division (using a diagview on the right-hand-side)
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const diagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2299,7 +2299,7 @@ Mat<eT>::Mat(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2315,7 +2315,7 @@ Mat<eT>::operator=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2331,7 +2331,7 @@ Mat<eT>::operator+=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2347,7 +2347,7 @@ Mat<eT>::operator-=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2363,7 +2363,7 @@ Mat<eT>::operator*=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2379,7 +2379,7 @@ Mat<eT>::operator%=(const spdiagview<eT>& X)
 
 template<typename eT>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const spdiagview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -2414,7 +2414,7 @@ Mat<eT>::Mat(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2429,7 +2429,7 @@ Mat<eT>::operator=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2444,7 +2444,7 @@ Mat<eT>::operator+=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2459,7 +2459,7 @@ Mat<eT>::operator-=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2474,7 +2474,7 @@ Mat<eT>::operator*=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2489,7 +2489,7 @@ Mat<eT>::operator%=(const subview_elem1<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const subview_elem1<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -2522,7 +2522,7 @@ Mat<eT>::Mat(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2537,7 +2537,7 @@ Mat<eT>::operator=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2552,7 +2552,7 @@ Mat<eT>::operator+=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2567,7 +2567,7 @@ Mat<eT>::operator-=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2582,7 +2582,7 @@ Mat<eT>::operator*=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2597,7 +2597,7 @@ Mat<eT>::operator%=(const subview_elem2<eT,T1,T2>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const subview_elem2<eT,T1,T2>& X)
   {
   arma_extra_debug_sigprint();
@@ -2647,7 +2647,7 @@ Mat<eT>::Mat(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2675,7 +2675,7 @@ Mat<eT>::operator=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2701,7 +2701,7 @@ Mat<eT>::operator+=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2727,7 +2727,7 @@ Mat<eT>::operator-=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2744,7 +2744,7 @@ Mat<eT>::operator*=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -2782,7 +2782,7 @@ Mat<eT>::operator%=(const SpBase<eT, T1>& m)
 template<typename eT>
 template<typename T1>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const SpBase<eT, T1>& m)
   {
   arma_extra_debug_sigprint();
@@ -4472,7 +4472,7 @@ Mat<eT>::Mat(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4491,7 +4491,7 @@ Mat<eT>::operator=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4508,7 +4508,7 @@ Mat<eT>::operator+=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4525,7 +4525,7 @@ Mat<eT>::operator-=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4542,7 +4542,7 @@ Mat<eT>::operator*=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4559,7 +4559,7 @@ Mat<eT>::operator%=(const Gen<T1, gen_type>& X)
 template<typename eT>
 template<typename T1, typename gen_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const Gen<T1, gen_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4598,7 +4598,7 @@ Mat<eT>::Mat(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4616,7 +4616,7 @@ Mat<eT>::operator=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4634,7 +4634,7 @@ Mat<eT>::operator+=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4652,7 +4652,7 @@ Mat<eT>::operator-=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4670,7 +4670,7 @@ Mat<eT>::operator*=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4688,7 +4688,7 @@ Mat<eT>::operator%=(const Op<T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const Op<T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4729,7 +4729,7 @@ Mat<eT>::Mat(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4761,7 +4761,7 @@ Mat<eT>::operator=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4778,7 +4778,7 @@ Mat<eT>::operator+=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4795,7 +4795,7 @@ Mat<eT>::operator-=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4812,7 +4812,7 @@ Mat<eT>::operator*=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4829,7 +4829,7 @@ Mat<eT>::operator%=(const eOp<T1, eop_type>& X)
 template<typename eT>
 template<typename T1, typename eop_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const eOp<T1, eop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4866,7 +4866,7 @@ Mat<eT>::Mat(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4882,7 +4882,7 @@ Mat<eT>::operator=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4898,7 +4898,7 @@ Mat<eT>::operator+=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4914,7 +4914,7 @@ Mat<eT>::operator-=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4930,7 +4930,7 @@ Mat<eT>::operator*=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4946,7 +4946,7 @@ Mat<eT>::operator%=(const mtOp<eT, T1, op_type>& X)
 template<typename eT>
 template<typename T1, typename op_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const mtOp<eT, T1, op_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -4984,7 +4984,7 @@ Mat<eT>::Mat(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5003,7 +5003,7 @@ Mat<eT>::operator=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5022,7 +5022,7 @@ Mat<eT>::operator+=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5041,7 +5041,7 @@ Mat<eT>::operator-=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5060,7 +5060,7 @@ Mat<eT>::operator*=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5079,7 +5079,7 @@ Mat<eT>::operator%=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const Glue<T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5097,7 +5097,7 @@ Mat<eT>::operator/=(const Glue<T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const Glue<T1, T2, glue_times>& X)
   {
   arma_extra_debug_sigprint();
@@ -5112,7 +5112,7 @@ Mat<eT>::operator+=(const Glue<T1, T2, glue_times>& X)
 template<typename eT>
 template<typename T1, typename T2>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const Glue<T1, T2, glue_times>& X)
   {
   arma_extra_debug_sigprint();
@@ -5152,7 +5152,7 @@ Mat<eT>::Mat(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5191,7 +5191,7 @@ Mat<eT>::operator=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5210,7 +5210,7 @@ Mat<eT>::operator+=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5228,7 +5228,7 @@ Mat<eT>::operator-=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5245,7 +5245,7 @@ Mat<eT>::operator*=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5262,7 +5262,7 @@ Mat<eT>::operator%=(const eGlue<T1, T2, eglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename eglue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const eGlue<T1, T2, eglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5299,7 +5299,7 @@ Mat<eT>::Mat(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5315,7 +5315,7 @@ Mat<eT>::operator=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator+=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5331,7 +5331,7 @@ Mat<eT>::operator+=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator-=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5347,7 +5347,7 @@ Mat<eT>::operator-=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator*=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5365,7 +5365,7 @@ Mat<eT>::operator*=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator%=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -5381,7 +5381,7 @@ Mat<eT>::operator%=(const mtGlue<eT, T1, T2, glue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename glue_type>
 inline
-const Mat<eT>&
+Mat<eT>&
 Mat<eT>::operator/=(const mtGlue<eT, T1, T2, glue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -8200,7 +8200,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::fixed(const std::string& text)
   template<typename eT>
   template<uword fixed_n_rows, uword fixed_n_cols>
   inline
-  const Mat<eT>&
+  Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
   Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -8236,7 +8236,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::fixed(const std::string& text)
   template<typename eT>
   template<uword fixed_n_rows, uword fixed_n_cols>
   inline
-  const Mat<eT>&
+  Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
   Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const std::initializer_list< std::initializer_list<eT> >& list)
     {
     arma_extra_debug_sigprint();
@@ -8253,7 +8253,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::fixed(const std::string& text)
 template<typename eT>
 template<uword fixed_n_rows, uword fixed_n_cols>
 arma_inline
-const Mat<eT>&
+Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
 Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const fixed<fixed_n_rows, fixed_n_cols>& X)
   {
   arma_extra_debug_sigprint();
@@ -8277,7 +8277,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const fixed<fixed_n_rows, 
   template<uword fixed_n_rows, uword fixed_n_cols>
   template<typename T1, typename eop_type>
   inline
-  const Mat<eT>&
+  Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
   Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const eOp<T1, eop_type>& X)
     {
     arma_extra_debug_sigprint();
@@ -8310,7 +8310,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const fixed<fixed_n_rows, 
   template<uword fixed_n_rows, uword fixed_n_cols>
   template<typename T1, typename T2, typename eglue_type>
   inline
-  const Mat<eT>&
+  Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>&
   Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::operator=(const eGlue<T1, T2, eglue_type>& X)
     {
     arma_extra_debug_sigprint();

--- a/include/armadillo_bits/Mat_meat.hpp
+++ b/include/armadillo_bits/Mat_meat.hpp
@@ -700,7 +700,7 @@ Mat<eT>::operator=(const std::vector<eT>& x)
 //! Set the matrix to be equal to the specified scalar.
 //! NOTE: the size of the matrix will be 1x1
 template<typename eT>
-arma_inline
+inline
 Mat<eT>&
 Mat<eT>::operator=(const eT val)
   {
@@ -715,7 +715,7 @@ Mat<eT>::operator=(const eT val)
 
 //! In-place addition of a scalar to all elements of the matrix
 template<typename eT>
-arma_inline
+inline
 Mat<eT>&
 Mat<eT>::operator+=(const eT val)
   {
@@ -730,7 +730,7 @@ Mat<eT>::operator+=(const eT val)
 
 //! In-place subtraction of a scalar from all elements of the matrix
 template<typename eT>
-arma_inline
+inline
 Mat<eT>&
 Mat<eT>::operator-=(const eT val)
   {
@@ -745,7 +745,7 @@ Mat<eT>::operator-=(const eT val)
 
 //! In-place multiplication of all elements of the matrix with a scalar
 template<typename eT>
-arma_inline
+inline
 Mat<eT>&
 Mat<eT>::operator*=(const eT val)
   {
@@ -760,7 +760,7 @@ Mat<eT>::operator*=(const eT val)
 
 //! In-place division of all elements of the matrix with a scalar
 template<typename eT>
-arma_inline
+inline
 Mat<eT>&
 Mat<eT>::operator/=(const eT val)
   {
@@ -8658,7 +8658,7 @@ Mat<eT>::fixed<fixed_n_rows, fixed_n_cols>::ones()
 
 //! prefix ++
 template<typename eT>
-arma_inline
+inline
 void
 Mat_aux::prefix_pp(Mat<eT>& x)
   {
@@ -8683,7 +8683,7 @@ Mat_aux::prefix_pp(Mat<eT>& x)
 
 //! prefix ++ for complex numbers (work around for limitations of the std::complex class)
 template<typename T>
-arma_inline
+inline
 void
 Mat_aux::prefix_pp(Mat< std::complex<T> >& x)
   {
@@ -8694,7 +8694,7 @@ Mat_aux::prefix_pp(Mat< std::complex<T> >& x)
 
 //! postfix ++
 template<typename eT>
-arma_inline
+inline
 void
 Mat_aux::postfix_pp(Mat<eT>& x)
   {
@@ -8719,7 +8719,7 @@ Mat_aux::postfix_pp(Mat<eT>& x)
 
 //! postfix ++ for complex numbers (work around for limitations of the std::complex class)
 template<typename T>
-arma_inline
+inline
 void
 Mat_aux::postfix_pp(Mat< std::complex<T> >& x)
   {
@@ -8730,7 +8730,7 @@ Mat_aux::postfix_pp(Mat< std::complex<T> >& x)
 
 //! prefix --
 template<typename eT>
-arma_inline
+inline
 void
 Mat_aux::prefix_mm(Mat<eT>& x)
   {
@@ -8755,7 +8755,7 @@ Mat_aux::prefix_mm(Mat<eT>& x)
 
 //! prefix -- for complex numbers (work around for limitations of the std::complex class)
 template<typename T>
-arma_inline
+inline
 void
 Mat_aux::prefix_mm(Mat< std::complex<T> >& x)
   {
@@ -8766,7 +8766,7 @@ Mat_aux::prefix_mm(Mat< std::complex<T> >& x)
 
 //! postfix --
 template<typename eT>
-arma_inline
+inline
 void
 Mat_aux::postfix_mm(Mat<eT>& x)
   {
@@ -8791,7 +8791,7 @@ Mat_aux::postfix_mm(Mat<eT>& x)
 
 //! postfix ++ for complex numbers (work around for limitations of the std::complex class)
 template<typename T>
-arma_inline
+inline
 void
 Mat_aux::postfix_mm(Mat< std::complex<T> >& x)
   {

--- a/include/armadillo_bits/Proxy.hpp
+++ b/include/armadillo_bits/Proxy.hpp
@@ -287,6 +287,51 @@ class Proxy< Gen<T1, gen_type > >
 
 
 
+template<typename T1>
+class Proxy< Gen<T1, gen_randn > >
+  {
+  public:
+  
+  typedef typename T1::elem_type                   elem_type;
+  typedef typename get_pod_type<elem_type>::result pod_type;
+  typedef Mat<elem_type>                           stored_type;
+  typedef const elem_type*                         ea_type;
+  typedef const Mat<elem_type>&                    aligned_ea_type;
+  
+  static const bool use_at      = false;
+  static const bool has_subview = false;
+  static const bool fake_mat    = false;
+  
+  static const bool is_row = Gen<T1, gen_randn>::is_row;
+  static const bool is_col = Gen<T1, gen_randn>::is_col;
+  
+  arma_aligned const Mat<elem_type> Q;
+  
+  inline explicit Proxy(const Gen<T1, gen_randn>& A)
+    : Q(A)
+    {
+    arma_extra_debug_sigprint();
+    }
+  
+  arma_inline uword get_n_rows() const { return (is_row ? 1 : Q.n_rows);                           }
+  arma_inline uword get_n_cols() const { return (is_col ? 1 : Q.n_cols);                           }
+  arma_inline uword get_n_elem() const { return (is_row ? 1 : Q.n_rows) * (is_col ? 1 : Q.n_cols); }
+  
+  arma_inline elem_type operator[] (const uword i)                    const { return Q[i];           }
+  arma_inline elem_type at         (const uword row, const uword col) const { return Q.at(row, col); }
+  arma_inline elem_type at_alt     (const uword i)                    const { return Q.at_alt(i);    }
+  
+  arma_inline         ea_type         get_ea() const { return Q.memptr(); }
+  arma_inline aligned_ea_type get_aligned_ea() const { return Q; }
+  
+  template<typename eT2>
+  arma_inline bool is_alias(const Mat<eT2>&) const { return false; }
+  
+  arma_inline bool is_aligned() const { return memory::is_aligned(Q.memptr()); }
+  };
+
+
+
 template<typename T1, typename eop_type>
 class Proxy< eOp<T1, eop_type > >
   {

--- a/include/armadillo_bits/ProxyCube.hpp
+++ b/include/armadillo_bits/ProxyCube.hpp
@@ -78,7 +78,7 @@ class ProxyCube< Cube<eT> >
 
 
 template<typename eT, typename gen_type>
-class ProxyCube< GenCube<eT, gen_type > >
+class ProxyCube< GenCube<eT, gen_type> >
   {
   public:
   
@@ -116,6 +116,49 @@ class ProxyCube< GenCube<eT, gen_type > >
   arma_inline bool is_alias(const Cube<eT2>&) const { return false; }
   
   arma_inline bool is_aligned() const { return GenCube<eT, gen_type>::is_simple; }
+  };
+
+
+
+template<typename eT>
+class ProxyCube< GenCube<eT, gen_randn> >
+  {
+  public:
+  
+  typedef eT                                       elem_type;
+  typedef typename get_pod_type<elem_type>::result pod_type;
+  typedef Cube<eT>                                 stored_type;
+  typedef const eT*                                ea_type;
+  typedef const Cube<eT>&                          aligned_ea_type;
+  
+  static const bool use_at      = false;
+  static const bool has_subview = false;
+  
+  arma_aligned const Cube<eT> Q;
+  
+  inline explicit ProxyCube(const GenCube<eT, gen_randn>& A)
+    : Q(A)
+    {
+    arma_extra_debug_sigprint();
+    }
+  
+  arma_inline uword get_n_rows()       const { return Q.n_rows;       }
+  arma_inline uword get_n_cols()       const { return Q.n_cols;       }
+  arma_inline uword get_n_elem_slice() const { return Q.n_elem_slice; }
+  arma_inline uword get_n_slices()     const { return Q.n_slices;     }
+  arma_inline uword get_n_elem()       const { return Q.n_elem;       }
+  
+  arma_inline elem_type operator[] (const uword i)                                       const { return Q[i];                  }
+  arma_inline elem_type at         (const uword row, const uword col, const uword slice) const { return Q.at(row, col, slice); }
+  arma_inline elem_type at_alt     (const uword i)                                       const { return Q.at_alt(i);           }
+  
+  arma_inline         ea_type         get_ea() const { return Q.memptr(); }
+  arma_inline aligned_ea_type get_aligned_ea() const { return Q;          }
+  
+  template<typename eT2>
+  arma_inline bool is_alias(const Cube<eT2>&) const { return false; }
+  
+  arma_inline bool is_aligned() const { return memory::is_aligned(Q.memptr()); }
   };
 
 

--- a/include/armadillo_bits/Row_bones.hpp
+++ b/include/armadillo_bits/Row_bones.hpp
@@ -40,30 +40,30 @@ class Row : public Mat<eT>
   template<typename fill_type> inline Row(const uword in_rows, const uword in_cols, const fill::fill_class<fill_type>& f);
   template<typename fill_type> inline Row(const SizeMat& s,                         const fill::fill_class<fill_type>& f);
   
-  inline                  Row(const char*        text);
-  inline const Row& operator=(const char*        text);
+  inline            Row(const char*        text);
+  inline Row& operator=(const char*        text);
   
-  inline                  Row(const std::string& text);
-  inline const Row& operator=(const std::string& text);
+  inline            Row(const std::string& text);
+  inline Row& operator=(const std::string& text);
   
-  inline                  Row(const std::vector<eT>& x);
-  inline const Row& operator=(const std::vector<eT>& x);
+  inline            Row(const std::vector<eT>& x);
+  inline Row& operator=(const std::vector<eT>& x);
   
   #if defined(ARMA_USE_CXX11)
-  inline                  Row(const std::initializer_list<eT>& list);
-  inline const Row& operator=(const std::initializer_list<eT>& list);
+  inline            Row(const std::initializer_list<eT>& list);
+  inline Row& operator=(const std::initializer_list<eT>& list);
   
-  inline                  Row(Row&& m);
-  inline const Row& operator=(Row&& m);
+  inline            Row(Row&& m);
+  inline Row& operator=(Row&& m);
   #endif
   
   inline explicit Row(const SpRow<eT>& X);
   
-  inline const Row& operator=(const eT val);
-  inline const Row& operator=(const Row& X);
+  inline Row& operator=(const eT val);
+  inline Row& operator=(const Row& X);
   
-  template<typename T1> inline                   Row(const Base<eT,T1>& X);
-  template<typename T1> inline const Row&  operator=(const Base<eT,T1>& X);
+  template<typename T1> inline             Row(const Base<eT,T1>& X);
+  template<typename T1> inline Row&  operator=(const Base<eT,T1>& X);
   
   inline Row(      eT* aux_mem, const uword aux_length, const bool copy_aux_mem = true, const bool strict = false);
   inline Row(const eT* aux_mem, const uword aux_length);
@@ -71,11 +71,11 @@ class Row : public Mat<eT>
   template<typename T1, typename T2>
   inline explicit Row(const Base<pod_type,T1>& A, const Base<pod_type,T2>& B);
   
-  template<typename T1> inline                  Row(const BaseCube<eT,T1>& X);
-  template<typename T1> inline const Row& operator=(const BaseCube<eT,T1>& X);
+  template<typename T1> inline            Row(const BaseCube<eT,T1>& X);
+  template<typename T1> inline Row& operator=(const BaseCube<eT,T1>& X);
   
-  inline                  Row(const subview_cube<eT>& X);
-  inline const Row& operator=(const subview_cube<eT>& X);
+  inline            Row(const subview_cube<eT>& X);
+  inline Row& operator=(const subview_cube<eT>& X);
   
   inline mat_injector<Row> operator<<(const eT val);
   
@@ -199,25 +199,25 @@ class Row<eT>::fixed : public Row<eT>
   inline fixed(const char*        text);
   inline fixed(const std::string& text);
   
-  template<typename T1> inline const Row& operator=(const Base<eT,T1>& A);
+  template<typename T1> inline Row& operator=(const Base<eT,T1>& A);
   
-  inline const Row& operator=(const eT val);
-  inline const Row& operator=(const char*        text);
-  inline const Row& operator=(const std::string& text);
-  inline const Row& operator=(const subview_cube<eT>& X);
+  inline Row& operator=(const eT val);
+  inline Row& operator=(const char*        text);
+  inline Row& operator=(const std::string& text);
+  inline Row& operator=(const subview_cube<eT>& X);
   
   using Row<eT>::operator();
   
   #if defined(ARMA_USE_CXX11)
-    inline                fixed(const std::initializer_list<eT>& list);
-    inline const Row& operator=(const std::initializer_list<eT>& list);
+    inline          fixed(const std::initializer_list<eT>& list);
+    inline Row& operator=(const std::initializer_list<eT>& list);
   #endif
   
-  arma_inline const Row& operator=(const fixed<fixed_n_elem>& X);
+  arma_inline Row& operator=(const fixed<fixed_n_elem>& X);
   
   #if defined(ARMA_GOOD_COMPILER)
-    template<typename T1,              typename   eop_type> inline const Row& operator=(const   eOp<T1,       eop_type>& X);
-    template<typename T1, typename T2, typename eglue_type> inline const Row& operator=(const eGlue<T1, T2, eglue_type>& X);
+    template<typename T1,              typename   eop_type> inline Row& operator=(const   eOp<T1,       eop_type>& X);
+    template<typename T1, typename T2, typename eglue_type> inline Row& operator=(const eGlue<T1, T2, eglue_type>& X);
   #endif
   
   arma_inline const Op< Row_fixed_type, op_htrans >  t() const;

--- a/include/armadillo_bits/Row_meat.hpp
+++ b/include/armadillo_bits/Row_meat.hpp
@@ -134,7 +134,7 @@ Row<eT>::Row(const char* text)
 
 template<typename eT>
 inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -161,7 +161,7 @@ Row<eT>::Row(const std::string& text)
 
 template<typename eT>
 inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -192,7 +192,7 @@ Row<eT>::Row(const std::vector<eT>& x)
 //! create a row vector from std::vector
 template<typename eT>
 inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::operator=(const std::vector<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -226,7 +226,7 @@ Row<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  const Row<eT>&
+  Row<eT>&
   Row<eT>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -280,7 +280,7 @@ Row<eT>::operator=(const std::vector<eT>& x)
   
   template<typename eT>
   inline
-  const Row<eT>&
+  Row<eT>&
   Row<eT>::operator=(Row<eT>&& X)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   X = %x") % this % &X);
@@ -321,7 +321,7 @@ Row<eT>::Row(const SpRow<eT>& X)
 
 template<typename eT>
 inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -335,7 +335,7 @@ Row<eT>::operator=(const eT val)
 
 template<typename eT>
 inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::operator=(const Row<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -363,7 +363,7 @@ Row<eT>::Row(const Base<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::operator=(const Base<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -436,7 +436,7 @@ Row<eT>::Row(const BaseCube<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::operator=(const BaseCube<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -463,7 +463,7 @@ Row<eT>::Row(const subview_cube<eT>& X)
 
 template<typename eT>
 inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1181,7 +1181,7 @@ Row<eT>::fixed<fixed_n_elem>::fixed(const std::string& text)
 template<typename eT>
 template<uword fixed_n_elem>
 template<typename T1>
-const Row<eT>&
+Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const Base<eT,T1>& A)
   {
   arma_extra_debug_sigprint();
@@ -1195,7 +1195,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const Base<eT,T1>& A)
 
 template<typename eT>
 template<uword fixed_n_elem>
-const Row<eT>&
+Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -1209,7 +1209,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const eT val)
 
 template<typename eT>
 template<uword fixed_n_elem>
-const Row<eT>&
+Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -1223,7 +1223,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const char* text)
 
 template<typename eT>
 template<uword fixed_n_elem>
-const Row<eT>&
+Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -1237,7 +1237,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const std::string& text)
 
 template<typename eT>
 template<uword fixed_n_elem>
-const Row<eT>&
+Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1267,7 +1267,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
   template<typename eT>
   template<uword fixed_n_elem>
   inline
-  const Row<eT>&
+  Row<eT>&
   Row<eT>::fixed<fixed_n_elem>::operator=(const std::initializer_list<eT>& list)
     {
     arma_extra_debug_sigprint();
@@ -1292,7 +1292,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const subview_cube<eT>& X)
 template<typename eT>
 template<uword fixed_n_elem>
 arma_inline
-const Row<eT>&
+Row<eT>&
 Row<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   {
   arma_extra_debug_sigprint();
@@ -1316,7 +1316,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   template<uword fixed_n_elem>
   template<typename T1, typename eop_type>
   inline
-  const Row<eT>&
+  Row<eT>&
   Row<eT>::fixed<fixed_n_elem>::operator=(const eOp<T1, eop_type>& X)
     {
     arma_extra_debug_sigprint();
@@ -1349,7 +1349,7 @@ Row<eT>::fixed<fixed_n_elem>::operator=(const fixed<fixed_n_elem>& X)
   template<uword fixed_n_elem>
   template<typename T1, typename T2, typename eglue_type>
   inline
-  const Row<eT>&
+  Row<eT>&
   Row<eT>::fixed<fixed_n_elem>::operator=(const eGlue<T1, T2, eglue_type>& X)
     {
     arma_extra_debug_sigprint();

--- a/include/armadillo_bits/SpCol_bones.hpp
+++ b/include/armadillo_bits/SpCol_bones.hpp
@@ -35,19 +35,19 @@ class SpCol : public SpMat<eT>
   inline explicit SpCol(const uword n_elem);
   inline          SpCol(const uword in_rows, const uword in_cols);
   
-  inline                  SpCol(const char*        text);
-  inline const SpCol& operator=(const char*        text);
+  inline            SpCol(const char*        text);
+  inline SpCol& operator=(const char*        text);
   
-  inline                  SpCol(const std::string& text);
-  inline const SpCol& operator=(const std::string& text);
+  inline            SpCol(const std::string& text);
+  inline SpCol& operator=(const std::string& text);
   
-  inline const SpCol& operator=(const eT val);
+  inline SpCol& operator=(const eT val);
   
-  template<typename T1> inline                  SpCol(const Base<eT,T1>& X);
-  template<typename T1> inline const SpCol& operator=(const Base<eT,T1>& X);
+  template<typename T1> inline            SpCol(const Base<eT,T1>& X);
+  template<typename T1> inline SpCol& operator=(const Base<eT,T1>& X);
   
-  template<typename T1> inline                  SpCol(const SpBase<eT,T1>& X);
-  template<typename T1> inline const SpCol& operator=(const SpBase<eT,T1>& X);
+  template<typename T1> inline            SpCol(const SpBase<eT,T1>& X);
+  template<typename T1> inline SpCol& operator=(const SpBase<eT,T1>& X);
   
   template<typename T1, typename T2>
   inline explicit SpCol(const SpBase<pod_type,T1>& A, const SpBase<pod_type,T2>& B);

--- a/include/armadillo_bits/SpCol_meat.hpp
+++ b/include/armadillo_bits/SpCol_meat.hpp
@@ -76,7 +76,7 @@ SpCol<eT>::SpCol(const char* text)
 //! construct a column vector from specified text
 template<typename eT>
 inline
-const SpCol<eT>&
+SpCol<eT>&
 SpCol<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -108,7 +108,7 @@ SpCol<eT>::SpCol(const std::string& text)
 //! construct a column vector from specified text
 template<typename eT>
 inline
-const SpCol<eT>&
+SpCol<eT>&
 SpCol<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -122,7 +122,7 @@ SpCol<eT>::operator=(const std::string& text)
 
 template<typename eT>
 inline
-const SpCol<eT>&
+SpCol<eT>&
 SpCol<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -151,7 +151,7 @@ SpCol<eT>::SpCol(const Base<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const SpCol<eT>&
+SpCol<eT>&
 SpCol<eT>::operator=(const Base<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -182,7 +182,7 @@ SpCol<eT>::SpCol(const SpBase<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const SpCol<eT>&
+SpCol<eT>&
 SpCol<eT>::operator=(const SpBase<eT,T1>& X)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/SpMat_bones.hpp
+++ b/include/armadillo_bits/SpMat_bones.hpp
@@ -85,16 +85,16 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   inline explicit SpMat(const uword in_rows, const uword in_cols);
   inline explicit SpMat(const SizeMat& s);
   
-  inline                  SpMat(const char*        text);
-  inline const SpMat& operator=(const char*        text);
-  inline                  SpMat(const std::string& text);
-  inline const SpMat& operator=(const std::string& text);
-  inline                  SpMat(const SpMat<eT>&   x);
+  inline            SpMat(const char*        text);
+  inline SpMat& operator=(const char*        text);
+  inline            SpMat(const std::string& text);
+  inline SpMat& operator=(const std::string& text);
+  inline            SpMat(const SpMat<eT>&   x);
   
   
   #if defined(ARMA_USE_CXX11)
-  inline                  SpMat(SpMat&& m);
-  inline const SpMat& operator=(SpMat&& m);
+  inline            SpMat(SpMat&& m);
+  inline SpMat& operator=(SpMat&& m);
   #endif
   
   template<typename T1, typename T2, typename T3>
@@ -109,65 +109,65 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   template<typename T1, typename T2>
   inline SpMat(const bool add_values, const Base<uword,T1>& locations, const Base<eT,T2>& values, const uword n_rows, const uword n_cols, const bool sort_locations = true, const bool check_for_zeros = true);
   
-  inline const SpMat&  operator=(const eT val); //! sets size to 1x1
-  inline const SpMat& operator*=(const eT val);
-  inline const SpMat& operator/=(const eT val);
+  inline SpMat&  operator=(const eT val); //! sets size to 1x1
+  inline SpMat& operator*=(const eT val);
+  inline SpMat& operator/=(const eT val);
   // operator+=(val) and operator-=(val) are not defined as they don't make sense for sparse matrices
   
-  inline const SpMat&  operator=(const SpMat& m);
-  inline const SpMat& operator+=(const SpMat& m);
-  inline const SpMat& operator-=(const SpMat& m);
-  inline const SpMat& operator*=(const SpMat& m);
-  inline const SpMat& operator%=(const SpMat& m);
-  inline const SpMat& operator/=(const SpMat& m);
+  inline SpMat&  operator=(const SpMat& m);
+  inline SpMat& operator+=(const SpMat& m);
+  inline SpMat& operator-=(const SpMat& m);
+  inline SpMat& operator*=(const SpMat& m);
+  inline SpMat& operator%=(const SpMat& m);
+  inline SpMat& operator/=(const SpMat& m);
   
-  template<typename T1> inline explicit          SpMat(const Base<eT, T1>& m);
-  template<typename T1> inline const SpMat&  operator=(const Base<eT, T1>& m);
-  template<typename T1> inline const SpMat& operator+=(const Base<eT, T1>& m);
-  template<typename T1> inline const SpMat& operator-=(const Base<eT, T1>& m);
-  template<typename T1> inline const SpMat& operator*=(const Base<eT, T1>& m);
-  template<typename T1> inline const SpMat& operator/=(const Base<eT, T1>& m);
-  template<typename T1> inline const SpMat& operator%=(const Base<eT, T1>& m);
+  template<typename T1> inline explicit    SpMat(const Base<eT, T1>& m);
+  template<typename T1> inline SpMat&  operator=(const Base<eT, T1>& m);
+  template<typename T1> inline SpMat& operator+=(const Base<eT, T1>& m);
+  template<typename T1> inline SpMat& operator-=(const Base<eT, T1>& m);
+  template<typename T1> inline SpMat& operator*=(const Base<eT, T1>& m);
+  template<typename T1> inline SpMat& operator/=(const Base<eT, T1>& m);
+  template<typename T1> inline SpMat& operator%=(const Base<eT, T1>& m);
   
   
   //! construction of complex matrix out of two non-complex matrices
   template<typename T1, typename T2>
   inline explicit SpMat(const SpBase<pod_type, T1>& A, const SpBase<pod_type, T2>& B);
   
-  inline                   SpMat(const SpSubview<eT>& X);
-  inline const SpMat&  operator=(const SpSubview<eT>& X);
-  inline const SpMat& operator+=(const SpSubview<eT>& X);
-  inline const SpMat& operator-=(const SpSubview<eT>& X);
-  inline const SpMat& operator*=(const SpSubview<eT>& X);
-  inline const SpMat& operator%=(const SpSubview<eT>& X);
-  inline const SpMat& operator/=(const SpSubview<eT>& X);
+  inline             SpMat(const SpSubview<eT>& X);
+  inline SpMat&  operator=(const SpSubview<eT>& X);
+  inline SpMat& operator+=(const SpSubview<eT>& X);
+  inline SpMat& operator-=(const SpSubview<eT>& X);
+  inline SpMat& operator*=(const SpSubview<eT>& X);
+  inline SpMat& operator%=(const SpSubview<eT>& X);
+  inline SpMat& operator/=(const SpSubview<eT>& X);
   
   // delayed unary ops
-  template<typename T1, typename spop_type> inline                   SpMat(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat&  operator=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator+=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator-=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator*=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator%=(const SpOp<T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator/=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline             SpMat(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat&  operator=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator+=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator-=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator*=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator%=(const SpOp<T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator/=(const SpOp<T1, spop_type>& X);
   
   // delayed binary ops
-  template<typename T1, typename T2, typename spglue_type> inline                   SpMat(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline const SpMat&  operator=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator+=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator-=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator*=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator%=(const SpGlue<T1, T2, spglue_type>& X);
-  template<typename T1, typename T2, typename spglue_type> inline const SpMat& operator/=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline             SpMat(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline SpMat&  operator=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator+=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator-=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator*=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator%=(const SpGlue<T1, T2, spglue_type>& X);
+  template<typename T1, typename T2, typename spglue_type> inline SpMat& operator/=(const SpGlue<T1, T2, spglue_type>& X);
   
   // delayed mixed-type unary ops
-  template<typename T1, typename spop_type> inline                   SpMat(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat&  operator=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator+=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator-=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator*=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator%=(const mtSpOp<eT, T1, spop_type>& X);
-  template<typename T1, typename spop_type> inline const SpMat& operator/=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline             SpMat(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat&  operator=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator+=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator-=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator*=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator%=(const mtSpOp<eT, T1, spop_type>& X);
+  template<typename T1, typename spop_type> inline SpMat& operator/=(const mtSpOp<eT, T1, spop_type>& X);
   
   
   arma_inline       SpSubview<eT> row(const uword row_num);

--- a/include/armadillo_bits/SpMat_meat.hpp
+++ b/include/armadillo_bits/SpMat_meat.hpp
@@ -125,7 +125,7 @@ SpMat<eT>::SpMat(const char* text)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -158,7 +158,7 @@ SpMat<eT>::SpMat(const std::string& text)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -213,7 +213,7 @@ SpMat<eT>::SpMat(const SpMat<eT>& x)
   
   template<typename eT>
   inline
-  const SpMat<eT>&
+  SpMat<eT>&
   SpMat<eT>::operator=(SpMat<eT>&& in_mat)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   in_mat = %x") % this % &in_mat);
@@ -514,7 +514,7 @@ SpMat<eT>::SpMat
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -542,7 +542,7 @@ SpMat<eT>::operator=(const eT val)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -566,7 +566,7 @@ SpMat<eT>::operator*=(const eT val)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator/=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -584,7 +584,7 @@ SpMat<eT>::operator/=(const eT val)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -598,7 +598,7 @@ SpMat<eT>::operator=(const SpMat<eT>& x)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator+=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -614,7 +614,7 @@ SpMat<eT>::operator+=(const SpMat<eT>& x)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator-=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -630,7 +630,7 @@ SpMat<eT>::operator-=(const SpMat<eT>& x)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator*=(const SpMat<eT>& y)
   {
   arma_extra_debug_sigprint();
@@ -647,7 +647,7 @@ SpMat<eT>::operator*=(const SpMat<eT>& y)
 // This is in-place element-wise matrix multiplication.
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator%=(const SpMat<eT>& y)
   {
   arma_extra_debug_sigprint();
@@ -760,7 +760,7 @@ SpMat<eT>::SpMat
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator/=(const SpMat<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -805,7 +805,7 @@ SpMat<eT>::SpMat(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const Base<eT, T1>& expr)
   {
   arma_extra_debug_sigprint();
@@ -861,7 +861,7 @@ SpMat<eT>::operator=(const Base<eT, T1>& expr)
 template<typename eT>
 template<typename T1>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator+=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -874,7 +874,7 @@ SpMat<eT>::operator+=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator-=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -887,7 +887,7 @@ SpMat<eT>::operator-=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator*=(const Base<eT, T1>& y)
   {
   arma_extra_debug_sigprint();
@@ -985,7 +985,7 @@ SpMat<eT>::operator*=(const Base<eT, T1>& y)
 template<typename eT>
 template<typename T1>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator/=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -1002,7 +1002,7 @@ SpMat<eT>::operator/=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator%=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -1083,7 +1083,7 @@ SpMat<eT>::SpMat(const SpSubview<eT>& X)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1133,7 +1133,7 @@ SpMat<eT>::operator=(const SpSubview<eT>& X)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator+=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1149,7 +1149,7 @@ SpMat<eT>::operator+=(const SpSubview<eT>& X)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator-=(const SpSubview<eT>& X)
   {
   arma_extra_debug_sigprint();
@@ -1165,7 +1165,7 @@ SpMat<eT>::operator-=(const SpSubview<eT>& X)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator*=(const SpSubview<eT>& y)
   {
   arma_extra_debug_sigprint();
@@ -1181,7 +1181,7 @@ SpMat<eT>::operator*=(const SpSubview<eT>& y)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator%=(const SpSubview<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -1197,7 +1197,7 @@ SpMat<eT>::operator%=(const SpSubview<eT>& x)
 
 template<typename eT>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator/=(const SpSubview<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -1240,7 +1240,7 @@ SpMat<eT>::SpMat(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1257,7 +1257,7 @@ SpMat<eT>::operator=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator+=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1274,7 +1274,7 @@ SpMat<eT>::operator+=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator-=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1291,7 +1291,7 @@ SpMat<eT>::operator-=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator*=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1308,7 +1308,7 @@ SpMat<eT>::operator*=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator%=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1325,7 +1325,7 @@ SpMat<eT>::operator%=(const SpOp<T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator/=(const SpOp<T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1384,7 +1384,7 @@ SpMat<eT>::SpMat(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1399,7 +1399,7 @@ SpMat<eT>::operator=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator+=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1414,7 +1414,7 @@ SpMat<eT>::operator+=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator-=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1429,7 +1429,7 @@ SpMat<eT>::operator-=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator*=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1444,7 +1444,7 @@ SpMat<eT>::operator*=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator%=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1459,7 +1459,7 @@ SpMat<eT>::operator%=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename spop_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator/=(const mtSpOp<eT, T1, spop_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1474,7 +1474,7 @@ SpMat<eT>::operator/=(const mtSpOp<eT, T1, spop_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1491,7 +1491,7 @@ SpMat<eT>::operator=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator+=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1508,7 +1508,7 @@ SpMat<eT>::operator+=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator-=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1525,7 +1525,7 @@ SpMat<eT>::operator-=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator*=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1542,7 +1542,7 @@ SpMat<eT>::operator*=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator%=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();
@@ -1559,7 +1559,7 @@ SpMat<eT>::operator%=(const SpGlue<T1, T2, spglue_type>& X)
 template<typename eT>
 template<typename T1, typename T2, typename spglue_type>
 inline
-const SpMat<eT>&
+SpMat<eT>&
 SpMat<eT>::operator/=(const SpGlue<T1, T2, spglue_type>& X)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/SpRow_bones.hpp
+++ b/include/armadillo_bits/SpRow_bones.hpp
@@ -35,19 +35,19 @@ class SpRow : public SpMat<eT>
   inline explicit SpRow(const uword N);
   inline          SpRow(const uword in_rows, const uword in_cols);
   
-  inline                  SpRow(const char*        text);
-  inline const SpRow& operator=(const char*        text);
+  inline            SpRow(const char*        text);
+  inline SpRow& operator=(const char*        text);
   
-  inline                  SpRow(const std::string& text);
-  inline const SpRow& operator=(const std::string& text);
+  inline            SpRow(const std::string& text);
+  inline SpRow& operator=(const std::string& text);
   
-  inline const SpRow& operator=(const eT val);
+  inline SpRow& operator=(const eT val);
   
-  template<typename T1> inline                  SpRow(const Base<eT,T1>& X);
-  template<typename T1> inline const SpRow& operator=(const Base<eT,T1>& X);
+  template<typename T1> inline            SpRow(const Base<eT,T1>& X);
+  template<typename T1> inline SpRow& operator=(const Base<eT,T1>& X);
   
-  template<typename T1> inline                  SpRow(const SpBase<eT,T1>& X);
-  template<typename T1> inline const SpRow& operator=(const SpBase<eT,T1>& X);
+  template<typename T1> inline            SpRow(const SpBase<eT,T1>& X);
+  template<typename T1> inline SpRow& operator=(const SpBase<eT,T1>& X);
   
   template<typename T1, typename T2>
   inline explicit SpRow(const SpBase<pod_type,T1>& A, const SpBase<pod_type,T2>& B);

--- a/include/armadillo_bits/SpRow_meat.hpp
+++ b/include/armadillo_bits/SpRow_meat.hpp
@@ -73,7 +73,7 @@ SpRow<eT>::SpRow(const char* text)
 
 template<typename eT>
 inline
-const SpRow<eT>&
+SpRow<eT>&
 SpRow<eT>::operator=(const char* text)
   {
   arma_extra_debug_sigprint();
@@ -103,7 +103,7 @@ SpRow<eT>::SpRow(const std::string& text)
 
 template<typename eT>
 inline
-const SpRow<eT>&
+SpRow<eT>&
 SpRow<eT>::operator=(const std::string& text)
   {
   arma_extra_debug_sigprint();
@@ -117,7 +117,7 @@ SpRow<eT>::operator=(const std::string& text)
 
 template<typename eT>
 inline
-const SpRow<eT>&
+SpRow<eT>&
 SpRow<eT>::operator=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -146,7 +146,7 @@ SpRow<eT>::SpRow(const Base<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const SpRow<eT>&
+SpRow<eT>&
 SpRow<eT>::operator=(const Base<eT,T1>& X)
   {
   arma_extra_debug_sigprint();
@@ -175,7 +175,7 @@ SpRow<eT>::SpRow(const SpBase<eT,T1>& X)
 template<typename eT>
 template<typename T1>
 inline
-const SpRow<eT>&
+SpRow<eT>&
 SpRow<eT>::operator=(const SpBase<eT,T1>& X)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/SpSubview_bones.hpp
+++ b/include/armadillo_bits/SpSubview_bones.hpp
@@ -50,28 +50,28 @@ class SpSubview : public SpBase<eT, SpSubview<eT> >
 
   inline ~SpSubview();
 
-  inline const SpSubview& operator+= (const eT val);
-  inline const SpSubview& operator-= (const eT val);
-  inline const SpSubview& operator*= (const eT val);
-  inline const SpSubview& operator/= (const eT val);
+  inline SpSubview& operator+= (const eT val);
+  inline SpSubview& operator-= (const eT val);
+  inline SpSubview& operator*= (const eT val);
+  inline SpSubview& operator/= (const eT val);
 
-  inline const SpSubview& operator=(const SpSubview& x);
+  inline SpSubview& operator=(const SpSubview& x);
 
-  template<typename T1> inline const SpSubview& operator= (const Base<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator+=(const Base<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator-=(const Base<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator*=(const Base<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator%=(const Base<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator/=(const Base<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator= (const Base<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator+=(const Base<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator-=(const Base<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator*=(const Base<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator%=(const Base<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator/=(const Base<eT, T1>& x);
 
-  template<typename T1> inline const SpSubview& operator_equ_common(const SpBase<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator_equ_common(const SpBase<eT, T1>& x);
   
-  template<typename T1> inline const SpSubview& operator= (const SpBase<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator+=(const SpBase<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator-=(const SpBase<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator*=(const SpBase<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator%=(const SpBase<eT, T1>& x);
-  template<typename T1> inline const SpSubview& operator/=(const SpBase<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator= (const SpBase<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator+=(const SpBase<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator-=(const SpBase<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator*=(const SpBase<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator%=(const SpBase<eT, T1>& x);
+  template<typename T1> inline SpSubview& operator/=(const SpBase<eT, T1>& x);
 
   /*
   inline static void extract(SpMat<eT>& out, const SpSubview& in);

--- a/include/armadillo_bits/SpSubview_meat.hpp
+++ b/include/armadillo_bits/SpSubview_meat.hpp
@@ -93,7 +93,7 @@ SpSubview<eT>::~SpSubview()
 
 template<typename eT>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator+=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -114,7 +114,7 @@ SpSubview<eT>::operator+=(const eT val)
 
 template<typename eT>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator-=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -135,7 +135,7 @@ SpSubview<eT>::operator-=(const eT val)
 
 template<typename eT>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator*=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -181,7 +181,7 @@ SpSubview<eT>::operator*=(const eT val)
 
 template<typename eT>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator/=(const eT val)
   {
   arma_extra_debug_sigprint();
@@ -230,7 +230,7 @@ SpSubview<eT>::operator/=(const eT val)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator=(const Base<eT, T1>& in)
   {
   arma_extra_debug_sigprint();
@@ -431,7 +431,7 @@ SpSubview<eT>::operator=(const Base<eT, T1>& in)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator+=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -444,7 +444,7 @@ SpSubview<eT>::operator+=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator-=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -457,7 +457,7 @@ SpSubview<eT>::operator-=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator*=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -474,7 +474,7 @@ SpSubview<eT>::operator*=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator%=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -487,7 +487,7 @@ SpSubview<eT>::operator%=(const Base<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator/=(const Base<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -499,7 +499,7 @@ SpSubview<eT>::operator/=(const Base<eT, T1>& x)
 
 template<typename eT>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator=(const SpSubview<eT>& x)
   {
   arma_extra_debug_sigprint();
@@ -512,7 +512,7 @@ SpSubview<eT>::operator=(const SpSubview<eT>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -525,7 +525,7 @@ SpSubview<eT>::operator=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator_equ_common(const SpBase<eT, T1>& in)
   {
   arma_extra_debug_sigprint();
@@ -721,7 +721,7 @@ SpSubview<eT>::operator_equ_common(const SpBase<eT, T1>& in)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator+=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -735,7 +735,7 @@ SpSubview<eT>::operator+=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator-=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -749,7 +749,7 @@ SpSubview<eT>::operator-=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator*=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -762,7 +762,7 @@ SpSubview<eT>::operator*=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator%=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();
@@ -777,7 +777,7 @@ SpSubview<eT>::operator%=(const SpBase<eT, T1>& x)
 template<typename eT>
 template<typename T1>
 inline
-const SpSubview<eT>&
+SpSubview<eT>&
 SpSubview<eT>::operator/=(const SpBase<eT, T1>& x)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/arma_version.hpp
+++ b/include/armadillo_bits/arma_version.hpp
@@ -20,9 +20,9 @@
 
 
 #define ARMA_VERSION_MAJOR 7
-#define ARMA_VERSION_MINOR 800
-#define ARMA_VERSION_PATCH 1
-#define ARMA_VERSION_NAME  "Rogue State Redux"
+#define ARMA_VERSION_MINOR 900
+#define ARMA_VERSION_PATCH 0
+#define ARMA_VERSION_NAME  "unstable development version"
 
 
 

--- a/include/armadillo_bits/arma_version.hpp
+++ b/include/armadillo_bits/arma_version.hpp
@@ -20,7 +20,7 @@
 
 
 #define ARMA_VERSION_MAJOR 7
-#define ARMA_VERSION_MINOR 900
+#define ARMA_VERSION_MINOR 899
 #define ARMA_VERSION_PATCH 0
 #define ARMA_VERSION_NAME  "unstable development version"
 

--- a/include/armadillo_bits/compiler_setup.hpp
+++ b/include/armadillo_bits/compiler_setup.hpp
@@ -354,6 +354,8 @@
     #endif
   #endif
   
+  #undef  arma_deprecated
+  #define arma_deprecated __declspec(deprecated)
   // #undef  arma_inline
   // #define arma_inline inline __forceinline
   

--- a/include/armadillo_bits/compiler_setup.hpp
+++ b/include/armadillo_bits/compiler_setup.hpp
@@ -318,6 +318,10 @@
 
 #if defined(__INTEL_COMPILER)
   
+  #if (__INTEL_COMPILER == 9999)
+    #error "*** Need a newer compiler ***"
+  #endif
+  
   #if (__INTEL_COMPILER < 1300)
     #error "*** Need a newer compiler ***"
   #endif

--- a/include/armadillo_bits/debug.hpp
+++ b/include/armadillo_bits/debug.hpp
@@ -335,7 +335,7 @@ inline
 void
 arma_check(const bool state, const T1& x)
   {
-  if(state == true)  { arma_stop_logic_error(arma_str::str_wrapper(x)); }
+  if(state)  { arma_stop_logic_error(arma_str::str_wrapper(x)); }
   }
 
 
@@ -345,7 +345,7 @@ inline
 void
 arma_check(const bool state, const T1& x, const T2& y)
   {
-  if(state == true)  { arma_stop_logic_error( std::string(x) + std::string(y) ); }
+  if(state)  { arma_stop_logic_error( std::string(x) + std::string(y) ); }
   }
 
 
@@ -355,7 +355,7 @@ inline
 void
 arma_check_bad_alloc(const bool state, const T1& x)
   {
-  if(state == true)  { arma_stop_bad_alloc(x); }
+  if(state)  { arma_stop_bad_alloc(x); }
   }
 
 

--- a/include/armadillo_bits/diskio_meat.hpp
+++ b/include/armadillo_bits/diskio_meat.hpp
@@ -1624,6 +1624,8 @@ diskio::load_csv_ascii(Mat<eT>& x, std::istream& f, std::string&)
   {
   arma_extra_debug_sigprint();
   
+  // TODO: add handling of complex numbers, with each element stored in "a+ib" format
+  
   bool load_okay = f.good();
   
   f.clear();

--- a/include/armadillo_bits/diskio_meat.hpp
+++ b/include/armadillo_bits/diskio_meat.hpp
@@ -797,13 +797,17 @@ diskio::save_raw_ascii(const Mat<eT>& x, std::ostream& f)
   
   uword cell_width;
   
-  // TODO: need sane values for complex numbers
-  
-  if( (is_float<eT>::value) || (is_double<eT>::value) )
+  if(is_real<eT>::value)
     {
     f.setf(ios::scientific);
     f.precision(14);
     cell_width = 22;
+    }
+  
+  if(is_cx<eT>::value)
+    {
+    f.setf(ios::scientific);
+    f.precision(14);
     }
   
   for(uword row=0; row < x.n_rows; ++row)
@@ -812,14 +816,14 @@ diskio::save_raw_ascii(const Mat<eT>& x, std::ostream& f)
       {
       f.put(' ');
       
-      if( (is_float<eT>::value) || (is_double<eT>::value) )
+      if(is_real<eT>::value)
         {
         f.width(std::streamsize(cell_width));
         }
       
       arma_ostream::print_elem(f, x.at(row,col), false);
       }
-      
+    
     f.put('\n');
     }
   
@@ -923,22 +927,26 @@ diskio::save_arma_ascii(const Mat<eT>& x, std::ostream& f)
   
   uword cell_width;
   
-  // TODO: need sane values for complex numbers
-  
-  if( (is_float<eT>::value) || (is_double<eT>::value) )
+  if(is_real<eT>::value)
     {
     f.setf(ios::scientific);
     f.precision(14);
     cell_width = 22;
     }
-    
+  
+  if(is_cx<eT>::value)
+    {
+    f.setf(ios::scientific);
+    f.precision(14);
+    }
+  
   for(uword row=0; row < x.n_rows; ++row)
     {
     for(uword col=0; col < x.n_cols; ++col)
       {
       f.put(' ');
       
-      if( (is_float<eT>::value) || (is_double<eT>::value) )        
+      if(is_real<eT>::value)
         {
         f.width(std::streamsize(cell_width));
         }
@@ -1000,7 +1008,7 @@ diskio::save_csv_ascii(const Mat<eT>& x, std::ostream& f)
   
   const ios::fmtflags orig_flags = f.flags();
   
-  // TODO: need sane values for complex numbers
+  // TODO: need to write each complex elements as "a+ib" instead of the default "(a,b)"
   
   if( (is_float<eT>::value) || (is_double<eT>::value) )
     {
@@ -3138,13 +3146,17 @@ diskio::save_raw_ascii(const Cube<eT>& x, std::ostream& f)
   
   uword cell_width;
   
-  // TODO: need sane values for complex numbers
-  
-  if( (is_float<eT>::value) || (is_double<eT>::value) )
+  if(is_real<eT>::value)
     {
     f.setf(ios::scientific);
     f.precision(14);
     cell_width = 22;
+    }
+  
+  if(is_cx<eT>::value)
+    {
+    f.setf(ios::scientific);
+    f.precision(14);
     }
   
   for(uword slice=0; slice < x.n_slices; ++slice)
@@ -3155,7 +3167,7 @@ diskio::save_raw_ascii(const Cube<eT>& x, std::ostream& f)
         {
         f.put(' ');
         
-        if( (is_float<eT>::value) || (is_double<eT>::value) )
+        if(is_real<eT>::value)
           {
           f.width(std::streamsize(cell_width));
           }
@@ -3267,15 +3279,19 @@ diskio::save_arma_ascii(const Cube<eT>& x, std::ostream& f)
   
   uword cell_width;
   
-  // TODO: need sane values for complex numbers
-  
-  if( (is_float<eT>::value) || (is_double<eT>::value) )
+  if(is_real<eT>::value)
     {
     f.setf(ios::scientific);
     f.precision(14);
     cell_width = 22;
     }
-    
+  
+  if(is_cx<eT>::value)
+    {
+    f.setf(ios::scientific);
+    f.precision(14);
+    }
+  
   for(uword slice=0; slice < x.n_slices; ++slice)
     {
     for(uword row=0; row < x.n_rows; ++row)
@@ -3284,7 +3300,7 @@ diskio::save_arma_ascii(const Cube<eT>& x, std::ostream& f)
         {
         f.put(' ');
         
-        if( (is_float<eT>::value) || (is_double<eT>::value) )        
+        if(is_real<eT>::value)
           {
           f.width(std::streamsize(cell_width));
           }

--- a/include/armadillo_bits/diskio_meat.hpp
+++ b/include/armadillo_bits/diskio_meat.hpp
@@ -1008,7 +1008,7 @@ diskio::save_csv_ascii(const Mat<eT>& x, std::ostream& f)
   
   const ios::fmtflags orig_flags = f.flags();
   
-  // TODO: need to write each complex elements as "a+ib" instead of the default "(a,b)"
+  // TODO: need to write each complex element as "a+ib" instead of the default "(a,b)"
   
   if( (is_float<eT>::value) || (is_double<eT>::value) )
     {

--- a/include/armadillo_bits/eOpCube_meat.hpp
+++ b/include/armadillo_bits/eOpCube_meat.hpp
@@ -20,6 +20,7 @@
 
 
 template<typename T1, typename eop_type>
+inline
 eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m)
   : P (in_m.get_ref())
   {
@@ -29,6 +30,7 @@ eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m)
 
 
 template<typename T1, typename eop_type>
+inline
 eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m, const typename T1::elem_type in_aux)
   : P   (in_m.get_ref())
   , aux (in_aux)
@@ -39,6 +41,7 @@ eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m,
 
 
 template<typename T1, typename eop_type>
+inline
 eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m, const uword in_aux_uword_a, const uword in_aux_uword_b)
   : P           (in_m.get_ref())
   , aux_uword_a (in_aux_uword_a)
@@ -50,6 +53,7 @@ eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m,
 
 
 template<typename T1, typename eop_type>
+inline
 eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m, const uword in_aux_uword_a, const uword in_aux_uword_b, const uword in_aux_uword_c)
   : P           (in_m.get_ref())
   , aux_uword_a (in_aux_uword_a)
@@ -62,6 +66,7 @@ eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m,
 
 
 template<typename T1, typename eop_type>
+inline
 eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m, const typename T1::elem_type in_aux, const uword in_aux_uword_a, const uword in_aux_uword_b, const uword in_aux_uword_c)
   : P           (in_m.get_ref())
   , aux         (in_aux)
@@ -75,6 +80,7 @@ eOpCube<T1, eop_type>::eOpCube(const BaseCube<typename T1::elem_type, T1>& in_m,
 
 
 template<typename T1, typename eop_type>
+inline
 eOpCube<T1, eop_type>::~eOpCube()
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/eOp_meat.hpp
+++ b/include/armadillo_bits/eOp_meat.hpp
@@ -20,6 +20,7 @@
 
 
 template<typename T1, typename eop_type>
+inline
 eOp<T1, eop_type>::eOp(const T1& in_m)
   : P(in_m)
   {
@@ -29,6 +30,7 @@ eOp<T1, eop_type>::eOp(const T1& in_m)
 
 
 template<typename T1, typename eop_type>
+inline
 eOp<T1, eop_type>::eOp(const T1& in_m, const typename T1::elem_type in_aux)
   : P(in_m)
   , aux(in_aux)
@@ -39,6 +41,7 @@ eOp<T1, eop_type>::eOp(const T1& in_m, const typename T1::elem_type in_aux)
 
 
 template<typename T1, typename eop_type>
+inline
 eOp<T1, eop_type>::eOp(const T1& in_m, const uword in_aux_uword_a, const uword in_aux_uword_b)
   : P(in_m)
   , aux_uword_a(in_aux_uword_a)
@@ -50,6 +53,7 @@ eOp<T1, eop_type>::eOp(const T1& in_m, const uword in_aux_uword_a, const uword i
 
 
 template<typename T1, typename eop_type>
+inline
 eOp<T1, eop_type>::eOp(const T1& in_m, const typename T1::elem_type in_aux, const uword in_aux_uword_a, const uword in_aux_uword_b)
   : P(in_m)
   , aux(in_aux)
@@ -62,6 +66,7 @@ eOp<T1, eop_type>::eOp(const T1& in_m, const typename T1::elem_type in_aux, cons
 
 
 template<typename T1, typename eop_type>
+inline
 eOp<T1, eop_type>::~eOp()
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/field_bones.hpp
+++ b/include/armadillo_bits/field_bones.hpp
@@ -53,11 +53,11 @@ class field
   inline ~field();
   inline  field();
   
-  inline                  field(const field& x);
-  inline const field& operator=(const field& x);
+  inline            field(const field& x);
+  inline field& operator=(const field& x);
   
-  inline                  field(const subview_field<oT>& x);
-  inline const field& operator=(const subview_field<oT>& x);
+  inline            field(const subview_field<oT>& x);
+  inline field& operator=(const subview_field<oT>& x);
   
   inline explicit field(const uword n_elem_in);
   inline explicit field(const uword n_rows_in, const uword n_cols_in);
@@ -72,14 +72,14 @@ class field
   inline void  set_size(const SizeCube& s);
   
   #if defined(ARMA_USE_CXX11)
-  inline                  field(const std::initializer_list<oT>& list);
-  inline const field& operator=(const std::initializer_list<oT>& list);
+  inline            field(const std::initializer_list<oT>& list);
+  inline field& operator=(const std::initializer_list<oT>& list);
   
-  inline                  field(const std::initializer_list< std::initializer_list<oT> >& list);
-  inline const field& operator=(const std::initializer_list< std::initializer_list<oT> >& list);
+  inline            field(const std::initializer_list< std::initializer_list<oT> >& list);
+  inline field& operator=(const std::initializer_list< std::initializer_list<oT> >& list);
   
-  inline                  field(field&& X);
-  inline const field& operator=(field&& X);
+  inline            field(field&& X);
+  inline field& operator=(field&& X);
   #endif
   
   template<typename oT2>

--- a/include/armadillo_bits/field_meat.hpp
+++ b/include/armadillo_bits/field_meat.hpp
@@ -74,7 +74,7 @@ field<oT>::field(const field& x)
 //! construct a field from a given field
 template<typename oT>
 inline
-const field<oT>&
+field<oT>&
 field<oT>::operator=(const field& x)
   {
   arma_extra_debug_sigprint();
@@ -105,7 +105,7 @@ field<oT>::field(const subview_field<oT>& X)
 //! construct a field from subview_field (e.g. construct a field from a delayed subfield operation)
 template<typename oT>
 inline
-const field<oT>&
+field<oT>&
 field<oT>::operator=(const subview_field<oT>& X)
   {
   arma_extra_debug_sigprint();
@@ -279,7 +279,7 @@ field<oT>::set_size(const SizeCube& s)
   
   template<typename oT>
   inline
-  const field<oT>&
+  field<oT>&
   field<oT>::operator=(const std::initializer_list<oT>& list)
     {
     arma_extra_debug_sigprint();
@@ -317,7 +317,7 @@ field<oT>::set_size(const SizeCube& s)
   
   template<typename oT>
   inline
-  const field<oT>&
+  field<oT>&
   field<oT>::operator=(const std::initializer_list< std::initializer_list<oT> >& list)
     {
     arma_extra_debug_sigprint();
@@ -404,7 +404,7 @@ field<oT>::set_size(const SizeCube& s)
   
   template<typename oT>
   inline
-  const field<oT>&
+  field<oT>&
   field<oT>::operator=(field<oT>&& X)
     {
     arma_extra_debug_sigprint(arma_str::format("this = %x   X = %x") % this % &X);

--- a/include/armadillo_bits/fn_log_det.hpp
+++ b/include/armadillo_bits/fn_log_det.hpp
@@ -121,7 +121,7 @@ log_det
   
   log_det(out_val, out_sign, X.get_ref());
   
-  return (is_cx<eT>::yes) ? std::complex<T>(out_val) : ( (out_sign >= T(1)) ? std::complex<T>(access::tmp_real(out_val),T(0)) : std::complex<T>(access::tmp_real(out_val),Datum<T>::pi) );
+  return (out_sign >= T(1)) ? std::complex<T>(out_val) : (out_val + std::complex<T>(T(0),Datum<T>::pi));
   }
 
 

--- a/include/armadillo_bits/gmm_diag_bones.hpp
+++ b/include/armadillo_bits/gmm_diag_bones.hpp
@@ -86,8 +86,8 @@ class gmm_diag
   inline ~gmm_diag();
   inline  gmm_diag();
   
-  inline                  gmm_diag(const gmm_diag& x);
-  inline const gmm_diag& operator=(const gmm_diag& x);
+  inline            gmm_diag(const gmm_diag& x);
+  inline gmm_diag& operator=(const gmm_diag& x);
   
   inline      gmm_diag(const uword in_n_dims, const uword in_n_gaus);
   inline void    reset(const uword in_n_dims, const uword in_n_gaus);

--- a/include/armadillo_bits/gmm_diag_meat.hpp
+++ b/include/armadillo_bits/gmm_diag_meat.hpp
@@ -55,7 +55,7 @@ gmm_diag<eT>::gmm_diag(const gmm_diag<eT>& x)
 
 template<typename eT>
 inline
-const gmm_diag<eT>&
+gmm_diag<eT>&
 gmm_diag<eT>::operator=(const gmm_diag<eT>& x)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/gmm_misc_bones.hpp
+++ b/include/armadillo_bits/gmm_misc_bones.hpp
@@ -32,7 +32,7 @@ class running_mean_scalar
   inline running_mean_scalar();
   inline running_mean_scalar(const running_mean_scalar& in_rms);
   
-  inline const running_mean_scalar& operator=(const running_mean_scalar& in_rms);
+  inline running_mean_scalar& operator=(const running_mean_scalar& in_rms);
   
   arma_hot inline void operator() (const eT X);
   
@@ -60,7 +60,7 @@ class running_mean_vec
   inline running_mean_vec();
   inline running_mean_vec(const running_mean_vec& in_rmv);
   
-  inline const running_mean_vec& operator=(const running_mean_vec& in_rmv);
+  inline running_mean_vec& operator=(const running_mean_vec& in_rmv);
   
   arma_hot inline void operator() (const Col<eT>& X, const uword index);
   

--- a/include/armadillo_bits/gmm_misc_meat.hpp
+++ b/include/armadillo_bits/gmm_misc_meat.hpp
@@ -46,7 +46,7 @@ running_mean_scalar<eT>::running_mean_scalar(const running_mean_scalar<eT>& in)
 
 template<typename eT>
 inline
-const running_mean_scalar<eT>&
+running_mean_scalar<eT>&
 running_mean_scalar<eT>::operator=(const running_mean_scalar<eT>& in)
   {
   arma_extra_debug_sigprint();
@@ -147,7 +147,7 @@ running_mean_vec<eT>::running_mean_vec(const running_mean_vec<eT>& in)
 
 template<typename eT>
 inline
-const running_mean_vec<eT>&
+running_mean_vec<eT>&
 running_mean_vec<eT>::operator=(const running_mean_vec<eT>& in)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/podarray_bones.hpp
+++ b/include/armadillo_bits/podarray_bones.hpp
@@ -46,8 +46,8 @@ class podarray
   inline ~podarray();
   inline  podarray();
   
-  inline                 podarray (const podarray& x);
-  inline const podarray& operator=(const podarray& x);
+  inline           podarray (const podarray& x);
+  inline podarray& operator=(const podarray& x);
   
   arma_inline explicit podarray(const uword new_N);
   

--- a/include/armadillo_bits/podarray_meat.hpp
+++ b/include/armadillo_bits/podarray_meat.hpp
@@ -62,7 +62,7 @@ podarray<eT>::podarray(const podarray& x)
 
 template<typename eT>
 inline
-const podarray<eT>&
+podarray<eT>&
 podarray<eT>::operator=(const podarray& x)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/running_stat_vec_bones.hpp
+++ b/include/armadillo_bits/running_stat_vec_bones.hpp
@@ -60,7 +60,7 @@ class running_stat_vec
   
   inline running_stat_vec(const running_stat_vec& in_rsv);
   
-  inline const running_stat_vec& operator=(const running_stat_vec& in_rsv);
+  inline running_stat_vec& operator=(const running_stat_vec& in_rsv);
   
   template<typename T1> arma_hot inline void operator() (const Base<              T, T1>& X);
   template<typename T1> arma_hot inline void operator() (const Base<std::complex<T>, T1>& X);

--- a/include/armadillo_bits/running_stat_vec_meat.hpp
+++ b/include/armadillo_bits/running_stat_vec_meat.hpp
@@ -58,7 +58,7 @@ running_stat_vec<obj_type>::running_stat_vec(const running_stat_vec<obj_type>& i
 
 template<typename obj_type>
 inline
-const running_stat_vec<obj_type>&
+running_stat_vec<obj_type>&
 running_stat_vec<obj_type>::operator=(const running_stat_vec<obj_type>& in_rsv)
   {
   arma_extra_debug_sigprint();

--- a/include/armadillo_bits/typedef_mat.hpp
+++ b/include/armadillo_bits/typedef_mat.hpp
@@ -68,6 +68,12 @@ typedef Col <float> fcolvec;
 typedef Row <float> frowvec;
 typedef Cube<float> fcube;
 
+typedef Mat <double> dmat;
+typedef Col <double> dvec;
+typedef Col <double> dcolvec;
+typedef Row <double> drowvec;
+typedef Cube<double> dcube;
+
 typedef Mat <double> mat;
 typedef Col <double> vec;
 typedef Col <double> colvec;
@@ -79,6 +85,12 @@ typedef Col <cx_float> cx_fvec;
 typedef Col <cx_float> cx_fcolvec;
 typedef Row <cx_float> cx_frowvec;
 typedef Cube<cx_float> cx_fcube;
+
+typedef Mat <cx_double> cx_dmat;
+typedef Col <cx_double> cx_dvec;
+typedef Col <cx_double> cx_dcolvec;
+typedef Row <cx_double> cx_drowvec;
+typedef Cube<cx_double> cx_dcube;
 
 typedef Mat <cx_double> cx_mat;
 typedef Col <cx_double> cx_vec;
@@ -103,6 +115,11 @@ typedef SpCol <float> sp_fvec;
 typedef SpCol <float> sp_fcolvec;
 typedef SpRow <float> sp_frowvec;
 
+typedef SpMat <double> sp_dmat;
+typedef SpCol <double> sp_dvec;
+typedef SpCol <double> sp_dcolvec;
+typedef SpRow <double> sp_drowvec;
+
 typedef SpMat <double> sp_mat;
 typedef SpCol <double> sp_vec;
 typedef SpCol <double> sp_colvec;
@@ -112,6 +129,11 @@ typedef SpMat <cx_float> sp_cx_fmat;
 typedef SpCol <cx_float> sp_cx_fvec;
 typedef SpCol <cx_float> sp_cx_fcolvec;
 typedef SpRow <cx_float> sp_cx_frowvec;
+
+typedef SpMat <cx_double> sp_cx_dmat;
+typedef SpCol <cx_double> sp_cx_dvec;
+typedef SpCol <cx_double> sp_cx_dcolvec;
+typedef SpRow <cx_double> sp_cx_drowvec;
 
 typedef SpMat <cx_double> sp_cx_mat;
 typedef SpCol <cx_double> sp_cx_vec;

--- a/include/armadillo_bits/typedef_mat_fixed.hpp
+++ b/include/armadillo_bits/typedef_mat_fixed.hpp
@@ -46,6 +46,15 @@ typedef fmat::fixed<7,7> fmat77;
 typedef fmat::fixed<8,8> fmat88;
 typedef fmat::fixed<9,9> fmat99;
 
+typedef dmat::fixed<2,2> dmat22;
+typedef dmat::fixed<3,3> dmat33;
+typedef dmat::fixed<4,4> dmat44;
+typedef dmat::fixed<5,5> dmat55;
+typedef dmat::fixed<6,6> dmat66;
+typedef dmat::fixed<7,7> dmat77;
+typedef dmat::fixed<8,8> dmat88;
+typedef dmat::fixed<9,9> dmat99;
+
 typedef mat::fixed<2,2> mat22;
 typedef mat::fixed<3,3> mat33;
 typedef mat::fixed<4,4> mat44;
@@ -63,6 +72,15 @@ typedef cx_fmat::fixed<6,6> cx_fmat66;
 typedef cx_fmat::fixed<7,7> cx_fmat77;
 typedef cx_fmat::fixed<8,8> cx_fmat88;
 typedef cx_fmat::fixed<9,9> cx_fmat99;
+
+typedef cx_dmat::fixed<2,2> cx_dmat22;
+typedef cx_dmat::fixed<3,3> cx_dmat33;
+typedef cx_dmat::fixed<4,4> cx_dmat44;
+typedef cx_dmat::fixed<5,5> cx_dmat55;
+typedef cx_dmat::fixed<6,6> cx_dmat66;
+typedef cx_dmat::fixed<7,7> cx_dmat77;
+typedef cx_dmat::fixed<8,8> cx_dmat88;
+typedef cx_dmat::fixed<9,9> cx_dmat99;
 
 typedef cx_mat::fixed<2,2> cx_mat22;
 typedef cx_mat::fixed<3,3> cx_mat33;
@@ -104,6 +122,15 @@ typedef fvec::fixed<7> fvec7;
 typedef fvec::fixed<8> fvec8;
 typedef fvec::fixed<9> fvec9;
 
+typedef dvec::fixed<2> dvec2;
+typedef dvec::fixed<3> dvec3;
+typedef dvec::fixed<4> dvec4;
+typedef dvec::fixed<5> dvec5;
+typedef dvec::fixed<6> dvec6;
+typedef dvec::fixed<7> dvec7;
+typedef dvec::fixed<8> dvec8;
+typedef dvec::fixed<9> dvec9;
+
 typedef vec::fixed<2> vec2;
 typedef vec::fixed<3> vec3;
 typedef vec::fixed<4> vec4;
@@ -121,6 +148,15 @@ typedef cx_fvec::fixed<6> cx_fvec6;
 typedef cx_fvec::fixed<7> cx_fvec7;
 typedef cx_fvec::fixed<8> cx_fvec8;
 typedef cx_fvec::fixed<9> cx_fvec9;
+
+typedef cx_dvec::fixed<2> cx_dvec2;
+typedef cx_dvec::fixed<3> cx_dvec3;
+typedef cx_dvec::fixed<4> cx_dvec4;
+typedef cx_dvec::fixed<5> cx_dvec5;
+typedef cx_dvec::fixed<6> cx_dvec6;
+typedef cx_dvec::fixed<7> cx_dvec7;
+typedef cx_dvec::fixed<8> cx_dvec8;
+typedef cx_dvec::fixed<9> cx_dvec9;
 
 typedef cx_vec::fixed<2> cx_vec2;
 typedef cx_vec::fixed<3> cx_vec3;
@@ -162,6 +198,15 @@ typedef fcolvec::fixed<7> fcolvec7;
 typedef fcolvec::fixed<8> fcolvec8;
 typedef fcolvec::fixed<9> fcolvec9;
 
+typedef dcolvec::fixed<2> dcolvec2;
+typedef dcolvec::fixed<3> dcolvec3;
+typedef dcolvec::fixed<4> dcolvec4;
+typedef dcolvec::fixed<5> dcolvec5;
+typedef dcolvec::fixed<6> dcolvec6;
+typedef dcolvec::fixed<7> dcolvec7;
+typedef dcolvec::fixed<8> dcolvec8;
+typedef dcolvec::fixed<9> dcolvec9;
+
 typedef colvec::fixed<2> colvec2;
 typedef colvec::fixed<3> colvec3;
 typedef colvec::fixed<4> colvec4;
@@ -179,6 +224,15 @@ typedef cx_fcolvec::fixed<6> cx_fcolvec6;
 typedef cx_fcolvec::fixed<7> cx_fcolvec7;
 typedef cx_fcolvec::fixed<8> cx_fcolvec8;
 typedef cx_fcolvec::fixed<9> cx_fcolvec9;
+
+typedef cx_dcolvec::fixed<2> cx_dcolvec2;
+typedef cx_dcolvec::fixed<3> cx_dcolvec3;
+typedef cx_dcolvec::fixed<4> cx_dcolvec4;
+typedef cx_dcolvec::fixed<5> cx_dcolvec5;
+typedef cx_dcolvec::fixed<6> cx_dcolvec6;
+typedef cx_dcolvec::fixed<7> cx_dcolvec7;
+typedef cx_dcolvec::fixed<8> cx_dcolvec8;
+typedef cx_dcolvec::fixed<9> cx_dcolvec9;
 
 typedef cx_colvec::fixed<2> cx_colvec2;
 typedef cx_colvec::fixed<3> cx_colvec3;
@@ -220,6 +274,15 @@ typedef frowvec::fixed<7> frowvec7;
 typedef frowvec::fixed<8> frowvec8;
 typedef frowvec::fixed<9> frowvec9;
 
+typedef drowvec::fixed<2> drowvec2;
+typedef drowvec::fixed<3> drowvec3;
+typedef drowvec::fixed<4> drowvec4;
+typedef drowvec::fixed<5> drowvec5;
+typedef drowvec::fixed<6> drowvec6;
+typedef drowvec::fixed<7> drowvec7;
+typedef drowvec::fixed<8> drowvec8;
+typedef drowvec::fixed<9> drowvec9;
+
 typedef rowvec::fixed<2> rowvec2;
 typedef rowvec::fixed<3> rowvec3;
 typedef rowvec::fixed<4> rowvec4;
@@ -237,6 +300,15 @@ typedef cx_frowvec::fixed<6> cx_frowvec6;
 typedef cx_frowvec::fixed<7> cx_frowvec7;
 typedef cx_frowvec::fixed<8> cx_frowvec8;
 typedef cx_frowvec::fixed<9> cx_frowvec9;
+
+typedef cx_drowvec::fixed<2> cx_drowvec2;
+typedef cx_drowvec::fixed<3> cx_drowvec3;
+typedef cx_drowvec::fixed<4> cx_drowvec4;
+typedef cx_drowvec::fixed<5> cx_drowvec5;
+typedef cx_drowvec::fixed<6> cx_drowvec6;
+typedef cx_drowvec::fixed<7> cx_drowvec7;
+typedef cx_drowvec::fixed<8> cx_drowvec8;
+typedef cx_drowvec::fixed<9> cx_drowvec9;
 
 typedef cx_rowvec::fixed<2> cx_rowvec2;
 typedef cx_rowvec::fixed<3> cx_rowvec3;

--- a/include/armadillo_bits/wall_clock_meat.hpp
+++ b/include/armadillo_bits/wall_clock_meat.hpp
@@ -83,8 +83,8 @@ wall_clock::toc()
       {
       gettimeofday(&posix_time2, 0);
       
-      const double tmp_time1 = posix_time1.tv_sec + posix_time1.tv_usec * 1.0e-6;
-      const double tmp_time2 = posix_time2.tv_sec + posix_time2.tv_usec * 1.0e-6;
+      const double tmp_time1 = double(posix_time1.tv_sec) + double(posix_time1.tv_usec) * 1.0e-6;
+      const double tmp_time2 = double(posix_time2.tv_sec) + double(posix_time2.tv_usec) * 1.0e-6;
       
       return tmp_time2 - tmp_time1;
       }

--- a/misc/armadillo.pc.in
+++ b/misc/armadillo.pc.in
@@ -1,7 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=@INSTALL_LIB_DIR@
-includedir=@INSTALL_INCLUDE_DIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: armadillo
 Description: Fast C++ matrix library with syntax similar to MATLAB and Octave

--- a/tests/fn_abs.cpp
+++ b/tests/fn_abs.cpp
@@ -1,11 +1,11 @@
 // Copyright 2015 Conrad Sanderson (http://conradsanderson.id.au)
 // Copyright 2015 National ICT Australia (NICTA)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ using namespace arma;
 
 TEST_CASE("fn_abs_1")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -30,8 +30,8 @@ TEST_CASE("fn_abs_1")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
-  mat abs_A = 
+
+  mat abs_A =
     "\
      0.061198   0.201990   0.019678   0.493936   0.126745   0.051408;\
      0.437242   0.058956   0.149362   0.045465   0.296153   0.035437;\
@@ -39,53 +39,53 @@ TEST_CASE("fn_abs_1")
      0.336352   0.411541   0.458476   0.393139   0.135040   0.373833;\
      0.239585   0.428913   0.406953   0.291020   0.353768   0.258704;\
     ";
-  
+
   mat X = abs(A);
-  
+
   REQUIRE( X(0,0) == Approx(0.061198) );
   REQUIRE( X(1,0) == Approx(0.437242) );
   REQUIRE( X(2,0) == Approx(0.492474) );
   REQUIRE( X(3,0) == Approx(0.336352) );
   REQUIRE( X(4,0) == Approx(0.239585) );
-  
+
   REQUIRE( X(0,1) == Approx(0.201990) );
   REQUIRE( X(1,1) == Approx(0.058956) );
   REQUIRE( X(2,1) == Approx(0.031309) );
   REQUIRE( X(3,1) == Approx(0.411541) );
   REQUIRE( X(4,1) == Approx(0.428913) );
-  
+
   REQUIRE( X(0,5) == Approx(0.051408) );
   REQUIRE( X(1,5) == Approx(0.035437) );
   REQUIRE( X(2,5) == Approx(0.454499) );
   REQUIRE( X(3,5) == Approx(0.373833) );
   REQUIRE( X(4,5) == Approx(0.258704) );
-  
+
   mat Y = abs(2*A) / 2;
-  
+
   REQUIRE( Y(0,0) == Approx(0.061198) );
   REQUIRE( Y(1,0) == Approx(0.437242) );
   REQUIRE( Y(2,0) == Approx(0.492474) );
   REQUIRE( Y(3,0) == Approx(0.336352) );
   REQUIRE( Y(4,0) == Approx(0.239585) );
-  
+
   REQUIRE( Y(0,1) == Approx(0.201990) );
   REQUIRE( Y(1,1) == Approx(0.058956) );
   REQUIRE( Y(2,1) == Approx(0.031309) );
   REQUIRE( Y(3,1) == Approx(0.411541) );
   REQUIRE( Y(4,1) == Approx(0.428913) );
-  
+
   REQUIRE( Y(0,5) == Approx(0.051408) );
   REQUIRE( Y(1,5) == Approx(0.035437) );
   REQUIRE( Y(2,5) == Approx(0.454499) );
   REQUIRE( Y(3,5) == Approx(0.373833) );
   REQUIRE( Y(4,5) == Approx(0.258704) );
-  
+
   REQUIRE( accu(   abs(A) -   abs_A ) == Approx(0.0) );
   REQUIRE( accu( 2*abs(A) - 2*abs_A ) == Approx(0.0) );
-  
+
   REQUIRE( accu(   abs(-A) -   abs_A ) == Approx(0.0) );
   REQUIRE( accu( 2*abs(-A) - 2*abs_A ) == Approx(0.0) );
-  
+
   // REQUIRE_THROWS(  );
   }
 
@@ -93,7 +93,7 @@ TEST_CASE("fn_abs_1")
 
 TEST_CASE("fn_abs_2")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -101,9 +101,9 @@ TEST_CASE("fn_abs_2")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
+
   cx_mat C = cx_mat(A,fliplr(A));
-  
+
   mat abs_C =
     "\
      0.079925   0.238462   0.494328   0.494328   0.238462   0.079925;\
@@ -112,29 +112,29 @@ TEST_CASE("fn_abs_2")
      0.502876   0.433130   0.603952   0.603952   0.433130   0.502876;\
      0.352603   0.555984   0.500303   0.500303   0.555984   0.352603;\
     ";
-  
+
   mat X = abs(C);
-  
+
   REQUIRE( X(0,0) == Approx(0.079925) );
   REQUIRE( X(1,0) == Approx(0.438676) );
   REQUIRE( X(2,0) == Approx(0.670149) );
   REQUIRE( X(3,0) == Approx(0.502876) );
   REQUIRE( X(4,0) == Approx(0.352603) );
-  
+
   REQUIRE( X(0,1) == Approx(0.238462) );
   REQUIRE( X(1,1) == Approx(0.301964) );
   REQUIRE( X(2,1) == Approx(0.075150) );
   REQUIRE( X(3,1) == Approx(0.433130) );
   REQUIRE( X(4,1) == Approx(0.555984) );
-  
+
   REQUIRE( X(0,5) == Approx(0.079925) );
   REQUIRE( X(1,5) == Approx(0.438676) );
   REQUIRE( X(2,5) == Approx(0.670149) );
   REQUIRE( X(3,5) == Approx(0.502876) );
   REQUIRE( X(4,5) == Approx(0.352603) );
-  
+
   REQUIRE( accu(   abs(C) -   abs_C ) == Approx(0.0) );
-  
+
   // REQUIRE_THROWS(  );
   }
 
@@ -144,9 +144,9 @@ TEST_CASE("fn_abs_3")
   {
   vec re =  2*linspace<vec>(1,5,6);
   vec im = -4*linspace<vec>(1,5,6);
-  
+
   cx_vec a(re,im);
-  
+
   vec b =
     {
      4.47213595499958,
@@ -156,20 +156,20 @@ TEST_CASE("fn_abs_3")
     18.78297101099824,
     22.36067977499790
     };
-  
-  
+
+
   vec c = abs(a);
-  
+
   REQUIRE( accu(c      - b) == Approx(0.0) );
   REQUIRE( accu(abs(a) - b) == Approx(0.0) );
   }
 
-  
+
 TEST_CASE("fn_abs_4")
   {
   vec a = -2*linspace<vec>(1,5,6);
   vec b = +2*linspace<vec>(1,5,6);
-  
+
   REQUIRE( accu(abs(a) - b) == Approx(0.0) );
   REQUIRE( accu(abs(a(span::all)) - b(span::all)) == Approx(0.0) );
   }
@@ -182,4 +182,68 @@ TEST_CASE("fn_abs_5")
 
   REQUIRE( accu(abs(-2*A) - (2*A)) == Approx(0.0) );
   REQUIRE( accu(abs(-2*A(span::all,span::all)) - (2*A(span::all,span::all))) == Approx(0.0) );
+  }
+
+
+
+TEST_CASE("fn_abs_sp_mat")
+  {
+  SpMat<double> a(3, 3);
+  a(0, 2) = 4.3;
+  a(1, 1) = -5.5;
+  a(2, 2) = -6.3;
+
+  SpMat<double> b = abs(a);
+
+  REQUIRE( (double) b(0, 0) == 0 );
+  REQUIRE( (double) b(1, 0) == 0 );
+  REQUIRE( (double) b(2, 0) == 0 );
+  REQUIRE( (double) b(0, 1) == 0 );
+  REQUIRE( (double) b(1, 1) == Approx(5.5) );
+  REQUIRE( (double) b(2, 1) == 0 );
+  REQUIRE( (double) b(0, 2) == Approx(4.3) );
+  REQUIRE( (double) b(1, 2) == 0 );
+  REQUIRE( (double) b(2, 2) == Approx(6.3) );
+
+  // Just test that these compile and run.
+  b = abs(a);
+  b *= abs(a);
+  b %= abs(a);
+  b /= abs(a);
+  }
+
+
+
+TEST_CASE("fn_abs_sp_mat_2")
+  {
+  mat x = randu<mat>(100, 100);
+  x -= 0.5;
+
+  SpMat<double> y(x);
+
+  mat xr = abs(x);
+  SpMat<double> yr = abs(y);
+
+  for(size_t i = 0; i < xr.n_elem; ++i)
+    {
+    REQUIRE( xr[i] == Approx((double) yr[i]) );
+    }
+  }
+
+
+
+TEST_CASE("fn_abs_sp_cx_mat")
+  {
+  cx_mat x = randu<cx_mat>(100, 100);
+  x -= cx_double(0.5, 0.5);
+
+  sp_cx_mat y(x);
+
+  mat xr = abs(x);
+  SpMat<double> yr = abs(y);
+
+  for(size_t i = 0; i < xr.n_elem; ++i)
+    {
+    REQUIRE( xr[i] == Approx((double) yr[i]) );
+    }
   }

--- a/tests/fn_accu.cpp
+++ b/tests/fn_accu.cpp
@@ -1,11 +1,11 @@
 // Copyright 2015 Conrad Sanderson (http://conradsanderson.id.au)
 // Copyright 2015 National ICT Australia (NICTA)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ using namespace arma;
 
 TEST_CASE("fn_accu_1")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -30,7 +30,7 @@ TEST_CASE("fn_accu_1")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
+
   REQUIRE( accu(A)          == Approx( 0.240136) );
   REQUIRE( accu(abs(A))     == Approx( 7.845382) );
   REQUIRE( accu(A-A)        == Approx( 0.0     ) );
@@ -44,16 +44,16 @@ TEST_CASE("fn_accu_1")
   REQUIRE( accu(A.row(1))   == Approx( 0.632961) );
   REQUIRE( accu(2*A.col(1)) == Approx( 0.424530) );
   REQUIRE( accu(2*A.row(1)) == Approx( 1.265922) );
-  
+
   REQUIRE( accu(A%A)        == Approx(2.834218657806) );
   REQUIRE( accu(A*A.t())    == Approx(1.218704694166) );
   REQUIRE( accu(A.t()*A)    == Approx(2.585464740700) );
-  
+
   REQUIRE( accu(vectorise(A)) == Approx(0.240136) );
-  
+
   REQUIRE( accu(   A(span(1,3), span(1,4)) ) == Approx(1.273017) );
   REQUIRE( accu( 2*A(span(1,3), span(1,4)) ) == Approx(2.546034) );
-  
+
   REQUIRE_THROWS( accu(A*A) );
   }
 
@@ -61,7 +61,7 @@ TEST_CASE("fn_accu_1")
 
 TEST_CASE("fn_accu_2")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -69,17 +69,17 @@ TEST_CASE("fn_accu_2")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
+
   cx_mat C = cx_mat(A, 2*fliplr(A));
   cx_mat D = cx_mat(2*fliplr(A), A);
-  
+
   REQUIRE( abs(accu(C) - cx_double(0.240136, +0.480272)) == Approx(0.0) );
-  
+
   REQUIRE( abs(accu(cx_double(2,3)*C) - cx_double(-0.960544000000001, +1.680951999999999)) == Approx(0.0) );
-  
+
   REQUIRE( abs(accu(C*D.t() ) - cx_double(-0.710872588088, +3.656114082498002)) == Approx(0.0) );
   REQUIRE( abs(accu(C*D.st()) - cx_double(0.0,             +6.093523470830000)) == Approx(0.0) );
-  
+
   REQUIRE( abs(accu(C.t() *D) - cx_double(10.341858962800, -7.756394222100000)) == Approx(0.0) );
   REQUIRE( abs(accu(C.st()*D) - cx_double(0.0,             +1.29273237035e+01)) == Approx(0.0) );
   }
@@ -91,7 +91,7 @@ TEST_CASE("fn_accu_3")
   vec a =  linspace<vec>(1,5,5);
   vec b =  linspace<vec>(1,5,6);
   vec c = -linspace<vec>(1,5,6);
-  
+
   REQUIRE(accu(a) == Approx( 15.0));
   REQUIRE(accu(b) == Approx( 18.0));
   REQUIRE(accu(c) == Approx(-18.0));
@@ -104,13 +104,13 @@ TEST_CASE("fn_accu_4")
   mat A(5,6);  A.fill(2.0);
   mat B(5,6);  B.fill(4.0);
   mat C(6,5);  C.fill(6.0);
-  
+
   REQUIRE( accu(A + B)                                           == Approx(double((2+4)*(A.n_rows*A.n_cols))) );
   REQUIRE( accu(A(span::all,span::all) + B(span::all,span::all)) == Approx(double((2+4)*(A.n_rows*A.n_cols))) );
-  
+
   REQUIRE( accu(A % B)                                           == Approx(double((2*4)*(A.n_rows*A.n_cols))) );
   REQUIRE( accu(A(span::all,span::all) % B(span::all,span::all)) == Approx(double((2*4)*(A.n_rows*A.n_cols))) );
-  
+
   // A and C matrices are non-conformat, so accu() will throw unless ARMA_NO_DEBUG is defined
   REQUIRE_THROWS( accu(A % C) );
   REQUIRE_THROWS( accu(A(span::all,span::all) % C(span::all,span::all)) );
@@ -118,3 +118,15 @@ TEST_CASE("fn_accu_4")
 
 
 
+TEST_CASE("fn_accu_spmat")
+  {
+  SpMat<unsigned int> b(4, 4);
+  b(0, 1) = 6;
+  b(1, 3) = 15;
+  b(3, 1) = 14;
+  b(2, 0) = 5;
+  b(3, 3) = 12;
+
+  REQUIRE( accu(b) == 52 );
+  REQUIRE( accu(b.submat(1, 1, 3, 3)) == 41 );
+  }

--- a/tests/fn_dot.cpp
+++ b/tests/fn_dot.cpp
@@ -1,11 +1,11 @@
 // Copyright 2015 Conrad Sanderson (http://conradsanderson.id.au)
 // Copyright 2015 National ICT Australia (NICTA)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ using namespace arma;
 
 TEST_CASE("fn_dot_1")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153;\
@@ -30,19 +30,19 @@ TEST_CASE("fn_dot_1")
      0.336352   0.411541   0.458476  -0.393139  -0.135040;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768;\
     ";
-  
+
   vec a = A.head_cols(1);
   vec b = A.tail_cols(1);
-  
+
   rowvec c = A.head_rows(1);
   rowvec d = A.tail_rows(1);
-  
+
   REQUIRE( dot(  a,  b) == Approx(-0.04208883710200) );
   REQUIRE( dot(2*a,2+b) == Approx( 2.24343432579600) );
-  
+
   REQUIRE( dot(    c,  d) == Approx( 0.108601544706000) );
   REQUIRE( dot(0.5*c,2-d) == Approx(-0.392115772353000) );
-  
+
   REQUIRE( dot(a,b) == Approx( dot(A.head_cols(1), A.tail_cols(1)) ) );
   REQUIRE( dot(c,d) == Approx( dot(A.head_rows(1), A.tail_rows(1)) ) );
   }
@@ -51,7 +51,7 @@ TEST_CASE("fn_dot_1")
 
 TEST_CASE("fn_dot_2")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153;\
@@ -59,19 +59,65 @@ TEST_CASE("fn_dot_2")
      0.336352   0.411541   0.458476  -0.393139  -0.135040;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768;\
     ";
-  
+
   cx_vec a = cx_vec(A.col(0), A.col(1));
   cx_vec b = cx_vec(A.col(2), A.col(3));
-  
+
   cx_rowvec c = cx_rowvec(A.row(0), A.row(1));
   cx_rowvec d = cx_rowvec(A.row(2), A.row(3));
-  
+
   REQUIRE( abs( dot(a,b) - cx_double(-0.009544718641000, -0.110209641379000)) == Approx(0.0) );
   REQUIRE( abs( dot(c,d) - cx_double(-0.326993347830000, +0.061084261990000)) == Approx(0.0) );
-  
+
   REQUIRE( abs(cdot(a,b) - cx_double(-0.314669805873000, -0.807333974477000)) == Approx(0.0) );
   REQUIRE( abs(cdot(c,d) - cx_double(-0.165527940664000, +0.586984291846000)) == Approx(0.0) );
   }
+
+
+
+TEST_CASE("fn_dot_sp_mat_mat")
+  {
+  // Make matrices.
+  SpMat<double> a("3.0 0.0 0.0; 1.0 2.0 2.0; 0.0 0.0 1.0");
+  Mat<double> b("1.0 2.0 1.0; 1.0 2.0 2.0; 3.0 4.0 5.0");
+
+  REQUIRE( dot(a, b) == Approx(17.0) );
+  REQUIRE( dot(b, a) == Approx(17.0) );
+  }
+
+
+
+TEST_CASE("fn_dot_sp_col_col")
+  {
+  SpCol<unsigned int> a("3; 4; 0; 0; 0; 2; 0; 0");
+  Col<unsigned int> b("1 6 1 2 3 7 1 2");
+
+  REQUIRE( dot(a, b) == 41 );
+  REQUIRE( dot(b, a) == 41 );
+  }
+
+
+
+TEST_CASE("fn_dot_sp_mat_sp_mat")
+  {
+  SpMat<double> a("3.0 0.0 0.0; 1.0 2.0 2.0; 0.0 0.0 1.0");
+  SpMat<double> b("3.0 0.0 0.0; 1.0 2.0 2.0; 0.0 0.0 1.0");
+
+  REQUIRE( dot(a, b) == Approx(19.0) );
+  REQUIRE( dot(b, a) == Approx(19.0) );
+  }
+
+
+
+TEST_CASE("fn_dot_sp_col_sp_col")
+  {
+  SpCol<unsigned int> a("3; 4; 0; 0; 0; 2; 0; 0");
+  SpCol<unsigned int> b("0; 8; 0; 1; 1; 0; 0; 0");
+
+  REQUIRE( dot(a, b) == 32 );
+  REQUIRE( dot(b, a) == 32 );
+  }
+
 
 
 // TODO: norm_dot

--- a/tests/fn_eigs_gen.cpp
+++ b/tests/fn_eigs_gen.cpp
@@ -1,0 +1,453 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("fn_eigs_gen_odd_test")
+  {
+  const uword n_rows = 10;
+  const uword n_eigval = 5;
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    sp_mat m;
+    m.sprandu(n_rows, n_rows, 0.3);
+    mat d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col< std::complex<double> > sp_eigval;
+    Mat< std::complex<double> > sp_eigvec;
+    eigs_gen(sp_eigval, sp_eigvec, m, n_eigval);
+
+    // Do the same for the dense case.
+    Col< std::complex<double> > eigval;
+    Mat< std::complex<double> > eigvec;
+    eig_gen(eigval, eigvec, d);
+
+    uvec used(n_rows);
+    used.fill(0);
+
+    for (size_t i = 0; i < n_eigval; ++i)
+      {
+      // Sorting these is a super bitch.
+      // Find which one is the likely dense eigenvalue.
+      uword dense_eval = n_rows + 1;
+      for (uword k = 0; k < n_rows; ++k)
+        {
+        if ((std::abs(std::complex<double>(sp_eigval[i]).real() - eigval[k].real()) < 1e-4) &&
+            (std::abs(std::complex<double>(sp_eigval[i]).imag() - eigval[k].imag()) < 1e-4) &&
+            (used[k] == 0))
+          {
+          dense_eval = k;
+          used[k] = 1;
+          break;
+          }
+        }
+
+      REQUIRE( dense_eval != n_rows + 1 );
+
+      REQUIRE( std::abs(sp_eigval[i]) == Approx(std::abs(eigval[dense_eval])).epsilon(0.1) );
+      for (uword j = 0; j < n_rows; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) == Approx(std::abs(eigvec(j, dense_eval))).epsilon(0.1) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_eigs_gen_even_test")
+  {
+  const uword n_rows = 10;
+  const uword n_eigval = 4;
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    sp_mat m;
+    m.sprandu(n_rows, n_rows, 0.3);
+    sp_mat z(5, 5);
+    z.sprandu(5, 5, 0.5);
+    m.submat(2, 2, 6, 6) += 5 * z;
+    mat d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col< std::complex<double> > sp_eigval;
+    Mat< std::complex<double> > sp_eigvec;
+    eigs_gen(sp_eigval, sp_eigvec, m, n_eigval);
+
+    // Do the same for the dense case.
+    Col< std::complex<double> > eigval;
+    Mat< std::complex<double> > eigvec;
+    eig_gen(eigval, eigvec, d);
+
+    uvec used(n_rows);
+    used.fill(0);
+
+    for (size_t i = 0; i < n_eigval; ++i)
+      {
+      // Sorting these is a super bitch.
+      // Find which one is the likely dense eigenvalue.
+      uword dense_eval = n_rows + 1;
+      for (uword k = 0; k < n_rows; ++k)
+        {
+        if ((std::abs(std::complex<double>(sp_eigval[i]).real() - eigval[k].real()) < 1e-4) &&
+            (std::abs(std::complex<double>(sp_eigval[i]).imag() - eigval[k].imag()) < 1e-4) &&
+            (used[k] == 0))
+          {
+          dense_eval = k;
+          used[k] = 1;
+          break;
+          }
+        }
+
+      REQUIRE( dense_eval != n_rows + 1 );
+
+      REQUIRE( std::abs(sp_eigval[i]) == Approx(std::abs(eigval[dense_eval])).epsilon(0.01) );
+      for (uword j = 0; j < n_rows; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) == Approx(std::abs(eigvec(j, dense_eval))).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_eigs_gen_odd_float_test")
+  {
+  const uword n_rows = 10;
+  const uword n_eigval = 5;
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    SpMat<float> m;
+    m.sprandu(n_rows, n_rows, 0.3);
+    for (uword i = 0; i < n_rows; ++i)
+      {
+      m(i, i) += 5 * double(i) / double(n_rows);
+      }
+    Mat<float> d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col< std::complex<float> > sp_eigval;
+    Mat< std::complex<float> > sp_eigvec;
+    eigs_gen(sp_eigval, sp_eigvec, m, n_eigval);
+
+    // Do the same for the dense case.
+    Col< std::complex<float> > eigval;
+    Mat< std::complex<float> > eigvec;
+    eig_gen(eigval, eigvec, d);
+
+    uvec used(n_rows);
+    used.fill(0);
+
+    for (size_t i = 0; i < n_eigval; ++i)
+      {
+      // Sorting these is a super bitch.
+      // Find which one is the likely dense eigenvalue.
+      uword dense_eval = n_rows + 1;
+      for (uword k = 0; k < n_rows; ++k)
+        {
+        if ((std::abs(std::complex<float>(sp_eigval[i]).real() - eigval[k].real()) < 0.001) &&
+            (std::abs(std::complex<float>(sp_eigval[i]).imag() - eigval[k].imag()) < 0.001) &&
+            (used[k] == 0))
+          {
+          dense_eval = k;
+          used[k] = 1;
+          break;
+          }
+        }
+
+      REQUIRE( dense_eval != n_rows + 1 );
+
+      REQUIRE( std::abs(sp_eigval[i]) == Approx(std::abs(eigval[dense_eval])).epsilon(0.001) );
+      for (uword j = 0; j < n_rows; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) == Approx(std::abs(eigvec(j, dense_eval))).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_eigs_gen_even_float_test")
+  {
+  const uword n_rows = 12;
+  const uword n_eigval = 8;
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    SpMat<float> m;
+    m.sprandu(n_rows, n_rows, 0.3);
+    for (uword i = 0; i < n_rows; ++i)
+      {
+      m(i, i) += 5 * double(i) / double(n_rows);
+      }
+    Mat<float> d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col< std::complex<float> > sp_eigval;
+    Mat< std::complex<float> > sp_eigvec;
+    eigs_gen(sp_eigval, sp_eigvec, m, n_eigval);
+
+    // Do the same for the dense case.
+    Col< std::complex<float> > eigval;
+    Mat< std::complex<float> > eigvec;
+    eig_gen(eigval, eigvec, d);
+
+    uvec used(n_rows);
+    used.fill(0);
+
+    for (size_t i = 0; i < n_eigval; ++i)
+      {
+      // Sorting these is a super bitch.
+      // Find which one is the likely dense eigenvalue.
+      uword dense_eval = n_rows + 1;
+      for (uword k = 0; k < n_rows; ++k)
+        {
+        if ((std::abs(std::complex<float>(sp_eigval[i]).real() - eigval[k].real()) < 0.001) &&
+            (std::abs(std::complex<float>(sp_eigval[i]).imag() - eigval[k].imag()) < 0.001) &&
+            (used[k] == 0))
+          {
+          dense_eval = k;
+          used[k] = 1;
+          break;
+          }
+        }
+
+      REQUIRE( dense_eval != n_rows + 1 );
+
+      REQUIRE( std::abs(sp_eigval[i]) == Approx(std::abs(eigval[dense_eval])).epsilon(0.01) );
+      for (uword j = 0; j < n_rows; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) == Approx(std::abs(eigvec(j, dense_eval))).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_eigs_gen_odd_complex_float_test")
+  {
+  const uword n_rows = 10;
+  const uword n_eigval = 5;
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    SpMat< std::complex<float> > m;
+    m.sprandu(n_rows, n_rows, 0.3);
+    Mat< std::complex<float> > d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col< std::complex<float> > sp_eigval;
+    Mat< std::complex<float> > sp_eigvec;
+    eigs_gen(sp_eigval, sp_eigvec, m, n_eigval);
+
+    // Do the same for the dense case.
+    Col< std::complex<float> > eigval;
+    Mat< std::complex<float> > eigvec;
+    eig_gen(eigval, eigvec, d);
+
+    uvec used(n_rows);
+    used.fill(0);
+
+    for (size_t i = 0; i < n_eigval; ++i)
+      {
+      // Sorting these is a super bitch.
+      // Find which one is the likely dense eigenvalue.
+      uword dense_eval = n_rows + 1;
+      for (uword k = 0; k < n_rows; ++k)
+        {
+        if ((std::abs(std::complex<float>(sp_eigval[i]).real() - eigval[k].real()) < 0.001) &&
+            (std::abs(std::complex<float>(sp_eigval[i]).imag() - eigval[k].imag()) < 0.001) &&
+            (used[k] == 0))
+          {
+          dense_eval = k;
+          used[k] = 1;
+          break;
+          }
+        }
+
+      REQUIRE( dense_eval != n_rows + 1 );
+
+      REQUIRE( std::abs(sp_eigval[i]) == Approx(std::abs(eigval[dense_eval])).epsilon(0.01) );
+      for (uword j = 0; j < n_rows; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) == Approx(std::abs(eigvec(j, dense_eval))).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_eigs_gen_even_complex_float_test")
+  {
+  const uword n_rows = 12;
+  const uword n_eigval = 8;
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    SpMat< std::complex<float> > m;
+    m.sprandu(n_rows, n_rows, 0.3);
+    Mat< std::complex<float> > d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col< std::complex<float> > sp_eigval;
+    Mat< std::complex<float> > sp_eigvec;
+    eigs_gen(sp_eigval, sp_eigvec, m, n_eigval);
+
+    // Do the same for the dense case.
+    Col< std::complex<float> > eigval;
+    Mat< std::complex<float> > eigvec;
+    eig_gen(eigval, eigvec, d);
+
+    uvec used(n_rows);
+    used.fill(0);
+
+    for (size_t i = 0; i < n_eigval; ++i)
+      {
+      // Sorting these is a super bitch.
+      // Find which one is the likely dense eigenvalue.
+      uword dense_eval = n_rows + 1;
+      for (uword k = 0; k < n_rows; ++k)
+        {
+        if ((std::abs(std::complex<float>(sp_eigval[i]).real() - eigval[k].real()) < 0.001) &&
+            (std::abs(std::complex<float>(sp_eigval[i]).imag() - eigval[k].imag()) < 0.001) &&
+            (used[k] == 0))
+          {
+          dense_eval = k;
+          used[k] = 1;
+          break;
+          }
+        }
+
+      REQUIRE( dense_eval != n_rows + 1 );
+
+      REQUIRE( std::abs(sp_eigval[i]) == Approx(std::abs(eigval[dense_eval])).epsilon(0.01) );
+      for (uword j = 0; j < n_rows; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) == Approx(std::abs(eigvec(j, dense_eval))).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("eigs_gen_odd_complex_test")
+  {
+  const uword n_rows = 10;
+  const uword n_eigval = 5;
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    SpMat< std::complex<double> > m;
+    m.sprandu(n_rows, n_rows, 0.3);
+    Mat< std::complex<double> > d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col< std::complex<double> > sp_eigval;
+    Mat< std::complex<double> > sp_eigvec;
+    eigs_gen(sp_eigval, sp_eigvec, m, n_eigval);
+
+    // Do the same for the dense case.
+    Col< std::complex<double> > eigval;
+    Mat< std::complex<double> > eigvec;
+    eig_gen(eigval, eigvec, d);
+
+    uvec used(n_rows);
+    used.fill(0);
+
+    for (size_t i = 0; i < n_eigval; ++i)
+      {
+      // Sorting these is a super bitch.
+      // Find which one is the likely dense eigenvalue.
+      uword dense_eval = n_rows + 1;
+      for (uword k = 0; k < n_rows; ++k)
+        {
+        if ((std::abs(std::complex<double>(sp_eigval[i]).real() - eigval[k].real()) < 1e-10) &&
+            (std::abs(std::complex<double>(sp_eigval[i]).imag() - eigval[k].imag()) < 1e-10) &&
+            (used[k] == 0))
+          {
+          dense_eval = k;
+          used[k] = 1;
+          break;
+          }
+        }
+
+      REQUIRE( dense_eval != n_rows + 1 );
+
+      REQUIRE( std::abs(sp_eigval[i]) == Approx(std::abs(eigval[dense_eval])).epsilon(0.01) );
+      for (size_t j = 0; j < n_rows; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) == Approx(std::abs(eigvec(j, dense_eval))).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_eigs_gen_even_complex_test")
+  {
+  const uword n_rows = 15;
+  const uword n_eigval = 6;
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    SpMat< std::complex<double> > m;
+    m.sprandu(n_rows, n_rows, 0.3);
+    Mat< std::complex<double> > d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col< std::complex<double> > sp_eigval;
+    Mat< std::complex<double> > sp_eigvec;
+    eigs_gen(sp_eigval, sp_eigvec, m, n_eigval);
+
+    // Do the same for the dense case.
+    Col< std::complex<double> > eigval;
+    Mat< std::complex<double> > eigvec;
+    eig_gen(eigval, eigvec, d);
+
+    uvec used(n_rows);
+    used.fill(0);
+
+    for (size_t i = 0; i < n_eigval; ++i)
+      {
+      // Sorting these is a super bitch.
+      // Find which one is the likely dense eigenvalue.
+      uword dense_eval = n_rows + 1;
+      for (uword k = 0; k < n_rows; ++k)
+        {
+        if ((std::abs(std::complex<double>(sp_eigval[i]).real() - eigval[k].real()) < 1e-10) &&
+            (std::abs(std::complex<double>(sp_eigval[i]).imag() - eigval[k].imag()) < 1e-10) &&
+            (used[k] == 0))
+          {
+          dense_eval = k;
+          used[k] = 1;
+          break;
+          }
+        }
+
+      REQUIRE( dense_eval != n_rows + 1 );
+
+      REQUIRE( std::abs(sp_eigval[i]) == Approx(std::abs(eigval[dense_eval])).epsilon(0.01) );
+      for (uword j = 0; j < n_rows; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) == Approx(std::abs(eigvec(j, dense_eval))).epsilon(0.01) );
+        }
+      }
+    }
+  }

--- a/tests/fn_eigs_sym.cpp
+++ b/tests/fn_eigs_sym.cpp
@@ -1,0 +1,139 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("fn_eigs_test")
+  {
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    // Test ARPACK decomposition of sparse matrices.
+    sp_mat m(1000, 1000);
+    sp_vec dd;
+    for (size_t i = 0; i < 10; ++i)
+      {
+      dd.sprandu(1000, 1, 0.15);
+      double eig = rand();
+      m += eig * dd * dd.t();
+      }
+    mat d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    vec sp_eigval;
+    mat sp_eigvec;
+    eigs_sym(sp_eigval, sp_eigvec, m, 5);
+
+    // Do the same for the dense case.
+    vec eigval;
+    mat eigvec;
+    eig_sym(eigval, eigvec, d);
+
+    for (uword i = 0; i < 5; ++i)
+      {
+      // It may be pointed the wrong direction.
+      REQUIRE( sp_eigval[i] == Approx(eigval[i + 995]).epsilon(0.01) );
+
+      for (uword j = 0; j < 1000; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) ==
+                 Approx(std::abs(eigvec(j, i + 995))).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_eigs_float_test")
+  {
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    // Test ARPACK decomposition of sparse matrices.
+    SpMat<float> m(100, 100);
+    SpCol<float> dd;
+    for (size_t i = 0; i < 10; ++i)
+      {
+      dd.sprandu(100, 1, 0.15);
+      float eig = rand();
+      m += 0.000001 * eig * dd * dd.t();
+      }
+    Mat<float> d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    Col<float> sp_eigval;
+    Mat<float> sp_eigvec;
+    eigs_sym(sp_eigval, sp_eigvec, m, 5);
+
+    // Do the same for the dense case.
+    Col<float> eigval;
+    Mat<float> eigvec;
+    eig_sym(eigval, eigvec, d);
+
+    for (uword i = 0; i < 5; ++i)
+      {
+      // It may be pointed the wrong direction.
+      REQUIRE( sp_eigval[i] == Approx(eigval[i + 95]).epsilon(0.01) );
+
+      for (uword j = 0; j < 100; ++j)
+        {
+        REQUIRE(std::abs(sp_eigvec(j, i)) ==
+                Approx(std::abs(eigvec(j, i + 95))).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_eigs_sm_test")
+  {
+  for (size_t trial = 0; trial < 10; ++trial)
+    {
+    // Test ARPACK decomposition of sparse matrices.
+    sp_mat m(100, 100);
+    sp_vec dd;
+    for (uword i = 0; i < 100; ++i)
+      {
+      m(i, i) = i + 10;
+      }
+    mat d(m);
+
+    // Eigendecompose, getting first 5 eigenvectors.
+    vec sp_eigval;
+    mat sp_eigvec;
+    eigs_sym(sp_eigval, sp_eigvec, m, 5, "sm");
+
+    // Do the same for the dense case.
+    vec eigval;
+    mat eigvec;
+    eig_sym(eigval, eigvec, d);
+
+    for (size_t i = 0; i < 5; ++i)
+      {
+      // It may be pointed the wrong direction.
+      REQUIRE( sp_eigval[i] == Approx(eigval[i]).epsilon(0.01) );
+
+      for (size_t j = 0; j < 100; ++j)
+        {
+        REQUIRE( std::abs(sp_eigvec(j, i)) ==
+                 Approx(std::abs(eigvec(j, i))).epsilon(0.01) );
+        }
+      }
+    }
+  }

--- a/tests/fn_max.cpp
+++ b/tests/fn_max.cpp
@@ -1,0 +1,736 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("fn_max_subview_test")
+  {
+  // We will assume subview.at() works and returns points within the bounds of
+  // the matrix, so we just have to ensure the results are the same as
+  // Mat.max()...
+  for (size_t r = 50; r < 150; ++r)
+    {
+    mat x;
+    x.randu(r, r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+    uword x_subview_max3;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(0, 0, r - 1, r - 1).max(x_subview_max1);
+    const double mval2 = x.cols(0, r - 1).max(x_subview_max2);
+    const double mval3 = x.rows(0, r - 1).max(x_subview_max3);
+
+    REQUIRE( x_max == x_subview_max1 );
+    REQUIRE( x_max == x_subview_max2 );
+    REQUIRE( x_max == x_subview_max3 );
+
+    REQUIRE( mval == Approx(mval1) );
+    REQUIRE( mval == Approx(mval2) );
+    REQUIRE( mval == Approx(mval3) );
+    }
+  }
+
+
+
+TEST_CASE("fn_max_subview_col_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    vec x;
+    x.randu(r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(0, 0, r - 1, 0).max(x_subview_max1);
+    const double mval2 = x.rows(0, r - 1).max(x_subview_max2);
+
+    REQUIRE( x_max == x_subview_max1 );
+    REQUIRE( x_max == x_subview_max2 );
+
+    REQUIRE( mval == Approx(mval1) );
+    REQUIRE( mval == Approx(mval2) );
+    }
+  }
+
+
+
+TEST_CASE("fn_max_subview_row_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    rowvec x;
+    x.randu(r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(0, 0, 0, r - 1).max(x_subview_max1);
+    const double mval2 = x.cols(0, r - 1).max(x_subview_max2);
+
+    REQUIRE( x_max == x_subview_max1 );
+    REQUIRE( x_max == x_subview_max2 );
+
+    REQUIRE( mval == Approx(mval1) );
+    REQUIRE( mval == Approx(mval2) );
+    }
+  }
+
+
+
+TEST_CASE("fn_max_incomplete_subview_test")
+  {
+  for (size_t r = 50; r < 150; ++r)
+    {
+    mat x;
+    x.randu(r, r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+    uword x_subview_max3;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(1, 1, r - 2, r - 2).max(x_subview_max1);
+    const double mval2 = x.cols(1, r - 2).max(x_subview_max2);
+    const double mval3 = x.rows(1, r - 2).max(x_subview_max3);
+
+    uword row, col;
+    x.max(row, col);
+
+    if (row != 0 && row != r - 1 && col != 0 && col != r - 1)
+      {
+      uword srow, scol;
+
+      srow = x_subview_max1 % (r - 2);
+      scol = x_subview_max1 / (r - 2);
+      REQUIRE( x_max == (srow + 1) + r * (scol + 1) );
+      REQUIRE( x_max == x_subview_max2 + r );
+
+      srow = x_subview_max3 % (r - 2);
+      scol = x_subview_max3 / (r - 2);
+      REQUIRE( x_max == (srow + 1) + r * scol );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      REQUIRE( mval == Approx(mval3) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_incomplete_subview_col_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    vec x;
+    x.randu(r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(1, 0, r - 2, 0).max(x_subview_max1);
+    const double mval2 = x.rows(1, r - 2).max(x_subview_max2);
+
+    if (x_max != 0 && x_max != r - 1)
+      {
+      REQUIRE( x_max == x_subview_max1 + 1 );
+      REQUIRE( x_max == x_subview_max2 + 1 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_subview_row_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    cx_rowvec x;
+    x.randu(r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(0, 0, 0, r - 1).max(x_subview_max1);
+    const std::complex<double> mval2 = x.cols(0, r - 1).max(x_subview_max2);
+
+    REQUIRE( x_max == x_subview_max1 );
+    REQUIRE( x_max == x_subview_max2 );
+
+    REQUIRE( mval.real() == Approx(mval1.real()) );
+    REQUIRE( mval.imag() == Approx(mval1.imag()) );
+    REQUIRE( mval.real() == Approx(mval2.real()) );
+    REQUIRE( mval.imag() == Approx(mval2.imag()) );
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_incomplete_subview_test")
+  {
+  for (size_t r = 50; r < 150; ++r)
+    {
+    cx_mat x;
+    x.randu(r, r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+    uword x_subview_max3;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(1, 1, r - 2, r - 2).max(x_subview_max1);
+    const std::complex<double> mval2 = x.cols(1, r - 2).max(x_subview_max2);
+    const std::complex<double> mval3 = x.rows(1, r - 2).max(x_subview_max3);
+
+    uword row, col;
+    x.max(row, col);
+
+    if (row != 0 && row != r - 1 && col != 0 && col != r - 1)
+      {
+      uword srow, scol;
+
+      srow = x_subview_max1 % (r - 2);
+      scol = x_subview_max1 / (r - 2);
+      REQUIRE( x_max == (srow + 1) + r * (scol + 1) );
+      REQUIRE( x_max == x_subview_max2 + r );
+
+      srow = x_subview_max3 % (r - 2);
+      scol = x_subview_max3 / (r - 2);
+      REQUIRE( x_max == (srow + 1) + r * scol );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      REQUIRE( mval.real() == Approx(mval3.real()) );
+      REQUIRE( mval.imag() == Approx(mval3.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_incomplete_subview_col_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    cx_vec x;
+    x.randu(r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(1, 0, r - 2, 0).max(x_subview_max1);
+    const std::complex<double> mval2 = x.rows(1, r - 2).max(x_subview_max2);
+
+    if (x_max != 0 && x_max != r - 1)
+      {
+      REQUIRE( x_max == x_subview_max1 + 1 );
+      REQUIRE( x_max == x_subview_max2 + 1 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_incomplete_subview_row_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    cx_rowvec x;
+    x.randu(r);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(0, 1, 0, r - 2).max(x_subview_max1);
+    const std::complex<double> mval2 = x.cols(1, r - 2).max(x_subview_max2);
+
+    if (x_max != 0 && x_max != r - 1)
+      {
+      REQUIRE( x_max == x_subview_max1 + 1 );
+      REQUIRE( x_max == x_subview_max2 + 1 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_weird_operation_test")
+  {
+  mat a(10, 10);
+  mat b(25, 10);
+  a.randn();
+  b.randn();
+
+  mat output = a * b.t();
+
+  uword real_max;
+  uword operation_max;
+
+  const double mval = output.max(real_max);
+  const double other_mval = (a * b.t()).max(operation_max);
+
+  REQUIRE( real_max == operation_max );
+  REQUIRE( mval == Approx(other_mval) );
+  }
+
+
+
+TEST_CASE("fn_max_weird_sparse_operation_test")
+  {
+  sp_mat a(10, 10);
+  sp_mat b(25, 10);
+  a.sprandn(10, 10, 0.3);
+  b.sprandn(25, 10, 0.3);
+
+  sp_mat output = a * b.t();
+
+  uword real_max;
+  uword operation_max;
+
+  const double mval = output.max(real_max);
+  const double other_mval = (a * b.t()).max(operation_max);
+
+  REQUIRE( real_max == operation_max );
+  REQUIRE( mval == Approx(other_mval) );
+  }
+
+
+
+TEST_CASE("fn_max_spsubview_test")
+  {
+  // We will assume subview.at() works and returns points within the bounds of
+  // the matrix, so we just have to ensure the results are the same as
+  // Mat.max()...
+  for (size_t r = 50; r < 150; ++r)
+    {
+    sp_mat x;
+    x.sprandn(r, r, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+    uword x_subview_max3;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(0, 0, r - 1, r - 1).max(x_subview_max1);
+    const double mval2 = x.cols(0, r - 1).max(x_subview_max2);
+    const double mval3 = x.rows(0, r - 1).max(x_subview_max3);
+
+    if (mval != 0.0)
+      {
+      REQUIRE( x_max == x_subview_max1 );
+      REQUIRE( x_max == x_subview_max2 );
+      REQUIRE( x_max == x_subview_max3 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      REQUIRE( mval == Approx(mval3) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_spsubview_col_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_vec x;
+    x.sprandn(r, 1, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(0, 0, r - 1, 0).max(x_subview_max1);
+    const double mval2 = x.rows(0, r - 1).max(x_subview_max2);
+
+    if (mval != 0.0)
+      {
+      REQUIRE( x_max == x_subview_max1 );
+      REQUIRE( x_max == x_subview_max2 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_spsubview_row_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_rowvec x;
+    x.sprandn(1, r, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(0, 0, 0, r - 1).max(x_subview_max1);
+    const double mval2 = x.cols(0, r - 1).max(x_subview_max2);
+
+    if (mval != 0.0)
+      {
+      REQUIRE( x_max == x_subview_max1 );
+      REQUIRE( x_max == x_subview_max2 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_spincompletesubview_test")
+  {
+  for (size_t r = 50; r < 150; ++r)
+    {
+    sp_mat x;
+    x.sprandn(r, r, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+    uword x_subview_max3;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(1, 1, r - 2, r - 2).max(x_subview_max1);
+    const double mval2 = x.cols(1, r - 2).max(x_subview_max2);
+    const double mval3 = x.rows(1, r - 2).max(x_subview_max3);
+
+    uword row, col;
+    x.max(row, col);
+
+    if (row != 0 && row != r - 1 && col != 0 && col != r - 1 && mval != 0.0)
+      {
+      uword srow, scol;
+
+      srow = x_subview_max1 % (r - 2);
+      scol = x_subview_max1 / (r - 2);
+      REQUIRE( x_max == (srow + 1) + r * (scol + 1) );
+      REQUIRE( x_max == x_subview_max2 + r );
+
+      srow = x_subview_max3 % (r - 2);
+      scol = x_subview_max3 / (r - 2);
+      REQUIRE( x_max == (srow + 1) + r * scol );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      REQUIRE( mval == Approx(mval3) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_spincompletesubview_col_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_vec x;
+    x.sprandu(r, 1, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(1, 0, r - 2, 0).max(x_subview_max1);
+    const double mval2 = x.rows(1, r - 2).max(x_subview_max2);
+
+    if (x_max != 0 && x_max != r - 1 && mval != 0.0)
+      {
+      REQUIRE( x_max == x_subview_max1 + 1 );
+      REQUIRE( x_max == x_subview_max2 + 1 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_spincompletesubview_row_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_rowvec x;
+    x.sprandn(1, r, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const double mval = x.max(x_max);
+    const double mval1 = x.submat(0, 1, 0, r - 2).max(x_subview_max1);
+    const double mval2 = x.cols(1, r - 2).max(x_subview_max2);
+
+    if (mval != 0.0 && x_max != 0 && x_max != r - 1)
+      {
+      REQUIRE( x_max == x_subview_max1 + 1 );
+      REQUIRE( x_max == x_subview_max2 + 1 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_spsubview_test")
+  {
+  // We will assume subview.at() works and returns points within the bounds of
+  // the matrix, so we just have to ensure the results are the same as
+  // Mat.max()...
+  for (size_t r = 50; r < 150; ++r)
+    {
+    sp_cx_mat x;
+    x.sprandn(r, r, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+    uword x_subview_max3;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(0, 0, r - 1, r - 1).max(x_subview_max1);
+    const std::complex<double> mval2 = x.cols(0, r - 1).max(x_subview_max2);
+    const std::complex<double> mval3 = x.rows(0, r - 1).max(x_subview_max3);
+
+    if (mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_max == x_subview_max1 );
+      REQUIRE( x_max == x_subview_max2 );
+      REQUIRE( x_max == x_subview_max3 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      REQUIRE( mval.real() == Approx(mval3.real()) );
+      REQUIRE( mval.imag() == Approx(mval3.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_spsubview_col_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_cx_vec x;
+    x.sprandn(r, 1, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(0, 0, r - 1, 0).max(x_subview_max1);
+    const std::complex<double> mval2 = x.rows(0, r - 1).max(x_subview_max2);
+
+    if (mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_max == x_subview_max1 );
+      REQUIRE( x_max == x_subview_max2 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_spsubview_row_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_cx_rowvec x;
+    x.sprandn(1, r, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(0, 0, 0, r - 1).max(x_subview_max1);
+    const std::complex<double> mval2 = x.cols(0, r - 1).max(x_subview_max2);
+
+    if (mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_max == x_subview_max1 );
+      REQUIRE( x_max == x_subview_max2 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_spincompletesubview_test")
+  {
+  for (size_t r = 50; r < 150; ++r)
+    {
+    sp_cx_mat x;
+    x.sprandn(r, r, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+    uword x_subview_max3;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(1, 1, r - 2, r - 2).max(x_subview_max1);
+    const std::complex<double> mval2 = x.cols(1, r - 2).max(x_subview_max2);
+    const std::complex<double> mval3 = x.rows(1, r - 2).max(x_subview_max3);
+
+    uword row, col;
+    x.max(row, col);
+
+    if (row != 0 && row != r - 1 && col != 0 && col != r - 1 && mval != std::complex<double>(0.0))
+      {
+      uword srow, scol;
+
+      srow = x_subview_max1 % (r - 2);
+      scol = x_subview_max1 / (r - 2);
+      REQUIRE( x_max == (srow + 1) + r * (scol + 1) );
+      REQUIRE( x_max == x_subview_max2 + r );
+
+      srow = x_subview_max3 % (r - 2);
+      scol = x_subview_max3 / (r - 2);
+      REQUIRE( x_max == (srow + 1) + r * scol );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      REQUIRE( mval.real() == Approx(mval3.real()) );
+      REQUIRE( mval.imag() == Approx(mval3.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_spincompletesubview_col_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_cx_vec x;
+    x.sprandn(r, 1, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(1, 0, r - 2, 0).max(x_subview_max1);
+    const std::complex<double> mval2 = x.rows(1, r - 2).max(x_subview_max2);
+
+    if (x_max != 0 && x_max != r - 1 && mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_max == x_subview_max1 + 1 );
+      REQUIRE( x_max == x_subview_max2 + 1 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_max_cx_spincompletesubview_row_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_cx_rowvec x;
+    x.sprandn(1, r, 0.3);
+
+    uword x_max;
+    uword x_subview_max1;
+    uword x_subview_max2;
+
+    const std::complex<double> mval = x.max(x_max);
+    const std::complex<double> mval1 = x.submat(0, 1, 0, r - 2).max(x_subview_max1);
+    const std::complex<double> mval2 = x.cols(1, r - 2).max(x_subview_max2);
+
+    if (x_max != 0 && x_max != r - 1 && mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_max == x_subview_max1 + 1 );
+      REQUIRE( x_max == x_subview_max2 + 1 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }

--- a/tests/fn_mean.cpp
+++ b/tests/fn_mean.cpp
@@ -1,0 +1,948 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("fn_mean_spmat_empty_test")
+  {
+  SpMat<double> m(20, 25);
+
+  SpRow<double> result = mean(m, 0);
+  REQUIRE( result.n_nonzero == 0 );
+  REQUIRE( result.n_rows == 1 );
+  REQUIRE( result.n_cols == 25 );
+
+  SpCol<double> result2 = mean(m, 1);
+  REQUIRE( result2.n_nonzero == 0 );
+  REQUIRE( result2.n_rows == 20 );
+  REQUIRE( result2.n_cols == 1 );
+
+  double r = mean(mean(m));
+  REQUIRE( r == Approx(0.0) );
+
+  // Now the same with subviews.
+  result = mean(m.submat(2, 2, 11, 16));
+  REQUIRE( result.n_nonzero == 0 );
+  REQUIRE( result.n_rows == 1 );
+  REQUIRE( result.n_cols == 15 );
+
+  result2 = mean(m.submat(2, 2, 11, 16), 1);
+  REQUIRE( result2.n_nonzero == 0 );
+  REQUIRE( result2.n_rows == 10 );
+  REQUIRE( result2.n_cols == 1 );
+
+  r = mean(mean(m.submat(2, 2, 11, 16)));
+  REQUIRE( r == Approx(0.0) );
+
+  // And with an operation.
+  result = mean(trans(m));
+  REQUIRE( result.n_nonzero == 0 );
+  REQUIRE( result.n_rows == 1 );
+  REQUIRE( result.n_cols == 20 );
+
+  result2 = mean(trans(m), 1);
+  REQUIRE( result2.n_nonzero == 0 );
+  REQUIRE( result2.n_rows == 25 );
+  REQUIRE( result2.n_cols == 1 );
+
+  r = mean(mean(trans(m)));
+  REQUIRE( r == Approx(0.0) );
+  }
+
+
+
+TEST_CASE("fn_mean_spcxmat_empty_test")
+  {
+  // Now with complex numbers.
+  SpMat<std::complex<double> > m(20, 25);
+  SpRow<std::complex<double> > result = mean(m, 0);
+
+  REQUIRE( result.n_nonzero == 0 );
+  REQUIRE( result.n_rows == 1 );
+  REQUIRE( result.n_cols == 25 );
+
+  SpCol<std::complex<double> > result2 = mean(m, 1);
+
+  REQUIRE( result2.n_nonzero == 0 );
+  REQUIRE( result2.n_rows == 20 );
+  REQUIRE( result2.n_cols == 1 );
+
+  std::complex<double> r = mean(mean(m));
+
+  REQUIRE( real(r) == Approx(0.0) );
+  REQUIRE( imag(r) == Approx(0.0) );
+
+  // Now the same with subviews.
+  result = mean(m.submat(2, 2, 11, 16));
+  REQUIRE( result.n_nonzero == 0 );
+  REQUIRE( result.n_rows == 1 );
+  REQUIRE( result.n_cols == 15 );
+
+  result2 = mean(m.submat(2, 2, 11, 16), 1);
+  REQUIRE( result2.n_nonzero == 0 );
+  REQUIRE( result2.n_rows == 10 );
+  REQUIRE( result2.n_cols == 1 );
+
+  r = mean(mean(m.submat(2, 2, 11, 16)));
+  REQUIRE( real(r) == Approx(0.0) );
+  REQUIRE( imag(r) == Approx(0.0) );
+
+  // And with an operation.
+  result = mean(trans(m));
+  REQUIRE( result.n_nonzero == 0 );
+  REQUIRE( result.n_rows == 1 );
+  REQUIRE( result.n_cols == 20 );
+
+  result2 = mean(trans(m), 1);
+  REQUIRE( result2.n_nonzero == 0 );
+  REQUIRE( result2.n_rows == 25 );
+  REQUIRE( result2.n_cols == 1 );
+
+  r = mean(mean(trans(m)));
+  REQUIRE( real(r) == Approx(0.0) );
+  REQUIRE( imag(r) == Approx(0.0) );
+  }
+
+
+
+TEST_CASE("fn_mean_spmat_test")
+  {
+  // Create a random matrix and do mean testing on it, with varying levels of
+  // nonzero (eventually this becomes a fully dense matrix).
+  for (int i = 0; i < 10; ++i)
+    {
+    SpMat<double> x;
+    x.sprandu(50, 75, ((double) (i + 1)) / 10);
+    mat d(x);
+
+    SpRow<double> rr = mean(x);
+    rowvec drr = mean(d);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+
+    SpCol<double> cr = mean(x, 1);
+    vec dcr = mean(d, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+
+    double dr = mean(mean(x));
+    double ddr = mean(mean(d));
+
+    REQUIRE( dr == Approx(ddr) );
+
+    // Now on a subview.
+    rr = mean(x.submat(11, 11, 30, 45), 0);
+    drr = mean(d.submat(11, 11, 30, 45), 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 35 );
+    for (uword j = 0; j < 35; ++j)
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+
+    cr = mean(x.submat(11, 11, 30, 45), 1);
+    dcr = mean(d.submat(11, 11, 30, 45), 1);
+
+    REQUIRE( cr.n_rows == 20 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 20; ++j)
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+
+    dr = mean(mean(x.submat(11, 11, 30, 45)));
+    ddr = mean(mean(d.submat(11, 11, 30, 45)));
+
+    REQUIRE( dr == Approx(ddr) );
+
+    // Now on an SpOp (spop_scalar_times)
+    rr = mean(3.0 * x);
+    drr = mean(3.0 * d);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+
+    cr = mean(4.5 * x, 1);
+    dcr = mean(4.5 * d, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+
+    dr = mean(mean(1.2 * x));
+    ddr = mean(mean(1.2 * d));
+
+    REQUIRE( dr == Approx(ddr) );
+
+    // Now on an SpGlue!
+    SpMat<double> y;
+    y.sprandu(50, 75, 0.3);
+    mat e(y);
+
+    rr = mean(x + y);
+    drr = mean(d + e);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+
+    cr = mean(x + y, 1);
+    dcr = mean(d + e, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+
+    dr = mean(mean(x + y));
+    ddr = mean(mean(d + e));
+
+    REQUIRE( dr == Approx(ddr) );
+    }
+  }
+
+
+
+TEST_CASE("fn_mean_spcxmat_test")
+  {
+  // Create a random matrix and do mean testing on it, with varying levels of
+  // nonzero (eventually this becomes a fully dense matrix).
+  for (int i = 0; i < 10; ++i)
+  {
+    SpMat<std::complex<double> > x;
+    x.sprandu(50, 75, ((double) (i + 1)) / 10);
+    cx_mat d(x);
+
+    SpRow<std::complex<double> > rr = mean(x);
+    cx_rowvec drr = mean(d);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( real(drr[j]) == Approx(real((std::complex<double>) rr[j])) );
+      REQUIRE( imag(drr[j]) == Approx(imag((std::complex<double>) rr[j])) );
+      }
+
+    SpCol<std::complex<double> > cr = mean(x, 1);
+    cx_vec dcr = mean(d, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( real(dcr[j]) == Approx(real((std::complex<double>) cr[j])) );
+      REQUIRE( imag(dcr[j]) == Approx(imag((std::complex<double>) cr[j])) );
+      }
+
+    std::complex<double> dr = mean(mean(x));
+    std::complex<double> ddr = mean(mean(d));
+
+    REQUIRE( real(dr) == Approx(real(ddr)) );
+    REQUIRE( imag(dr) == Approx(imag(ddr)) );
+
+    // Now on a subview.
+    rr = mean(x.submat(11, 11, 30, 45), 0);
+    drr = mean(d.submat(11, 11, 30, 45), 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 35 );
+    for (uword j = 0; j < 35; ++j)
+      {
+      REQUIRE( real(drr[j]) == Approx(real((std::complex<double>) rr[j])) );
+      REQUIRE( imag(drr[j]) == Approx(imag((std::complex<double>) rr[j])) );
+      }
+
+    cr = mean(x.submat(11, 11, 30, 45), 1);
+    dcr = mean(d.submat(11, 11, 30, 45), 1);
+
+    REQUIRE( cr.n_rows == 20 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 20; ++j)
+      {
+      REQUIRE( real(dcr[j]) == Approx(real((std::complex<double>) cr[j])) );
+      REQUIRE( imag(dcr[j]) == Approx(imag((std::complex<double>) cr[j])) );
+      }
+
+    dr = mean(mean(x.submat(11, 11, 30, 45)));
+    ddr = mean(mean(d.submat(11, 11, 30, 45)));
+
+    REQUIRE( real(dr) == Approx(real(ddr)) );
+    REQUIRE( imag(dr) == Approx(imag(ddr)) );
+
+    // Now on an SpOp (spop_scalar_times)
+    rr = mean(3.0 * x);
+    drr = mean(3.0 * d);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( real(drr[j]) == Approx(real((std::complex<double>) rr[j])) );
+      REQUIRE( imag(drr[j]) == Approx(imag((std::complex<double>) rr[j])) );
+      }
+
+    cr = mean(4.5 * x, 1);
+    dcr = mean(4.5 * d, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( real(dcr[j]) == Approx(real((std::complex<double>) cr[j])) );
+      REQUIRE( imag(dcr[j]) == Approx(imag((std::complex<double>) cr[j])) );
+      }
+
+    dr = mean(mean(1.2 * x));
+    ddr = mean(mean(1.2 * d));
+
+    REQUIRE( real(dr) == Approx(real(ddr)) );
+    REQUIRE( imag(dr) == Approx(imag(ddr)) );
+
+    // Now on an SpGlue!
+    SpMat<std::complex<double> > y;
+    y.sprandu(50, 75, 0.3);
+    cx_mat e(y);
+
+    rr = mean(x + y);
+    drr = mean(d + e);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( real(drr[j]) == Approx(real((std::complex<double>) rr[j])) );
+      REQUIRE( imag(drr[j]) == Approx(imag((std::complex<double>) rr[j])) );
+      }
+
+    cr = mean(x + y, 1);
+    dcr = mean(d + e, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( real(dcr[j]) == Approx(real((std::complex<double>) cr[j])) );
+      REQUIRE( imag(dcr[j]) == Approx(imag((std::complex<double>) cr[j])) );
+      }
+
+    dr = mean(mean(x + y));
+    ddr = mean(mean(d + e));
+
+    REQUIRE( real(dr) == Approx(real(ddr)) );
+    REQUIRE( imag(dr) == Approx(imag(ddr)) );
+    }
+  }
+
+
+TEST_CASE("fn_mean_sp_vector_test")
+  {
+  // Test mean() on vectors.
+  SpCol<double> c(1000);
+
+  SpCol<double> cr = mean(c, 0);
+  REQUIRE( cr.n_rows == 1 );
+  REQUIRE( cr.n_cols == 1 );
+  REQUIRE( (double) cr[0] == Approx(0.0) );
+
+  cr = mean(c, 1);
+  REQUIRE( cr.n_rows == 1000 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( (double) cr[i] == Approx(0.0) );
+    }
+
+  double ddcr = mean(c);
+  REQUIRE( ddcr == Approx(0.0) );
+
+  c.sprandu(1000, 1, 0.3);
+  vec dc(c);
+
+  cr = mean(c, 0);
+  vec dcr = mean(dc, 0);
+
+  REQUIRE( cr.n_rows == 1 );
+  REQUIRE( cr.n_cols == 1 );
+  REQUIRE( (double) cr[0] == Approx(dcr[0]) );
+
+  cr = mean(c, 1);
+  dcr = mean(dc, 1);
+
+  REQUIRE( cr.n_rows == 1000 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( (double) cr[i] == Approx(dcr[i]) );
+    }
+
+  ddcr = mean(c);
+  double dddr = mean(dc);
+
+  REQUIRE( ddcr == Approx(dddr) );
+
+  SpRow<double> r;
+  r.sprandu(1, 1000, 0.3);
+  rowvec dr(r);
+
+  SpRow<double> rr = mean(r, 0);
+  rowvec drr = mean(dr, 0);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 1000 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( (double) rr[i] == Approx(drr[i]) );
+    }
+
+  rr = mean(r, 1);
+  drr = mean(dr, 1);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 1 );
+  REQUIRE( (double) rr[0] == Approx(drr[0]) );
+
+  ddcr = mean(r);
+  dddr = mean(dr);
+
+  REQUIRE( ddcr == Approx(dddr) );
+  }
+
+
+
+TEST_CASE("fn_mean_sp_cx_vector_test")
+  {
+  // Test mean() on vectors.
+  SpCol<std::complex<double> > c(1000);
+
+  SpCol<std::complex<double> > cr = mean(c, 0);
+  REQUIRE( cr.n_rows == 1 );
+  REQUIRE( cr.n_cols == 1 );
+  REQUIRE( real((std::complex<double>) cr[0]) == Approx(0.0) );
+  REQUIRE( imag((std::complex<double>) cr[0]) == Approx(0.0) );
+
+  cr = mean(c, 1);
+  REQUIRE( cr.n_rows == 1000 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword i = 0; i < 1000; ++i)
+  {
+    REQUIRE( real((std::complex<double>) cr[i]) == Approx(0.0) );
+    REQUIRE( imag((std::complex<double>) cr[i]) == Approx(0.0) );
+  }
+
+  std::complex<double> ddcr = mean(c);
+  REQUIRE( real(ddcr) == Approx(0.0) );
+  REQUIRE( imag(ddcr) == Approx(0.0) );
+
+  c.sprandu(1000, 1, 0.3);
+  cx_vec dc(c);
+
+  cr = mean(c, 0);
+  cx_vec dcr = mean(dc, 0);
+
+  REQUIRE( cr.n_rows == 1 );
+  REQUIRE( cr.n_cols == 1 );
+  REQUIRE( real((std::complex<double>) cr[0]) == Approx(real(dcr[0])) );
+  REQUIRE( imag((std::complex<double>) cr[0]) == Approx(imag(dcr[0])) );
+
+  cr = mean(c, 1);
+  dcr = mean(dc, 1);
+
+  REQUIRE( cr.n_rows == 1000 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( real((std::complex<double>) cr[i]) == Approx(real(dcr[i])) );
+    REQUIRE( imag((std::complex<double>) cr[i]) == Approx(imag(dcr[i])) );
+    }
+
+  ddcr = mean(c);
+  std::complex<double> dddr = mean(dc);
+
+  REQUIRE( real(ddcr) == Approx(real(dddr)) );
+  REQUIRE( imag(ddcr) == Approx(imag(dddr)) );
+
+  SpRow<std::complex<double> > r;
+  r.sprandu(1, 1000, 0.3);
+  cx_rowvec dr(r);
+
+  SpRow<std::complex<double> > rr = mean(r, 0);
+  cx_rowvec drr = mean(dr, 0);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 1000 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( real((std::complex<double>) rr[i]) == Approx(real(drr[i])) );
+    REQUIRE( imag((std::complex<double>) rr[i]) == Approx(imag(drr[i])) );
+    }
+
+  rr = mean(r, 1);
+  drr = mean(dr, 1);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 1 );
+  REQUIRE( real((std::complex<double>) rr[0]) == Approx(real(drr[0])) );
+  REQUIRE( imag((std::complex<double>) rr[0]) == Approx(imag(drr[0])) );
+
+  ddcr = mean(r);
+  dddr = mean(dr);
+
+  REQUIRE( real(ddcr) == Approx(real(dddr)) );
+  REQUIRE( imag(ddcr) == Approx(imag(dddr)) );
+  }
+
+
+
+TEST_CASE("fn_mean_robust_sparse_test")
+  {
+  // Create a sparse matrix with values that will overflow.
+  SpMat<double> x;
+  x.sprandu(50, 75, 0.1);
+  for (SpMat<double>::iterator i = x.begin(); i != x.end(); ++i)
+    {
+    (*i) *= std::numeric_limits<double>::max();
+    }
+  mat d(x);
+
+  SpRow<double> rr = mean(x);
+  rowvec drr = mean(d);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 75 );
+  for (uword j = 0; j < 75; ++j)
+    {
+    REQUIRE( drr[j] == Approx((double) rr[j]) );
+    }
+
+  SpCol<double> cr = mean(x, 1);
+  vec dcr = mean(d, 1);
+
+  REQUIRE( cr.n_rows == 50 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword j = 0; j < 50; ++j)
+    {
+    REQUIRE( dcr[j] == Approx((double) cr[j]) );
+    }
+
+  double dr = mean(mean(x));
+  double ddr = mean(mean(d));
+
+  REQUIRE( dr == Approx(ddr) );
+
+  // Now on a subview.
+  rr = mean(x.submat(11, 11, 30, 45), 0);
+  drr = mean(d.submat(11, 11, 30, 45), 0);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 35 );
+  for (uword j = 0; j < 35; ++j)
+    {
+    REQUIRE( drr[j] == Approx((double) rr[j]) );
+    }
+
+  cr = mean(x.submat(11, 11, 30, 45), 1);
+  dcr = mean(d.submat(11, 11, 30, 45), 1);
+
+  REQUIRE( cr.n_rows == 20 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword j = 0; j < 20; ++j)
+    {
+    REQUIRE( dcr[j] == Approx((double) cr[j]) );
+    }
+
+  dr = mean(mean(x.submat(11, 11, 30, 45)));
+  ddr = mean(mean(d.submat(11, 11, 30, 45)));
+
+  REQUIRE( dr == Approx(ddr) );
+
+  // Now on an SpOp (spop_scalar_times)
+  rr = mean(0.4 * x);
+  drr = mean(0.4 * d);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 75 );
+  for (uword j = 0; j < 75; ++j)
+    {
+    REQUIRE( drr[j] == Approx((double) rr[j]) );
+    }
+
+  cr = mean(0.1 * x, 1);
+  dcr = mean(0.1 * d, 1);
+
+  REQUIRE( cr.n_rows == 50 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword j = 0; j < 50; ++j)
+    {
+    REQUIRE( dcr[j] == Approx((double) cr[j]) );
+    }
+
+  dr = mean(mean(0.7 * x));
+  ddr = mean(mean(0.7 * d));
+
+  REQUIRE( dr == Approx(ddr) );
+
+  // Now on an SpGlue!
+  SpMat<double> y;
+  y.sprandu(50, 75, 0.3);
+  for (SpMat<double>::iterator i = y.begin(); i != y.end(); ++i)
+    {
+    (*i) *= std::numeric_limits<double>::max();
+    }
+  mat e(y);
+
+  rr = mean(0.5 * x + 0.5 * y);
+  drr = mean(0.5 * d + 0.5 * e);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 75 );
+  for (uword j = 0; j < 75; ++j)
+    {
+    REQUIRE( drr[j] == Approx((double) rr[j]) );
+    }
+
+  cr = mean(0.5 * x + 0.5 * y, 1);
+  dcr = mean(0.5 * d + 0.5 * e, 1);
+
+  REQUIRE( cr.n_rows == 50 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword j = 0; j < 50; ++j)
+    {
+    REQUIRE( dcr[j] == Approx((double) cr[j]) );
+    }
+
+  dr = mean(mean(0.5 * x + 0.5 * y));
+  ddr = mean(mean(0.5 * d + 0.5 * e));
+
+  REQUIRE( dr == Approx(ddr) );
+  }
+
+
+
+TEST_CASE("fn_mean_robust_cx_sparse_test")
+  {
+  SpMat<std::complex<double> > x;
+  x.sprandu(50, 75, 0.3);
+  for (SpMat<std::complex<double> >::iterator i = x.begin(); i != x.end(); ++i)
+    {
+    (*i) *= std::numeric_limits<double>::max();
+    }
+  cx_mat d(x);
+
+  SpRow<std::complex<double> > rr = mean(x);
+  cx_rowvec drr = mean(d);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 75 );
+  for (uword j = 0; j < 75; ++j)
+    {
+    REQUIRE( real(drr[j]) == Approx(real((std::complex<double>) rr[j])) );
+    REQUIRE( imag(drr[j]) == Approx(imag((std::complex<double>) rr[j])) );
+    }
+
+  SpCol<std::complex<double> > cr = mean(x, 1);
+  cx_vec dcr = mean(d, 1);
+
+  REQUIRE( cr.n_rows == 50 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword j = 0; j < 50; ++j)
+    {
+    REQUIRE( real(dcr[j]) == Approx(real((std::complex<double>) cr[j])) );
+    REQUIRE( imag(dcr[j]) == Approx(imag((std::complex<double>) cr[j])) );
+    }
+
+  std::complex<double> dr = mean(mean(x));
+  std::complex<double> ddr = mean(mean(d));
+
+  REQUIRE( real(dr) == Approx(real(ddr)) );
+  REQUIRE( imag(dr) == Approx(imag(ddr)) );
+
+  // Now on a subview.
+  rr = mean(x.submat(11, 11, 30, 45), 0);
+  drr = mean(d.submat(11, 11, 30, 45), 0);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 35 );
+  for (uword j = 0; j < 35; ++j)
+    {
+    REQUIRE( real(drr[j]) == Approx(real((std::complex<double>) rr[j])) );
+    REQUIRE( imag(drr[j]) == Approx(imag((std::complex<double>) rr[j])) );
+    }
+
+  cr = mean(x.submat(11, 11, 30, 45), 1);
+  dcr = mean(d.submat(11, 11, 30, 45), 1);
+
+  REQUIRE( cr.n_rows == 20 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword j = 0; j < 20; ++j)
+    {
+    REQUIRE( real(dcr[j]) == Approx(real((std::complex<double>) cr[j])) );
+    REQUIRE( imag(dcr[j]) == Approx(imag((std::complex<double>) cr[j])) );
+    }
+
+  dr = mean(mean(x.submat(11, 11, 30, 45)));
+  ddr = mean(mean(d.submat(11, 11, 30, 45)));
+
+  REQUIRE( real(dr) == Approx(real(ddr)) );
+  REQUIRE( imag(dr) == Approx(imag(ddr)) );
+
+  // Now on an SpOp (spop_scalar_times)
+  rr = mean(0.5 * x);
+  drr = mean(0.5 * d);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 75 );
+  for (uword j = 0; j < 75; ++j)
+    {
+    REQUIRE( real(drr[j]) == Approx(real((std::complex<double>) rr[j])) );
+    REQUIRE( imag(drr[j]) == Approx(imag((std::complex<double>) rr[j])) );
+    }
+
+  cr = mean(0.7 * x, 1);
+  dcr = mean(0.7 * d, 1);
+
+  REQUIRE( cr.n_rows == 50 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword j = 0; j < 50; ++j)
+    {
+    REQUIRE( real(dcr[j]) == Approx(real((std::complex<double>) cr[j])) );
+    REQUIRE( imag(dcr[j]) == Approx(imag((std::complex<double>) cr[j])) );
+    }
+
+  dr = mean(mean(0.6 * x));
+  ddr = mean(mean(0.6 * d));
+
+  REQUIRE( real(dr) == Approx(real(ddr)) );
+  REQUIRE( imag(dr) == Approx(imag(ddr)) );
+
+  // Now on an SpGlue!
+  SpMat<std::complex<double> > y;
+  y.sprandu(50, 75, 0.3);
+  for (SpMat<std::complex<double> >::iterator i = y.begin(); i != y.end(); ++i)
+    {
+    (*i) *= std::numeric_limits<double>::max();
+    }
+  cx_mat e(y);
+
+  rr = mean(0.5 * x + 0.5 * y);
+  drr = mean(0.5 * d + 0.5 * e);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 75 );
+  for (uword j = 0; j < 75; ++j)
+    {
+    REQUIRE( real(drr[j]) == Approx(real((std::complex<double>) rr[j])) );
+    REQUIRE( imag(drr[j]) == Approx(imag((std::complex<double>) rr[j])) );
+    }
+
+  cr = mean(0.5 * x + 0.5 * y, 1);
+  dcr = mean(0.5 * d + 0.5 * e, 1);
+
+  REQUIRE( cr.n_rows == 50 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword j = 0; j < 50; ++j)
+    {
+    REQUIRE( real(dcr[j]) == Approx(real((std::complex<double>) cr[j])) );
+    REQUIRE( imag(dcr[j]) == Approx(imag((std::complex<double>) cr[j])) );
+    }
+
+  dr = mean(mean(0.5 * x + 0.5 * y));
+  ddr = mean(mean(0.5 * d + 0.5 * e));
+
+  REQUIRE( real(dr) == Approx(real(ddr)) );
+  REQUIRE( imag(dr) == Approx(imag(ddr)) );
+  }
+
+
+
+TEST_CASE("fn_mean_robust_sparse_vector_test")
+  {
+  // Test mean() on vectors.
+  SpCol<double> c(1000);
+
+  SpCol<double> cr;
+  double ddcr;
+
+  c.sprandu(1000, 1, 0.3);
+  for (SpCol<double>::iterator i = c.begin(); i != c.end(); ++i)
+    {
+    (*i) *= (std::numeric_limits<double>::max());
+    }
+  vec dc(c);
+
+  cr = mean(c, 0);
+  vec dcr = mean(dc, 0);
+
+  REQUIRE( cr.n_rows == 1 );
+  REQUIRE( cr.n_cols == 1 );
+  REQUIRE( (double) cr[0] == Approx(dcr[0]) );
+
+  cr = mean(c, 1);
+  dcr = mean(dc, 1);
+
+  REQUIRE( cr.n_rows == 1000 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( (double) cr[i] == Approx(dcr[i]) );
+    }
+
+  ddcr = mean(c);
+  double dddr = mean(dc);
+
+  REQUIRE( ddcr == Approx(dddr) );
+
+  SpRow<double> r;
+  r.sprandu(1, 1000, 0.3);
+  for (SpRow<double>::iterator i = r.begin(); i != r.end(); ++i)
+    {
+    (*i) *= (std::numeric_limits<double>::max());
+    }
+  rowvec dr(r);
+
+  SpRow<double> rr = mean(r, 0);
+  rowvec drr = mean(dr, 0);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 1000 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( (double) rr[i] == Approx(drr[i]) );
+    }
+
+  rr = mean(r, 1);
+  drr = mean(dr, 1);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 1 );
+  REQUIRE( (double) rr[0] == Approx(drr[0]) );
+
+  ddcr = mean(r);
+  dddr = mean(dr);
+
+  REQUIRE( ddcr == Approx(dddr) );
+  }
+
+
+
+TEST_CASE("fn_mean_robust_cx_sparse_vector_test")
+  {
+  // Test mean() on vectors.
+  SpCol<std::complex<double> > c(1000);
+
+  SpCol<std::complex<double> > cr;
+  std::complex<double> ddcr;
+
+  c.sprandu(1000, 1, 0.3);
+  for (SpCol<std::complex<double> >::iterator i = c.begin(); i != c.end(); ++i)
+    {
+    (*i) *= (std::numeric_limits<double>::max());
+    }
+  cx_vec dc(c);
+
+  cr = mean(c, 0);
+  cx_vec dcr = mean(dc, 0);
+
+  REQUIRE( cr.n_rows == 1 );
+  REQUIRE( cr.n_cols == 1 );
+  REQUIRE( real((std::complex<double>) cr[0]) == Approx(real(dcr[0])) );
+  REQUIRE( imag((std::complex<double>) cr[0]) == Approx(imag(dcr[0])) );
+
+  cr = mean(c, 1);
+  dcr = mean(dc, 1);
+
+  REQUIRE( cr.n_rows == 1000 );
+  REQUIRE( cr.n_cols == 1 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( real((std::complex<double>) cr[i]) == Approx(real(dcr[i])) );
+    REQUIRE( imag((std::complex<double>) cr[i]) == Approx(imag(dcr[i])) );
+    }
+
+  ddcr = mean(c);
+  std::complex<double> dddr = mean(dc);
+
+  REQUIRE( real(ddcr) == Approx(real(dddr)) );
+  REQUIRE( imag(ddcr) == Approx(imag(dddr)) );
+
+  SpRow<std::complex<double> > r;
+  r.sprandu(1, 1000, 0.3);
+  cx_rowvec dr(r);
+
+  SpRow<std::complex<double> > rr = mean(r, 0);
+  cx_rowvec drr = mean(dr, 0);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 1000 );
+  for (uword i = 0; i < 1000; ++i)
+    {
+    REQUIRE( real((std::complex<double>) rr[i]) == Approx(real(drr[i])) );
+    REQUIRE( imag((std::complex<double>) rr[i]) == Approx(imag(drr[i])) );
+    }
+
+  rr = mean(r, 1);
+  drr = mean(dr, 1);
+
+  REQUIRE( rr.n_rows == 1 );
+  REQUIRE( rr.n_cols == 1 );
+  REQUIRE( real((std::complex<double>) rr[0]) == Approx(real(drr[0])) );
+  REQUIRE( imag((std::complex<double>) rr[0]) == Approx(imag(drr[0])) );
+
+  ddcr = mean(r);
+  dddr = mean(dr);
+
+  REQUIRE( real(ddcr) == Approx(real(dddr)) );
+  REQUIRE( imag(ddcr) == Approx(imag(dddr)) );
+  }
+
+
+
+TEST_CASE("fn_mean_sparse_alias_test")
+  {
+  sp_mat s;
+  s.sprandu(70, 70, 0.3);
+  mat d(s);
+
+  s = mean(s);
+  d = mean(d);
+
+  REQUIRE( d.n_rows == s.n_rows );
+  REQUIRE( d.n_cols == s.n_cols );
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    REQUIRE( d[i] == Approx((double) s[i]) );
+    }
+
+  s.sprandu(70, 70, 0.3);
+  d = s;
+
+  s = mean(s, 1);
+  d = mean(d, 1);
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    REQUIRE( d[i] == Approx((double) s[i]) );
+    }
+  }

--- a/tests/fn_min.cpp
+++ b/tests/fn_min.cpp
@@ -1,0 +1,452 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("fn_min_weird_operation")
+  {
+  mat a(10, 10);
+  mat b(25, 10);
+  a.randn();
+  b.randn();
+
+  mat output = a * b.t();
+
+  uword real_min;
+  uword operation_min;
+
+  const double mval = output.min(real_min);
+  const double other_mval = (a * b.t()).min(operation_min);
+
+  REQUIRE( real_min == operation_min );
+  REQUIRE( mval == Approx(other_mval) );
+  }
+
+
+
+TEST_CASE("fn_min_weird_sparse_operation")
+  {
+  sp_mat a(10, 10);
+  sp_mat b(25, 10);
+  a.sprandn(10, 10, 0.3);
+  b.sprandn(25, 10, 0.3);
+
+  sp_mat output = a * b.t();
+
+  uword real_min;
+  uword operation_min;
+
+  const double mval = output.min(real_min);
+  const double other_mval = (a * b.t()).min(operation_min);
+
+  REQUIRE( real_min == operation_min );
+  REQUIRE( mval == Approx(other_mval) );
+  }
+
+
+
+TEST_CASE("fn_min_sp_subview_test")
+  {
+  // We will assume subview.at() works and returns points within the bounds of
+  // the matrix, so we just have to ensure the results are the same as
+  // Mat.min()...
+  for (size_t r = 50; r < 150; ++r)
+    {
+    sp_mat x;
+    x.sprandn(r, r, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+    uword x_subview_min3;
+
+    const double mval = x.min(x_min);
+    const double mval1 = x.submat(0, 0, r - 1, r - 1).min(x_subview_min1);
+    const double mval2 = x.cols(0, r - 1).min(x_subview_min2);
+    const double mval3 = x.rows(0, r - 1).min(x_subview_min3);
+
+    if (mval != 0.0)
+      {
+      REQUIRE( x_min == x_subview_min1 );
+      REQUIRE( x_min == x_subview_min2 );
+      REQUIRE( x_min == x_subview_min3 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      REQUIRE( mval == Approx(mval3) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_spsubview_col_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_vec x;
+    x.sprandn(r, 1, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+
+    const double mval = x.min(x_min);
+    const double mval1 = x.submat(0, 0, r - 1, 0).min(x_subview_min1);
+    const double mval2 = x.rows(0, r - 1).min(x_subview_min2);
+
+    if (mval != 0.0)
+      {
+      REQUIRE( x_min == x_subview_min1 );
+      REQUIRE( x_min == x_subview_min2 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_spsubview_row_min_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_rowvec x;
+    x.sprandn(1, r, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+
+    const double mval = x.min(x_min);
+    const double mval1 = x.submat(0, 0, 0, r - 1).min(x_subview_min1);
+    const double mval2 = x.cols(0, r - 1).min(x_subview_min2);
+
+    if (mval != 0.0)
+      {
+      REQUIRE( x_min == x_subview_min1 );
+      REQUIRE( x_min == x_subview_min2 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_spincompletesubview_min_test")
+  {
+  for (size_t r = 50; r < 150; ++r)
+    {
+    sp_mat x;
+    x.sprandn(r, r, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+    uword x_subview_min3;
+
+    const double mval = x.min(x_min);
+    const double mval1 = x.submat(1, 1, r - 2, r - 2).min(x_subview_min1);
+    const double mval2 = x.cols(1, r - 2).min(x_subview_min2);
+    const double mval3 = x.rows(1, r - 2).min(x_subview_min3);
+
+    uword row, col;
+    x.min(row, col);
+
+    if (row != 0 && row != r - 1 && col != 0 && col != r - 1 && mval != 0.0)
+      {
+      uword srow, scol;
+
+      srow = x_subview_min1 % (r - 2);
+      scol = x_subview_min1 / (r - 2);
+      REQUIRE( x_min == (srow + 1) + r * (scol + 1) );
+      REQUIRE( x_min == x_subview_min2 + r );
+
+      srow = x_subview_min3 % (r - 2);
+      scol = x_subview_min3 / (r - 2);
+      REQUIRE( x_min == (srow + 1) + r * scol );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      REQUIRE( mval == Approx(mval3) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_spincompletesubview_col_min_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_vec x;
+    x.sprandu(r, 1, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+
+    const double mval = x.min(x_min);
+    const double mval1 = x.submat(1, 0, r - 2, 0).min(x_subview_min1);
+    const double mval2 = x.rows(1, r - 2).min(x_subview_min2);
+
+    if (x_min != 0 && x_min != r - 1 && mval != 0.0)
+      {
+      REQUIRE( x_min == x_subview_min1 + 1 );
+      REQUIRE( x_min == x_subview_min2 + 1 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_spincompletesubview_row_min_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_rowvec x;
+    x.sprandn(1, r, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+
+    const double mval = x.min(x_min);
+    const double mval1 = x.submat(0, 1, 0, r - 2).min(x_subview_min1);
+    const double mval2 = x.cols(1, r - 2).min(x_subview_min2);
+
+    if (mval != 0.0 && x_min != 0 && x_min != r - 1)
+      {
+      REQUIRE( x_min == x_subview_min1 + 1 );
+      REQUIRE( x_min == x_subview_min2 + 1 );
+
+      REQUIRE( mval == Approx(mval1) );
+      REQUIRE( mval == Approx(mval2) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_sp_cx_subview_min_test")
+  {
+  // We will assume subview.at() works and returns points within the bounds of
+  // the matrix, so we just have to ensure the results are the same as
+  // Mat.min()...
+  for (size_t r = 50; r < 150; ++r)
+    {
+    sp_cx_mat x;
+    x.sprandn(r, r, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+    uword x_subview_min3;
+
+    const std::complex<double> mval = x.min(x_min);
+    const std::complex<double> mval1 = x.submat(0, 0, r - 1, r - 1).min(x_subview_min1);
+    const std::complex<double> mval2 = x.cols(0, r - 1).min(x_subview_min2);
+    const std::complex<double> mval3 = x.rows(0, r - 1).min(x_subview_min3);
+
+    if (mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_min == x_subview_min1 );
+      REQUIRE( x_min == x_subview_min2 );
+      REQUIRE( x_min == x_subview_min3 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      REQUIRE( mval.real() == Approx(mval3.real()) );
+      REQUIRE( mval.imag() == Approx(mval3.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_sp_cx_subview_col_min_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_cx_vec x;
+    x.sprandn(r, 1, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+
+    const std::complex<double> mval = x.min(x_min);
+    const std::complex<double> mval1 = x.submat(0, 0, r - 1, 0).min(x_subview_min1);
+    const std::complex<double> mval2 = x.rows(0, r - 1).min(x_subview_min2);
+
+    if (mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_min == x_subview_min1 );
+      REQUIRE( x_min == x_subview_min2 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_sp_cx_subview_row_min_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_cx_rowvec x;
+    x.sprandn(1, r, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+
+    const std::complex<double> mval = x.min(x_min);
+    const std::complex<double> mval1 = x.submat(0, 0, 0, r - 1).min(x_subview_min1);
+    const std::complex<double> mval2 = x.cols(0, r - 1).min(x_subview_min2);
+
+    if (mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_min == x_subview_min1 );
+      REQUIRE( x_min == x_subview_min2 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_sp_cx_incomplete_subview_min_test")
+  {
+  for (size_t r = 50; r < 150; ++r)
+    {
+    sp_cx_mat x;
+    x.sprandn(r, r, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+    uword x_subview_min3;
+
+    const std::complex<double> mval = x.min(x_min);
+    const std::complex<double> mval1 = x.submat(1, 1, r - 2, r - 2).min(x_subview_min1);
+    const std::complex<double> mval2 = x.cols(1, r - 2).min(x_subview_min2);
+    const std::complex<double> mval3 = x.rows(1, r - 2).min(x_subview_min3);
+
+    uword row, col;
+    x.min(row, col);
+
+    if (row != 0 && row != r - 1 && col != 0 && col != r - 1 && mval != std::complex<double>(0.0))
+      {
+      uword srow, scol;
+
+      srow = x_subview_min1 % (r - 2);
+      scol = x_subview_min1 / (r - 2);
+      REQUIRE( x_min == (srow + 1) + r * (scol + 1) );
+      REQUIRE( x_min == x_subview_min2 + r );
+
+      srow = x_subview_min3 % (r - 2);
+      scol = x_subview_min3 / (r - 2);
+      REQUIRE( x_min == (srow + 1) + r * scol );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      REQUIRE( mval.real() == Approx(mval3.real()) );
+      REQUIRE( mval.imag() == Approx(mval3.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_sp_cx_incomplete_subview_col_min_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    arma::sp_cx_vec x;
+    x.sprandn(r, 1, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+
+    const std::complex<double> mval = x.min(x_min);
+    const std::complex<double> mval1 = x.submat(1, 0, r - 2, 0).min(x_subview_min1);
+    const std::complex<double> mval2 = x.rows(1, r - 2).min(x_subview_min2);
+
+    if (x_min != 0 && x_min != r - 1 && mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_min == x_subview_min1 + 1 );
+      REQUIRE( x_min == x_subview_min2 + 1 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_min_sp_cx_incomplete_subview_row_min_test")
+  {
+  for (size_t r = 10; r < 50; ++r)
+    {
+    sp_cx_rowvec x;
+    x.sprandn(1, r, 0.3);
+
+    uword x_min;
+    uword x_subview_min1;
+    uword x_subview_min2;
+
+    const std::complex<double> mval = x.min(x_min);
+    const std::complex<double> mval1 = x.submat(0, 1, 0, r - 2).min(x_subview_min1);
+    const std::complex<double> mval2 = x.cols(1, r - 2).min(x_subview_min2);
+
+    if (x_min != 0 && x_min != r - 1 && mval != std::complex<double>(0.0))
+      {
+      REQUIRE( x_min == x_subview_min1 + 1 );
+      REQUIRE( x_min == x_subview_min2 + 1 );
+
+      REQUIRE( mval.real() == Approx(mval1.real()) );
+      REQUIRE( mval.imag() == Approx(mval1.imag()) );
+      REQUIRE( mval.real() == Approx(mval2.real()) );
+      REQUIRE( mval.imag() == Approx(mval2.imag()) );
+      }
+    }
+  }

--- a/tests/fn_spsolve.cpp
+++ b/tests/fn_spsolve.cpp
@@ -1,0 +1,900 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+#if defined(ARMA_USE_SUPERLU)
+
+TEST_CASE("fn_spsolve_sparse_test")
+  {
+  // We want to spsolve a system of equations, AX = B, where we want to recover
+  // X and we have A and B, and A is sparse.
+  for (size_t t = 0; t < 10; ++t)
+    {
+    const uword size = 5 * (t + 1);
+
+    mat rX;
+    rX.randu(size, size);
+
+    sp_mat A;
+    A.sprandu(size, size, 0.25);
+    for (uword i = 0; i < size; ++i)
+      {
+      A(i, i) += rand();
+      }
+
+    mat B = A * rX;
+
+    mat X;
+    bool result = spsolve(X, A, B);
+    REQUIRE( result );
+
+    // Dense solver.
+    mat dA(A);
+    mat dX = solve(dA, B);
+
+    REQUIRE( X.n_cols == dX.n_cols );
+    REQUIRE( X.n_rows == dX.n_rows );
+
+    for (uword i = 0; i < dX.n_cols; ++i)
+      {
+      for (uword j = 0; j < dX.n_rows; ++j)
+        {
+        REQUIRE( (double) X(j, i) == Approx((double) dX(j, i)) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_sparse_nonsymmetric_test")
+  {
+  for (size_t t = 0; t < 10; ++t)
+    {
+    const uword r_size = 5 * (t + 1);
+    const uword c_size = 3 * (t + 4);
+
+    mat rX;
+    rX.randu(r_size, c_size);
+
+    sp_mat A;
+    A.sprandu(r_size, r_size, 0.25);
+    for (uword i = 0; i < r_size; ++i)
+      {
+      A(i, i) += rand();
+      }
+
+    mat B = A * rX;
+
+    mat X;
+    bool result = spsolve(X, A, B);
+    REQUIRE( result );
+
+    // Dense solver.
+    mat dA(A);
+    mat dX = solve(dA, B);
+
+    REQUIRE( X.n_cols == dX.n_cols );
+    REQUIRE( X.n_rows == dX.n_rows );
+
+    for (uword i = 0; i < dX.n_cols; ++i)
+      {
+      for (uword j = 0; j < dX.n_rows; ++j)
+        {
+        REQUIRE( (double) X(j, i) == Approx((double) dX(j, i)) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_sparse_float_test")
+  {
+  // We want to spsolve a system of equations, AX = B, where we want to recover
+  // X and we have A and B, and A is sparse.
+  for (size_t t = 0; t < 10; ++t)
+    {
+    const uword size = 5 * (t + 1);
+
+    fmat rX;
+    rX.randu(size, size);
+
+    SpMat<float> A;
+    A.sprandu(size, size, 0.25);
+    for (uword i = 0; i < size; ++i)
+      {
+      A(i, i) += rand();
+      }
+
+    fmat B = A * rX;
+
+    fmat X;
+    bool result = spsolve(X, A, B);
+    REQUIRE( result );
+
+    // Dense solver.
+    fmat dA(A);
+    fmat dX = solve(dA, B);
+
+    REQUIRE( X.n_cols == dX.n_cols );
+    REQUIRE( X.n_rows == dX.n_rows );
+
+    for (size_t i = 0; i < dX.n_cols; ++i)
+      {
+      for (size_t j = 0; j < dX.n_rows; ++j)
+        {
+        REQUIRE( (float) X(j, i) == Approx((float) dX(j, i)) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_sparse_nonsymmetric_float_test")
+  {
+  for (size_t t = 0; t < 10; ++t)
+    {
+    const uword r_size = 5 * (t + 1);
+    const uword c_size = 3 * (t + 4);
+
+    fmat rX;
+    rX.randu(r_size, c_size);
+
+    SpMat<float> A;
+    A.sprandu(r_size, r_size, 0.25);
+    for (uword i = 0; i < r_size; ++i)
+      {
+      A(i, i) += rand();
+      }
+
+    fmat B = A * rX;
+
+    fmat X;
+    bool result = spsolve(X, A, B);
+    REQUIRE( result );
+
+    // Dense solver.
+    fmat dA(A);
+    fmat dX = solve(dA, B);
+
+    REQUIRE( X.n_cols == dX.n_cols );
+    REQUIRE( X.n_rows == dX.n_rows );
+
+    for (uword i = 0; i < dX.n_cols; ++i)
+      {
+      for (uword j = 0; j < dX.n_rows; ++j)
+        {
+        REQUIRE( (float) X(j, i) == Approx((float) dX(j, i)) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_sparse_complex_float_test")
+  {
+  // We want to spsolve a system of equations, AX = B, where we want to recover
+  // X and we have A and B, and A is sparse.
+  for (size_t t = 0; t < 10; ++t)
+    {
+    const uword size = 5 * (t + 1);
+
+    Mat<std::complex<float> > rX;
+    rX.randu(size, size);
+
+    SpMat<std::complex<float> > A;
+    A.sprandu(size, size, 0.25);
+    for(uword i = 0; i < size; ++i)
+      {
+      A(i, i) += rand();
+      }
+
+    Mat<std::complex<float> > B = A * rX;
+
+    Mat<std::complex<float> > X;
+    bool result = spsolve(X, A, B);
+    REQUIRE( result );
+
+    // Dense solver.
+    Mat<std::complex<float> > dA(A);
+    Mat<std::complex<float> > dX = solve(dA, B);
+
+    REQUIRE( X.n_cols == dX.n_cols );
+    REQUIRE( X.n_rows == dX.n_rows );
+
+    for (uword i = 0; i < dX.n_cols; ++i)
+      {
+      for (uword j = 0; j < dX.n_rows; ++j)
+        {
+        REQUIRE( (float) std::abs((std::complex<float>) X(j, i)) ==
+                 Approx((float) std::abs((std::complex<float>) dX(j, i))) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_sparse_nonsymmetric_complex_float_test")
+  {
+  for (size_t t = 0; t < 10; ++t)
+    {
+    const uword r_size = 5 * (t + 1);
+    const uword c_size = 3 * (t + 4);
+
+    Mat<std::complex<float> > rX;
+    rX.randu(r_size, c_size);
+
+    SpMat<std::complex<float> > A;
+    A.sprandu(r_size, r_size, 0.25);
+    for (uword i = 0; i < r_size; ++i)
+      {
+      A(i, i) += rand();
+      }
+
+    Mat<std::complex<float> > B = A * rX;
+
+    Mat<std::complex<float> > X;
+    bool result = spsolve(X, A, B);
+    REQUIRE( result );
+
+    // Dense solver.
+    Mat<std::complex<float> > dA(A);
+    Mat<std::complex<float> > dX = solve(dA, B);
+
+    REQUIRE( X.n_cols == dX.n_cols );
+    REQUIRE( X.n_rows == dX.n_rows );
+
+    for (uword i = 0; i < dX.n_cols; ++i)
+      {
+      for (uword j = 0; j < dX.n_rows; ++j)
+        {
+        REQUIRE( (float) std::abs((std::complex<float>) X(j, i)) ==
+                 Approx((float) std::abs((std::complex<float>) dX(j, i))) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_sparse_complex_test")
+  {
+  // We want to spsolve a system of equations, AX = B, where we want to recover
+  // X and we have A and B, and A is sparse.
+  for (size_t t = 0; t < 10; ++t)
+    {
+    const uword size = 5 * (t + 1);
+
+    Mat<std::complex<double> > rX;
+    rX.randu(size, size);
+
+    SpMat<std::complex<double> > A;
+    A.sprandu(size, size, 0.25);
+    for (uword i = 0; i < size; ++i)
+      {
+      A(i, i) += rand();
+      }
+
+    Mat<std::complex<double> > B = A * rX;
+
+    Mat<std::complex<double> > X;
+    bool result = spsolve(X, A, B);
+    REQUIRE( result );
+
+    // Dense solver.
+    Mat<std::complex<double> > dA(A);
+    Mat<std::complex<double> > dX = solve(dA, B);
+
+    REQUIRE( X.n_cols == dX.n_cols );
+    REQUIRE( X.n_rows == dX.n_rows );
+
+    for (uword i = 0; i < dX.n_cols; ++i)
+      {
+      for (uword j = 0; j < dX.n_rows; ++j)
+        {
+        REQUIRE( (double) std::abs((std::complex<double>) X(j, i)) ==
+                 Approx((double) std::abs((std::complex<double>) dX(j, i))) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_sparse_nonsymmetric_complex_test")
+  {
+  for (size_t t = 0; t < 10; ++t)
+    {
+    const uword r_size = 5 * (t + 1);
+    const uword c_size = 3 * (t + 4);
+
+    Mat<std::complex<double> > rX;
+    rX.randu(r_size, c_size);
+
+    SpMat<std::complex<double> > A;
+    A.sprandu(r_size, r_size, 0.25);
+    for (uword i = 0; i < r_size; ++i)
+      {
+      A(i, i) += rand();
+      }
+
+    Mat<std::complex<double> > B = A * rX;
+
+    Mat<std::complex<double> > X;
+    bool result = spsolve(X, A, B);
+    REQUIRE( result );
+
+    // Dense solver.
+    Mat<std::complex<double> > dA(A);
+    Mat<std::complex<double> > dX = solve(dA, B);
+
+    REQUIRE( X.n_cols == dX.n_cols );
+    REQUIRE( X.n_rows == dX.n_rows );
+
+    for (uword i = 0; i < dX.n_cols; ++i)
+      {
+      for (uword j = 0; j < dX.n_rows; ++j)
+        {
+        REQUIRE( (double) std::abs((std::complex<double>) X(j, i)) ==
+                 Approx((double) std::abs((std::complex<double>) dX(j, i))) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_delayed_sparse_test")
+  {
+  const uword size = 10;
+
+  mat rX;
+  rX.randu(size, size);
+
+  sp_mat A;
+  A.sprandu(size, size, 0.25);
+  for (uword i = 0; i < size; ++i)
+    {
+    A(i, i) += rand();
+    }
+
+  mat B = A * rX;
+
+  mat X;
+  bool result = spsolve(X, A, B);
+  REQUIRE( result );
+
+  mat dX = spsolve(A, B);
+
+  REQUIRE( X.n_cols == dX.n_cols );
+  REQUIRE( X.n_rows == dX.n_rows );
+
+  for (uword i = 0; i < dX.n_cols; ++i)
+    {
+    for (uword j = 0; j < dX.n_rows; ++j)
+      {
+      REQUIRE( (double) X(j, i) == Approx((double) dX(j, i)) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_superlu_solve_test")
+  {
+  // Solve this matrix, as in the examples:
+  // [[19  0  21 21  0]
+  //  [12 21   0  0  0]
+  //  [ 0 12  16  0  0]
+  //  [ 0  0   0  5 21]
+  //  [12 12   0  0 18]]
+  sp_mat b(5, 5);
+  b(0, 0) = 19;
+  b(0, 2) = 21;
+  b(0, 3) = 21;
+  b(1, 0) = 12;
+  b(1, 1) = 21;
+  b(2, 1) = 12;
+  b(2, 2) = 16;
+  b(3, 3) = 5;
+  b(3, 4) = 21;
+  b(4, 0) = 12;
+  b(4, 1) = 12;
+  b(4, 4) = 18;
+
+  mat db(b);
+
+  sp_mat a;
+  a.eye(5, 5);
+  mat da(a);
+
+  mat x;
+  spsolve(x, a, db);
+
+  mat dx = solve(da, db);
+
+  for (uword i = 0; i < x.n_cols; ++i)
+    {
+    for (uword j = 0; j < x.n_rows; ++j)
+      {
+      REQUIRE( (double) x(j, i) == Approx(dx(j, i)) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_random_superlu_solve_test")
+  {
+  // Try to solve some random systems.
+  const size_t iterations = 10;
+  for (size_t it = 0; it < iterations; ++it)
+    {
+    sp_mat a;
+    a.sprandu(50, 50, 0.3);
+    sp_mat trueX;
+    trueX.sprandu(50, 50, 0.3);
+
+    sp_mat b = a * trueX;
+
+    // Get things into the right format.
+    mat db(b);
+
+    mat x;
+
+    spsolve(x, a, db);
+
+    for (uword i = 0; i < x.n_cols; ++i)
+      {
+      for (uword j = 0; j < x.n_rows; ++j)
+        {
+        REQUIRE( x(j, i) == Approx((double) trueX(j, i)) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_float_superlu_solve_test")
+  {
+  // Solve this matrix, as in the examples:
+  // [[19  0  21 21  0]
+  //  [12 21   0  0  0]
+  //  [ 0 12  16  0  0]
+  //  [ 0  0   0  5 21]
+  //  [12 12   0  0 18]]
+  sp_fmat b(5, 5);
+  b(0, 0) = 19;
+  b(0, 2) = 21;
+  b(0, 3) = 21;
+  b(1, 0) = 12;
+  b(1, 1) = 21;
+  b(2, 1) = 12;
+  b(2, 2) = 16;
+  b(3, 3) = 5;
+  b(3, 4) = 21;
+  b(4, 0) = 12;
+  b(4, 1) = 12;
+  b(4, 4) = 18;
+
+  fmat db(b);
+
+  sp_fmat a;
+  a.eye(5, 5);
+  fmat da(a);
+
+  fmat x;
+  spsolve(x, a, db);
+
+  fmat dx = solve(da, db);
+
+  for (uword i = 0; i < x.n_cols; ++i)
+    {
+    for (uword j = 0; j < x.n_rows; ++j)
+      {
+      REQUIRE( (float) x(j, i) == Approx(dx(j, i)) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_float_random_superlu_solve_test")
+  {
+  // Try to solve some random systems.
+  const size_t iterations = 10;
+  for (size_t it = 0; it < iterations; ++it)
+    {
+    sp_fmat a;
+    a.sprandu(50, 50, 0.3);
+    sp_fmat trueX;
+    trueX.sprandu(50, 50, 0.3);
+
+    sp_fmat b = a * trueX;
+
+    // Get things into the right format.
+    fmat db(b);
+
+    fmat x;
+
+    spsolve(x, a, db);
+
+    for (uword i = 0; i < x.n_cols; ++i)
+      {
+      for (uword j = 0; j < x.n_rows; ++j)
+        {
+        if (std::abs(trueX(j, i)) < 0.001)
+          REQUIRE( std::abs(x(j, i)) < 0.005 );
+        else
+          REQUIRE( trueX(j, i) == Approx((float) x(j, i)).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_cx_float_superlu_solve_test")
+  {
+  // Solve this matrix, as in the examples:
+  // [[19  0  21 21  0]
+  //  [12 21   0  0  0]
+  //  [ 0 12  16  0  0]
+  //  [ 0  0   0  5 21]
+  //  [12 12   0  0 18]] (imaginary part is the same)
+  SpMat<std::complex<float> > b(5, 5);
+  b(0, 0) = std::complex<float>(19, 19);
+  b(0, 2) = std::complex<float>(21, 21);
+  b(0, 3) = std::complex<float>(21, 21);
+  b(1, 0) = std::complex<float>(12, 12);
+  b(1, 1) = std::complex<float>(21, 21);
+  b(2, 1) = std::complex<float>(12, 12);
+  b(2, 2) = std::complex<float>(16, 16);
+  b(3, 3) = std::complex<float>(5, 5);
+  b(3, 4) = std::complex<float>(21, 21);
+  b(4, 0) = std::complex<float>(12, 12);
+  b(4, 1) = std::complex<float>(12, 12);
+  b(4, 4) = std::complex<float>(18, 18);
+
+  Mat<std::complex<float> > db(b);
+
+  SpMat<std::complex<float> > a;
+  a.eye(5, 5);
+  Mat<std::complex<float> > da(a);
+
+  Mat<std::complex<float> > x;
+  spsolve(x, a, db);
+
+  Mat<std::complex<float> > dx = solve(da, db);
+
+  for (uword i = 0; i < x.n_cols; ++i)
+    {
+    for (uword j = 0; j < x.n_rows; ++j)
+      {
+      if (std::abs(x(j, i)) < 0.001 )
+        {
+        REQUIRE( std::abs(dx(j, i)) < 0.005 );
+        }
+      else
+        {
+        REQUIRE( ((std::complex<float>) x(j, i)).real() ==
+                 Approx(dx(j, i).real()).epsilon(0.01) );
+        REQUIRE( ((std::complex<float>) x(j, i)).imag() ==
+                 Approx(dx(j, i).imag()).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_cx_float_random_superlu_solve_test")
+  {
+  // Try to solve some random systems.
+  const size_t iterations = 10;
+  for (size_t it = 0; it < iterations; ++it)
+    {
+    SpMat<std::complex<float> > a;
+    a.sprandu(50, 50, 0.3);
+    SpMat<std::complex<float> > trueX;
+    trueX.sprandu(50, 50, 0.3);
+
+    SpMat<std::complex<float> > b = a * trueX;
+
+    // Get things into the right format.
+    Mat<std::complex<float> > db(b);
+
+    Mat<std::complex<float> > x;
+
+    spsolve(x, a, db);
+
+    for (uword i = 0; i < x.n_cols; ++i)
+      {
+      for (uword j = 0; j < x.n_rows; ++j)
+        {
+        if (std::abs((std::complex<float>) trueX(j, i)) < 0.001 )
+          {
+          REQUIRE( std::abs(x(j, i)) < 0.001 );
+          }
+        else
+          {
+          REQUIRE( ((std::complex<float>) trueX(j, i)).real() ==
+                   Approx(x(j, i).real()).epsilon(0.01) );
+          REQUIRE( ((std::complex<float>) trueX(j, i)).imag() ==
+                   Approx(x(j, i).imag()).epsilon(0.01) );
+          }
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_cx_superlu_solve_test")
+  {
+  // Solve this matrix, as in the examples:
+  // [[19  0  21 21  0]
+  //  [12 21   0  0  0]
+  //  [ 0 12  16  0  0]
+  //  [ 0  0   0  5 21]
+  //  [12 12   0  0 18]] (imaginary part is the same)
+  SpMat<std::complex<double> > b(5, 5);
+  b(0, 0) = std::complex<double>(19, 19);
+  b(0, 2) = std::complex<double>(21, 21);
+  b(0, 3) = std::complex<double>(21, 21);
+  b(1, 0) = std::complex<double>(12, 12);
+  b(1, 1) = std::complex<double>(21, 21);
+  b(2, 1) = std::complex<double>(12, 12);
+  b(2, 2) = std::complex<double>(16, 16);
+  b(3, 3) = std::complex<double>(5, 5);
+  b(3, 4) = std::complex<double>(21, 21);
+  b(4, 0) = std::complex<double>(12, 12);
+  b(4, 1) = std::complex<double>(12, 12);
+  b(4, 4) = std::complex<double>(18, 18);
+
+  cx_mat db(b);
+
+  sp_cx_mat a;
+  a.eye(5, 5);
+  cx_mat da(a);
+
+  cx_mat x;
+  spsolve(x, a, db);
+
+  cx_mat dx = solve(da, db);
+
+  for (uword i = 0; i < x.n_cols; ++i)
+    {
+    for (uword j = 0; j < x.n_rows; ++j)
+      {
+      if (std::abs(x(j, i)) < 0.001)
+        {
+        REQUIRE( std::abs(dx(j, i)) < 0.005 );
+        }
+      else
+        {
+        REQUIRE( ((std::complex<double>) x(j, i)).real() ==
+                 Approx(dx(j, i).real()).epsilon(0.01) );
+        REQUIRE( ((std::complex<double>) x(j, i)).imag() ==
+                 Approx(dx(j, i).imag()).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_cx_random_superlu_solve_test")
+  {
+  // Try to solve some random systems.
+  const size_t iterations = 10;
+  for (size_t it = 0; it < iterations; ++it)
+    {
+    sp_cx_mat a;
+    a.sprandu(50, 50, 0.3);
+    sp_cx_mat trueX;
+    trueX.sprandu(50, 50, 0.3);
+
+    sp_cx_mat b = a * trueX;
+
+    // Get things into the right format.
+    cx_mat db(b);
+
+    cx_mat x;
+
+    spsolve(x, a, db);
+
+    for (uword i = 0; i < x.n_cols; ++i)
+      {
+      for (uword j = 0; j < x.n_rows; ++j)
+        {
+        if (std::abs((std::complex<double>) trueX(j, i)) < 0.001)
+          {
+          REQUIRE( std::abs(x(j, i)) < 0.005 );
+          }
+        else
+          {
+          REQUIRE( ((std::complex<double>) trueX(j, i)).real() ==
+                   Approx(x(j, i).real()).epsilon(0.01) );
+          REQUIRE( ((std::complex<double>) trueX(j, i)).imag() ==
+                   Approx(x(j, i).imag()).epsilon(0.01) );
+          }
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_function_test")
+  {
+  sp_mat a;
+  a.sprandu(50, 50, 0.3);
+  sp_mat trueX;
+  trueX.sprandu(50, 50, 0.3);
+
+  sp_mat b = a * trueX;
+
+  // Get things into the right format.
+  mat db(b);
+
+  mat x;
+
+  // Mostly these are compilation tests.
+  spsolve(x, a, db);
+  x = spsolve(a, db); // Test another overload.
+  x = spsolve(a, db + 0.0);
+  spsolve(x, a, db + 0.0);
+
+  for (uword i = 0; i < x.n_cols; ++i)
+    {
+    for (uword j = 0; j < x.n_rows; ++j)
+      {
+      REQUIRE( (double) trueX(j, i) == Approx(x(j, i)) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_float_function_test")
+  {
+  sp_fmat a;
+  a.sprandu(50, 50, 0.3);
+  sp_fmat trueX;
+  trueX.sprandu(50, 50, 0.3);
+
+  sp_fmat b = a * trueX;
+
+  // Get things into the right format.
+  fmat db(b);
+
+  fmat x;
+
+  // Mostly these are compilation tests.
+  spsolve(x, a, db);
+  x = spsolve(a, db); // Test another overload.
+  x = spsolve(a, db + 0.0);
+  spsolve(x, a, db + 0.0);
+
+  for (uword i = 0; i < x.n_cols; ++i)
+    {
+    for (uword j = 0; j < x.n_rows; ++j)
+      {
+      if (std::abs(trueX(j, i)) < 0.001)
+        {
+        REQUIRE( std::abs(x(j, i)) < 0.001 );
+        }
+      else
+        {
+        REQUIRE( (float) trueX(j, i) == Approx(x(j, i)).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_cx_function_test")
+  {
+  sp_cx_mat a;
+  a.sprandu(50, 50, 0.3);
+  sp_cx_mat trueX;
+  trueX.sprandu(50, 50, 0.3);
+
+  sp_cx_mat b = a * trueX;
+
+  // Get things into the right format.
+  cx_mat db(b);
+
+  cx_mat x;
+
+  // Mostly these are compilation tests.
+  spsolve(x, a, db);
+  x = spsolve(a, db); // Test another overload.
+  x = spsolve(a, db + std::complex<double>(0.0));
+  spsolve(x, a, db + std::complex<double>(0.0));
+
+  for (uword i = 0; i < x.n_cols; ++i)
+    {
+    for (uword j = 0; j < x.n_rows; ++j)
+      {
+      if (std::abs((std::complex<double>) trueX(j, i)) < 0.001)
+        {
+        REQUIRE( std::abs(x(j, i)) < 0.005 );
+        }
+      else
+        {
+        REQUIRE( ((std::complex<double>) trueX(j, i)).real() ==
+                 Approx(x(j, i).real()).epsilon(0.01) );
+        REQUIRE( ((std::complex<double>) trueX(j, i)).imag() ==
+                 Approx(x(j, i).imag()).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_spsolve_cx_float_function_test")
+  {
+  sp_cx_fmat a;
+  a.sprandu(50, 50, 0.3);
+  sp_cx_fmat trueX;
+  trueX.sprandu(50, 50, 0.3);
+
+  sp_cx_fmat b = a * trueX;
+
+  // Get things into the right format.
+  cx_fmat db(b);
+
+  cx_fmat x;
+
+  // Mostly these are compilation tests.
+  spsolve(x, a, db);
+  x = spsolve(a, db); // Test another overload.
+  x = spsolve(a, db + std::complex<float>(0.0));
+  spsolve(x, a, db + std::complex<float>(0.0));
+
+  for (uword i = 0; i < x.n_cols; ++i)
+    {
+    for (uword j = 0; j < x.n_rows; ++j)
+      {
+      if (std::abs((std::complex<float>) trueX(j, i)) < 0.001 )
+        {
+        REQUIRE( std::abs(x(j, i)) < 0.005 );
+        }
+      else
+        {
+        REQUIRE( ((std::complex<float>) trueX(j, i)).real() ==
+                 Approx(x(j, i).real()).epsilon(0.01) );
+        REQUIRE( ((std::complex<float>) trueX(j, i)).imag() ==
+                 Approx(x(j, i).imag()).epsilon(0.01) );
+        }
+      }
+    }
+  }
+
+#endif

--- a/tests/fn_sum.cpp
+++ b/tests/fn_sum.cpp
@@ -1,11 +1,11 @@
 // Copyright 2015 Conrad Sanderson (http://conradsanderson.id.au)
 // Copyright 2015 National ICT Australia (NICTA)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,7 @@ TEST_CASE("fn_sum_1")
   {
   vec a = linspace<vec>(1,5,5);
   vec b = linspace<vec>(1,5,6);
-  
+
   REQUIRE(sum(a) == Approx(15.0));
   REQUIRE(sum(b) == Approx(18.0));
   }
@@ -39,16 +39,16 @@ TEST_CASE("sum2")
     {  0.49345, -0.12020,  0.78987,  0.53124 },
     {  0.73573,  0.52104, -0.22263,  0.40163 }
     };
-  
+
   rowvec colsums = { 0.44080, 1.09382, 0.97808, 1.83429 };
-  
+
   colvec rowsums =
     {
     1.21686,
     1.69436,
     1.43577
     };
-  
+
   REQUIRE( accu(abs(colsums - sum(A  ))) == Approx(0.0) );
   REQUIRE( accu(abs(colsums - sum(A,0))) == Approx(0.0) );
   REQUIRE( accu(abs(rowsums - sum(A,1))) == Approx(0.0) );
@@ -63,22 +63,22 @@ TEST_CASE("sum3")
     {  0.49345, -0.12020,  0.78987,  0.53124 },
     {  0.73573,  0.52104, -0.22263,  0.40163 }
     };
-  
+
   cx_mat A = cx_mat(AA, 0.5*AA);
-  
+
   rowvec re_colsums = { 0.44080, 1.09382, 0.97808, 1.83429 };
-  
+
   cx_rowvec cx_colsums = cx_rowvec(re_colsums, 0.5*re_colsums);
-  
+
   colvec re_rowsums =
     {
     1.21686,
     1.69436,
     1.43577
     };
-  
+
   cx_colvec cx_rowsums = cx_colvec(re_rowsums, 0.5*re_rowsums);
-  
+
   REQUIRE( accu(abs(cx_colsums - sum(A  ))) == Approx(0.0) );
   REQUIRE( accu(abs(cx_colsums - sum(A,0))) == Approx(0.0) );
   REQUIRE( accu(abs(cx_rowsums - sum(A,1))) == Approx(0.0) );
@@ -88,7 +88,69 @@ TEST_CASE("sum3")
 TEST_CASE("sum4")
   {
   mat X(100,101, fill::randu);
-  
+
   REQUIRE( (sum(sum(X))/X.n_elem)                      == Approx(0.5).epsilon(0.01) );
   REQUIRE( (sum(sum(X(span::all,span::all)))/X.n_elem) == Approx(0.5).epsilon(0.01) );
+  }
+
+
+
+TEST_CASE("sum_spmat")
+  {
+  SpCol<double> a(5);
+  a(0) = 3.0;
+  a(2) = 1.5;
+  a(3) = 1.0;
+
+  double res = sum(a);
+  REQUIRE( res == Approx(5.5) );
+
+  SpRow<double> b(5);
+  b(1) = 1.3;
+  b(2) = 4.4;
+  b(4) = 1.0;
+
+  res = sum(b);
+  REQUIRE( res == Approx(6.7) );
+
+  SpMat<double> c(8, 8);
+  c(0, 0) = 3.0;
+  c(1, 0) = 2.5;
+  c(6, 0) = 2.1;
+  c(4, 1) = 3.2;
+  c(5, 1) = 1.1;
+  c(1, 2) = 1.3;
+  c(2, 3) = 4.1;
+  c(5, 5) = 2.3;
+  c(6, 5) = 3.1;
+  c(7, 5) = 1.2;
+  c(7, 7) = 3.4;
+
+  SpMat<double> result = sum(c, 0);
+
+  REQUIRE( result.n_rows == 1 );
+  REQUIRE( result.n_cols == 8 );
+  REQUIRE( result.n_nonzero == 6 );
+  REQUIRE( (double) result(0, 0) == Approx(7.6) );
+  REQUIRE( (double) result(0, 1) == Approx(4.3) );
+  REQUIRE( (double) result(0, 2) == Approx(1.3) );
+  REQUIRE( (double) result(0, 3) == Approx(4.1) );
+  REQUIRE( (double) result(0, 4) == Approx(0.0) );
+  REQUIRE( (double) result(0, 5) == Approx(6.6) );
+  REQUIRE( (double) result(0, 6) == Approx(0.0) );
+  REQUIRE( (double) result(0, 7) == Approx(3.4) );
+
+  result = sum(c, 1);
+
+  REQUIRE( result.n_rows == 8 );
+  REQUIRE( result.n_cols == 1 );
+  REQUIRE( result.n_nonzero == 7 );
+  REQUIRE( (double) result(0, 0) == Approx(3.0) );
+  REQUIRE( (double) result(1, 0) == Approx(3.8) );
+  REQUIRE( (double) result(2, 0) == Approx(4.1) );
+  REQUIRE( (double) result(3, 0) == Approx(0.0) );
+  REQUIRE( (double) result(4, 0) == Approx(3.2) );
+  REQUIRE( (double) result(5, 0) == Approx(3.4) );
+  REQUIRE( (double) result(6, 0) == Approx(5.2) );
+  REQUIRE( (double) result(7, 0) == Approx(4.6) );
   }

--- a/tests/fn_trace.cpp
+++ b/tests/fn_trace.cpp
@@ -1,11 +1,11 @@
 // Copyright 2015 Conrad Sanderson (http://conradsanderson.id.au)
 // Copyright 2015 National ICT Australia (NICTA)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ using namespace arma;
 
 TEST_CASE("fn_trace_1")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -30,14 +30,35 @@ TEST_CASE("fn_trace_1")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
+
   vec diagonal = { 0.061198, 0.058956, 0.314156, -0.393139, -0.353768 };
-  
+
   REQUIRE( accu( trace(A) - accu(diagonal) ) == Approx(0.0) );
-  
+
   REQUIRE( accu( trace(2*A) - accu(2*diagonal) ) == Approx(0.0) );
-  
+
   REQUIRE( accu( trace(A+A) - accu(diagonal+diagonal) ) == Approx(0.0) );
-  
+
   // REQUIRE_THROWS(  );
+  }
+
+
+
+TEST_CASE("fn_trace_spmat")
+  {
+  SpMat<double> a(6, 6);
+  a(0, 0) = 3.0;
+  a(2, 1) = 4.4;
+  a(4, 1) = 1.2;
+  a(0, 2) = 3.1;
+  a(1, 2) = 3.2;
+  a(2, 2) = 3.3;
+  a(3, 3) = 4.0;
+  a(5, 3) = 6.0;
+  a(5, 4) = 5.9;
+  a(5, 5) = 1.2;
+
+  REQUIRE( trace(a) == Approx(11.5) );
+
+  REQUIRE( trace(a.submat(2, 2, 4, 4)) == Approx(7.3) );
   }

--- a/tests/fn_trans.cpp
+++ b/tests/fn_trans.cpp
@@ -1,11 +1,11 @@
 // Copyright 2015 Conrad Sanderson (http://conradsanderson.id.au)
 // Copyright 2015 National ICT Australia (NICTA)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,7 @@ using namespace arma;
 
 TEST_CASE("fn_trans_1")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -30,8 +30,8 @@ TEST_CASE("fn_trans_1")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
-  mat At = 
+
+  mat At =
     "\
      0.061198   0.437242  -0.492474   0.336352   0.239585;\
      0.201990   0.058956  -0.031309   0.411541  -0.428913;\
@@ -40,9 +40,9 @@ TEST_CASE("fn_trans_1")
     -0.126745   0.296153   0.068317  -0.135040  -0.353768;\
      0.051408   0.035437  -0.454499   0.373833   0.258704;\
     ";
-  
+
   rowvec At_sum0 = { -0.28641, 0.63296, -0.17608, 1.05202, -0.98237 };
-  
+
   colvec At_sum1 =
     {
      0.58190,
@@ -52,10 +52,10 @@ TEST_CASE("fn_trans_1")
     -0.25108,
      0.26488
     };
-    
-  
+
+
   rowvec A_col1_t = { 0.201990, 0.058956, -0.031309, 0.411541, -0.428913 };
-  
+
   colvec A_row1_t =
     {
      0.437242,
@@ -65,93 +65,93 @@ TEST_CASE("fn_trans_1")
      0.296153,
      0.035437
     };
-  
-  
+
+
   double accu_A_col1_t = 0.21227;
   double accu_A_row1_t = 0.63296;
-  
+
   REQUIRE( accu(abs(mat(A.t().t()) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(    A.t().t()  - A)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(mat(A.t()    ) - At)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(A.st()   ) - At)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(A.ht()   ) - At)) == Approx(0.0) );
   REQUIRE( accu(abs(mat( trans(A)) - At)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(strans(A)) - At)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(A.t()     - At)) == Approx(0.0) );
   REQUIRE( accu(abs(A.st()    - At)) == Approx(0.0) );
   REQUIRE( accu(abs(A.ht()    - At)) == Approx(0.0) );
   REQUIRE( accu(abs( trans(A) - At)) == Approx(0.0) );
   REQUIRE( accu(abs(strans(A) - At)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(mat(At.t()    ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(At.st()   ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(At.ht()   ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(mat( trans(At)) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(strans(At)) - A)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(At.t()     - A)) == Approx(0.0) );
   REQUIRE( accu(abs(At.st()    - A)) == Approx(0.0) );
   REQUIRE( accu(abs(At.ht()    - A)) == Approx(0.0) );
   REQUIRE( accu(abs( trans(At) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(strans(At) - A)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs((0 + At.t()    ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs((0 + At.st()   ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs((0 + At.ht()   ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs((0 +  trans(At)) - A)) == Approx(0.0) );
   REQUIRE( accu(abs((0 + strans(At)) - A)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(mat(0 + At.t()    ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(0 + At.st()   ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(0 + At.ht()   ) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(0 +  trans(At)) - A)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(0 + strans(At)) - A)) == Approx(0.0) );
-  
-  
+
+
   REQUIRE( accu(abs(2*A.t()    - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(2*trans(A) - 2*At)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs((2*A).t()  - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(trans(2*A) - 2*At)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs((A+A).t()  - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(trans(A+A) - 2*At)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs((A.t()    + At) - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs((trans(A) + At) - 2*At)) == Approx(0.0) );
-  
+
 
   REQUIRE( accu(abs(mat(2*A.t())    - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(2*trans(A)) - 2*At)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(mat((2*A).t())  - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(trans(2*A)) - 2*At)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(mat((A+A).t())  - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(trans(A+A)) - 2*At)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(mat(A.t()    + At) - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(mat(trans(A) + At) - 2*At)) == Approx(0.0) );
-  
-  
+
+
   REQUIRE( accu(abs(rowvec(A.col(1).t()) - A_col1_t)) == Approx(0.0) );
   REQUIRE( accu(abs(colvec(A.row(1).t()) - A_row1_t)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(A.col(1).t() - A_col1_t)) == Approx(0.0) );
   REQUIRE( accu(abs(A.row(1).t() - A_row1_t)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(2*A.col(1).t() - 2*A_col1_t)) == Approx(0.0) );
   REQUIRE( accu(abs(2*A.row(1).t() - 2*A_row1_t)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs( (A.col(1).t() + A_col1_t) - 2*A_col1_t)) == Approx(0.0) );
   REQUIRE( accu(abs( (A.row(1).t() + A_row1_t) - 2*A_row1_t)) == Approx(0.0) );
-  
-  
+
+
   REQUIRE( abs( accu(A.col(1).t()) - accu_A_col1_t ) == Approx(0.0) );
   REQUIRE( abs( accu(A.row(1).t()) - accu_A_row1_t ) == Approx(0.0) );
-  
+
   REQUIRE( abs( accu(A.col(1).t()) - accu(A.col(1)) ) == Approx(0.0) );
   REQUIRE( abs( accu(A.row(1).t()) - accu(A.row(1)) ) == Approx(0.0) );
 
@@ -165,7 +165,7 @@ TEST_CASE("fn_trans_1")
 
 TEST_CASE("fn_trans_2")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -173,10 +173,10 @@ TEST_CASE("fn_trans_2")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
+
   cx_mat C = cx_mat(A,fliplr(A));
 
-  cx_mat Ct = 
+  cx_mat Ct =
     {
     { cx_double( 0.061198, -0.051408), cx_double( 0.437242, -0.035437), cx_double(-0.492474, +0.454499), cx_double( 0.336352, -0.373833), cx_double( 0.239585, -0.258704) },
     { cx_double( 0.201990, +0.126745), cx_double( 0.058956, -0.296153), cx_double(-0.031309, -0.068317), cx_double( 0.411541, +0.135040), cx_double(-0.428913, +0.353768) },
@@ -185,10 +185,10 @@ TEST_CASE("fn_trans_2")
     { cx_double(-0.126745, -0.201990), cx_double( 0.296153, -0.058956), cx_double( 0.068317, +0.031309), cx_double(-0.135040, -0.411541), cx_double(-0.353768, +0.428913) },
     { cx_double( 0.051408, -0.061198), cx_double( 0.035437, -0.437242), cx_double(-0.454499, +0.492474), cx_double( 0.373833, -0.336352), cx_double( 0.258704, -0.239585) }
     };
-  
+
   cx_rowvec C_col1_t = { cx_double(0.201990, +0.126745), cx_double(0.058956, -0.296153), cx_double(-0.031309, -0.068317), cx_double(0.411541, +0.135040), cx_double(-0.428913, +0.353768) };
-  
-  cx_colvec C_row1_t = 
+
+  cx_colvec C_row1_t =
     {
     cx_double( 0.437242, -0.035437),
     cx_double( 0.058956, -0.296153),
@@ -197,96 +197,96 @@ TEST_CASE("fn_trans_2")
     cx_double( 0.296153, -0.058956),
     cx_double( 0.035437, -0.437242)
     };
-  
-  
+
+
   REQUIRE( accu(abs(C.t().t() - C)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_mat(C.t()   ) - Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(C.ht()  ) - Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(trans(C)) - Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(C.t()    - Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(C.ht()   - Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(trans(C) - Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_mat(Ct.t()   ) - C)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(Ct.ht()  ) - C)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(trans(Ct)) - C)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(Ct.t()    - C)) == Approx(0.0) );
   REQUIRE( accu(abs(Ct.ht()   - C)) == Approx(0.0) );
   REQUIRE( accu(abs(trans(Ct) - C)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(2*C.t()    - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(2*trans(C) - 2*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs((2*C).t()  - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(trans(2*C) - 2*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs((C+C).t()  - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(trans(C+C) - 2*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_double(2,3)*C.t()    - cx_double(2,3)*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_double(2,3)*trans(C) - cx_double(2,3)*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_mat(2*C.t())    - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(2*trans(C)) - 2*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_mat((2*C).t())  - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(trans(2*C)) - 2*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_mat((C+C).t())  - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(trans(C+C)) - 2*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_mat(cx_double(2,3)*C.t())    - cx_double(2,3)*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(cx_double(2,3)*trans(C)) - cx_double(2,3)*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs((C.t()    + Ct) - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs((trans(C) + Ct) - 2*Ct)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_rowvec(C.col(1).t()) - C_col1_t)) == Approx(0.0) );
   REQUIRE( accu(abs(cx_colvec(C.row(1).t()) - C_row1_t)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(C.col(1).t() - C_col1_t)) == Approx(0.0) );
   REQUIRE( accu(abs(C.row(1).t() - C_row1_t)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(2*C.col(1).t() - 2*C_col1_t)) == Approx(0.0) );
   REQUIRE( accu(abs(2*C.row(1).t() - 2*C_row1_t)) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs( (C.col(1).t() + C_col1_t) - 2*C_col1_t)) == Approx(0.0) );
   REQUIRE( accu(abs( (C.row(1).t() + C_row1_t) - 2*C_row1_t)) == Approx(0.0) );
-  
+
   //
 
   REQUIRE( accu(abs(cx_mat(C.st())    - conj(Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(cx_mat(strans(C)) - conj(Ct))) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(C.st()    - conj(Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(strans(C) - conj(Ct))) == Approx(0.0) );
 
   REQUIRE( accu(abs(2*C.st()    - conj(2*Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(2*strans(C) - conj(2*Ct))) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_double(2,3)*C.st()    - cx_double(2,3)*conj(Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(cx_double(2,3)*strans(C) - cx_double(2,3)*conj(Ct))) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs((C.st()    + C.st()) - conj(2*Ct))) == Approx(0.0) );
   REQUIRE( accu(abs((strans(C) + C.st()) - conj(2*Ct))) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(cx_rowvec(C.col(1).st()) - conj(C_col1_t))) == Approx(0.0) );
   REQUIRE( accu(abs(cx_colvec(C.row(1).st()) - conj(C_row1_t))) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(C.col(1).st() - conj(C_col1_t))) == Approx(0.0) );
   REQUIRE( accu(abs(C.row(1).st() - conj(C_row1_t))) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs(2*C.col(1).st() - conj(2*C_col1_t))) == Approx(0.0) );
   REQUIRE( accu(abs(2*C.row(1).st() - conj(2*C_row1_t))) == Approx(0.0) );
-  
+
   REQUIRE( accu(abs( (C.col(1).st() + conj(C_col1_t)) - conj(2*C_col1_t))) == Approx(0.0) );
   REQUIRE( accu(abs( (C.row(1).st() + conj(C_row1_t)) - conj(2*C_row1_t))) == Approx(0.0) );
-  
+
   //
-  
+
   REQUIRE_THROWS( C + C.t() );
   }
 
@@ -294,7 +294,7 @@ TEST_CASE("fn_trans_2")
 
 TEST_CASE("fn_trans_3")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -302,8 +302,8 @@ TEST_CASE("fn_trans_3")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
-  mat At = 
+
+  mat At =
     "\
      0.061198   0.437242  -0.492474   0.336352   0.239585;\
      0.201990   0.058956  -0.031309   0.411541  -0.428913;\
@@ -312,53 +312,53 @@ TEST_CASE("fn_trans_3")
     -0.126745   0.296153   0.068317  -0.135040  -0.353768;\
      0.051408   0.035437  -0.454499   0.373833   0.258704;\
     ";
-  
+
   mat B = A.head_cols(5);
-  
+
   mat Bt = At.head_rows(5);
-  
+
   mat X;
   mat Y;
-  
+
   X = A;  X = X.t();
   Y = B;  Y = Y.t();
-  
+
   REQUIRE( accu(abs(X - At)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - Bt)) == Approx(0.0) );
-  
+
   X = A;  X = 0 + X.t();
   Y = B;  Y = 0 + Y.t();
-  
+
   REQUIRE( accu(abs(X - At)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - Bt)) == Approx(0.0) );
-  
+
   X = A;  X = 2*X.t();
   Y = B;  Y = 2*Y.t();
-  
+
   REQUIRE( accu(abs(X - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*Bt)) == Approx(0.0) );
-  
+
   X = A;  X = 0 + 2*X.t();
   Y = B;  Y = 0 + 2*Y.t();
-  
+
   REQUIRE( accu(abs(X - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*Bt)) == Approx(0.0) );
-  
+
   X = A;  X = (2*X).t();
   Y = B;  Y = (2*Y).t();
-  
+
   REQUIRE( accu(abs(X - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*Bt)) == Approx(0.0) );
-  
+
   X = A;  X = (X+X).t();
   Y = B;  Y = (Y+Y).t();
-  
+
   REQUIRE( accu(abs(X - 2*At)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*Bt)) == Approx(0.0) );
-  
+
   colvec q = A.col(1);
   rowvec r = A.row(1);
-  
+
   REQUIRE_THROWS( q = q.t() );
   REQUIRE_THROWS( r = r.t() );
   }
@@ -367,7 +367,7 @@ TEST_CASE("fn_trans_3")
 
 TEST_CASE("fn_trans_4")
   {
-  mat A = 
+  mat A =
     "\
      0.061198   0.201990   0.019678  -0.493936  -0.126745   0.051408;\
      0.437242   0.058956  -0.149362  -0.045465   0.296153   0.035437;\
@@ -375,10 +375,10 @@ TEST_CASE("fn_trans_4")
      0.336352   0.411541   0.458476  -0.393139  -0.135040   0.373833;\
      0.239585  -0.428913  -0.406953  -0.291020  -0.353768   0.258704;\
     ";
-  
+
   cx_mat C = cx_mat(A,fliplr(A));
 
-  cx_mat Ct = 
+  cx_mat Ct =
     {
     { cx_double( 0.061198, -0.051408), cx_double( 0.437242, -0.035437), cx_double(-0.492474, +0.454499), cx_double( 0.336352, -0.373833), cx_double( 0.239585, -0.258704) },
     { cx_double( 0.201990, +0.126745), cx_double( 0.058956, -0.296153), cx_double(-0.031309, -0.068317), cx_double( 0.411541, +0.135040), cx_double(-0.428913, +0.353768) },
@@ -387,102 +387,235 @@ TEST_CASE("fn_trans_4")
     { cx_double(-0.126745, -0.201990), cx_double( 0.296153, -0.058956), cx_double( 0.068317, +0.031309), cx_double(-0.135040, -0.411541), cx_double(-0.353768, +0.428913) },
     { cx_double( 0.051408, -0.061198), cx_double( 0.035437, -0.437242), cx_double(-0.454499, +0.492474), cx_double( 0.373833, -0.336352), cx_double( 0.258704, -0.239585) }
     };
-  
+
   cx_mat D = C.head_cols(5);
-  
+
   cx_mat Dt = Ct.head_rows(5);
-  
+
   cx_mat X;
   cx_mat Y;
-  
+
   //
-  
+
   X = C;  X = X.t();
   Y = D;  Y = Y.t();
-  
+
   REQUIRE( accu(abs(X - Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - Dt)) == Approx(0.0) );
-  
+
   X = C;  X = 0 + X.t();
   Y = D;  Y = 0 + Y.t();
-  
+
   REQUIRE( accu(abs(X - Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - Dt)) == Approx(0.0) );
-  
+
   X = C;  X = 2*X.t();
   Y = D;  Y = 2*Y.t();
-  
+
   REQUIRE( accu(abs(X - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*Dt)) == Approx(0.0) );
 
   X = C;  X = 0 + 2*X.t();
   Y = D;  Y = 0 + 2*Y.t();
-  
+
   REQUIRE( accu(abs(X - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*Dt)) == Approx(0.0) );
 
   X = C;  X = (2*X).t();
   Y = D;  Y = (2*Y).t();
-  
+
   REQUIRE( accu(abs(X - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*Dt)) == Approx(0.0) );
 
   X = C;  X = (X+X).t();
   Y = D;  Y = (Y+Y).t();
-  
+
   REQUIRE( accu(abs(X - 2*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*Dt)) == Approx(0.0) );
 
   X = C;  X = cx_double(2,3)*X.t();
   Y = D;  Y = cx_double(2,3)*Y.t();
-  
+
   REQUIRE( accu(abs(X - cx_double(2,3)*Ct)) == Approx(0.0) );
   REQUIRE( accu(abs(Y - cx_double(2,3)*Dt)) == Approx(0.0) );
-  
+
   //
-  
+
   X = C;  X = X.st();
   Y = D;  Y = Y.st();
-  
+
   REQUIRE( accu(abs(X - conj(Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(Y - conj(Dt))) == Approx(0.0) );
-  
+
   X = C;  X = 0 + X.st();
   Y = D;  Y = 0 + Y.st();
-  
+
   REQUIRE( accu(abs(X - conj(Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(Y - conj(Dt))) == Approx(0.0) );
-  
+
   X = C;  X = 2*X.st();
   Y = D;  Y = 2*Y.st();
-  
+
   REQUIRE( accu(abs(X - 2*conj(Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*conj(Dt))) == Approx(0.0) );
 
   X = C;  X = 0 + 2*X.st();
   Y = D;  Y = 0 + 2*Y.st();
-  
+
   REQUIRE( accu(abs(X - 2*conj(Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(Y - 2*conj(Dt))) == Approx(0.0) );
 
   X = C;  X = (2*X).st();
   Y = D;  Y = (2*Y).st();
-  
+
   REQUIRE( accu(abs(X - conj(2*Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(Y - conj(2*Dt))) == Approx(0.0) );
 
   X = C;  X = (X+X).st();
   Y = D;  Y = (Y+Y).st();
-  
+
   REQUIRE( accu(abs(X - conj(2*Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(Y - conj(2*Dt))) == Approx(0.0) );
 
   X = C;  X = cx_double(2,3)*X.st();
   Y = D;  Y = cx_double(2,3)*Y.st();
-  
+
   REQUIRE( accu(abs(X - cx_double(2,3)*conj(Ct))) == Approx(0.0) );
   REQUIRE( accu(abs(Y - cx_double(2,3)*conj(Dt))) == Approx(0.0) );
   }
 
 
 
+TEST_CASE("op_trans_sp_mat")
+  {
+  SpMat<unsigned int> a(4, 4);
+  a(1, 0) = 5;
+  a(2, 2) = 3;
+  a(3, 3) = 4;
+  a(1, 3) = 6;
+  a(3, 1) = 8;
+
+  SpMat<unsigned int> b = trans(a);
+
+  REQUIRE( (unsigned int) b(0, 0) == 0 );
+  REQUIRE( (unsigned int) b(1, 0) == 0 );
+  REQUIRE( (unsigned int) b(2, 0) == 0 );
+  REQUIRE( (unsigned int) b(3, 0) == 0 );
+  REQUIRE( (unsigned int) b(0, 1) == 5 );
+  REQUIRE( (unsigned int) b(1, 1) == 0 );
+  REQUIRE( (unsigned int) b(2, 1) == 0 );
+  REQUIRE( (unsigned int) b(3, 1) == 6 );
+  REQUIRE( (unsigned int) b(0, 2) == 0 );
+  REQUIRE( (unsigned int) b(1, 2) == 0 );
+  REQUIRE( (unsigned int) b(2, 2) == 3 );
+  REQUIRE( (unsigned int) b(3, 2) == 0 );
+  REQUIRE( (unsigned int) b(0, 3) == 0 );
+  REQUIRE( (unsigned int) b(1, 3) == 8 );
+  REQUIRE( (unsigned int) b(2, 3) == 0 );
+  REQUIRE( (unsigned int) b(3, 3) == 4 );
+
+  b = trans(b); // inplace
+
+  REQUIRE( (unsigned int) b(0, 0) == 0 );
+  REQUIRE( (unsigned int) b(1, 0) == 5 );
+  REQUIRE( (unsigned int) b(2, 0) == 0 );
+  REQUIRE( (unsigned int) b(3, 0) == 0 );
+  REQUIRE( (unsigned int) b(0, 1) == 0 );
+  REQUIRE( (unsigned int) b(1, 1) == 0 );
+  REQUIRE( (unsigned int) b(2, 1) == 0 );
+  REQUIRE( (unsigned int) b(3, 1) == 8 );
+  REQUIRE( (unsigned int) b(0, 2) == 0 );
+  REQUIRE( (unsigned int) b(1, 2) == 0 );
+  REQUIRE( (unsigned int) b(2, 2) == 3 );
+  REQUIRE( (unsigned int) b(3, 2) == 0 );
+  REQUIRE( (unsigned int) b(0, 3) == 0 );
+  REQUIRE( (unsigned int) b(1, 3) == 6 );
+  REQUIRE( (unsigned int) b(2, 3) == 0 );
+  REQUIRE( (unsigned int) b(3, 3) == 4 );
+
+  b = trans(a + a); // on an op
+
+  REQUIRE( (unsigned int) b(0, 0) == 0 );
+  REQUIRE( (unsigned int) b(1, 0) == 0 );
+  REQUIRE( (unsigned int) b(2, 0) == 0 );
+  REQUIRE( (unsigned int) b(3, 0) == 0 );
+  REQUIRE( (unsigned int) b(0, 1) == 10 );
+  REQUIRE( (unsigned int) b(1, 1) == 0 );
+  REQUIRE( (unsigned int) b(2, 1) == 0 );
+  REQUIRE( (unsigned int) b(3, 1) == 12 );
+  REQUIRE( (unsigned int) b(0, 2) == 0 );
+  REQUIRE( (unsigned int) b(1, 2) == 0 );
+  REQUIRE( (unsigned int) b(2, 2) == 6 );
+  REQUIRE( (unsigned int) b(3, 2) == 0 );
+  REQUIRE( (unsigned int) b(0, 3) == 0 );
+  REQUIRE( (unsigned int) b(1, 3) == 16 );
+  REQUIRE( (unsigned int) b(2, 3) == 0 );
+  REQUIRE( (unsigned int) b(3, 3) == 8 );
+
+  b = trans(trans(a)); // on another trans
+
+  REQUIRE( (unsigned int) b(0, 0) == 0 );
+  REQUIRE( (unsigned int) b(1, 0) == 5 );
+  REQUIRE( (unsigned int) b(2, 0) == 0 );
+  REQUIRE( (unsigned int) b(3, 0) == 0 );
+  REQUIRE( (unsigned int) b(0, 1) == 0 );
+  REQUIRE( (unsigned int) b(1, 1) == 0 );
+  REQUIRE( (unsigned int) b(2, 1) == 0 );
+  REQUIRE( (unsigned int) b(3, 1) == 8 );
+  REQUIRE( (unsigned int) b(0, 2) == 0 );
+  REQUIRE( (unsigned int) b(1, 2) == 0 );
+  REQUIRE( (unsigned int) b(2, 2) == 3 );
+  REQUIRE( (unsigned int) b(3, 2) == 0 );
+  REQUIRE( (unsigned int) b(0, 3) == 0 );
+  REQUIRE( (unsigned int) b(1, 3) == 6 );
+  REQUIRE( (unsigned int) b(2, 3) == 0 );
+  REQUIRE( (unsigned int) b(3, 3) == 4 );
+  }
+
+
+TEST_CASE("op_trans_sp_cxmat")
+  {
+  SpMat<std::complex<double> > a(10, 10);
+  for (uword c = 0; c < 7; ++c)
+  {
+    a(c, c) = std::complex<double>(1.3, 2.4);
+    a(c + 1, c) = std::complex<double>(0.0, -1.3);
+    a(c + 2, c) = std::complex<double>(2.1, 0.0);
+  }
+
+  SpMat<std::complex<double> > b = trans(a);
+
+  REQUIRE( b.n_nonzero == a.n_nonzero );
+
+  for (uword r = 0; r < 10; ++r)
+    {
+    for (uword c = 0; c < 10; ++c)
+      {
+      double lr = real(std::complex<double>(a(r, c)));
+      double rr = real(std::complex<double>(b(c, r)));
+      double li = imag(std::complex<double>(a(r, c)));
+      double ri = imag(std::complex<double>(b(c, r)));
+
+      REQUIRE( lr == Approx(rr) );
+      REQUIRE( li == Approx(-ri) );
+      }
+    }
+
+  b = trans(a.submat(3, 3, 7, 7));
+
+  REQUIRE( b.n_nonzero == a.submat(3, 3, 7, 7).n_nonzero );
+
+  for (uword r = 0; r < 5; ++r)
+    {
+    for (uword c = 0; c < 5; ++c)
+      {
+      double lr = real(std::complex<double>(a(r + 3, c + 3)));
+      double rr = real(std::complex<double>(b(c, r)));
+      double li = imag(std::complex<double>(a(r + 3, c + 3)));
+      double ri = imag(std::complex<double>(b(c, r)));
+
+      REQUIRE( lr == Approx(rr) );
+      REQUIRE( li == Approx(-ri) );
+      }
+    }
+  }

--- a/tests/fn_var.cpp
+++ b/tests/fn_var.cpp
@@ -1,0 +1,549 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("fn_var_empty_sparse_test")
+  {
+  SpMat<double> m(100, 100);
+
+  SpRow<double> result = var(m);
+
+  REQUIRE( result.n_cols == 100 );
+  REQUIRE( result.n_rows == 1 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) result[i] == Approx(0.0) );
+    }
+
+  result = var(m, 0, 0);
+
+  REQUIRE( result.n_cols == 100 );
+  REQUIRE( result.n_rows == 1 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) result[i] == Approx(0.0) );
+    }
+
+  result = var(m, 1, 0);
+
+  REQUIRE( result.n_cols == 100 );
+  REQUIRE( result.n_rows == 1 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) result[i] == Approx(0.0) );
+    }
+
+  result = var(m, 1);
+
+  REQUIRE( result.n_cols == 100 );
+  REQUIRE( result.n_rows == 1 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) result[i] == Approx(0.0) );
+    }
+
+  SpCol<double> colres = var(m, 1, 1);
+
+  REQUIRE( colres.n_cols == 1 );
+  REQUIRE( colres.n_rows == 100 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) colres[i] == Approx(0.0) );
+    }
+
+  colres = var(m, 0, 1);
+
+  REQUIRE( colres.n_cols == 1 );
+  REQUIRE( colres.n_rows == 100 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) colres[i] == Approx(0.0) );
+    }
+  }
+
+
+
+TEST_CASE("fn_var_empty_cx_sparse_test")
+  {
+  SpMat<std::complex<double> > m(100, 100);
+
+  SpRow<double> result = var(m);
+
+  REQUIRE( result.n_cols == 100 );
+  REQUIRE( result.n_rows == 1 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) result[i] == Approx(0.0) );
+    }
+
+  result = var(m, 0, 0);
+
+  REQUIRE( result.n_cols == 100 );
+  REQUIRE( result.n_rows == 1 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) result[i] == Approx(0.0) );
+    }
+
+  result = var(m, 1, 0);
+
+  REQUIRE( result.n_cols == 100 );
+  REQUIRE( result.n_rows == 1 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) result[i] == Approx(0.0) );
+    }
+
+  result = var(m, 1);
+
+  REQUIRE( result.n_cols == 100 );
+  REQUIRE( result.n_rows == 1 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) result[i] == Approx(0.0) );
+    }
+
+  SpCol<double> colres = var(m, 1, 1);
+
+  REQUIRE( colres.n_cols == 1 );
+  REQUIRE( colres.n_rows == 100 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) colres[i] == Approx(0.0) );
+    }
+
+  colres = var(m, 0, 1);
+
+  REQUIRE( colres.n_cols == 1 );
+  REQUIRE( colres.n_rows == 100 );
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( (double) colres[i] == Approx(0.0) );
+    }
+  }
+
+
+
+TEST_CASE("fn_var_sparse_test")
+  {
+  // Create a random matrix and do variance testing on it, with varying levels
+  // of nonzero (eventually this becomes a fully dense matrix).
+  for (int i = 0; i < 10; ++i)
+    {
+    SpMat<double> x;
+    x.sprandu(50, 75, ((double) (i + 1)) / 10);
+    mat d(x);
+
+    SpRow<double> rr = var(x);
+    rowvec drr = var(d);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(x, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(x, 1, 0);
+    drr = var(d, 1, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    SpCol<double> cr = var(x, 0, 1);
+    vec dcr = var(d, 0, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    cr = var(x, 1, 1);
+    dcr = var(d, 1, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    // Now on a subview.
+    rr = var(x.submat(11, 11, 30, 45), 0, 0);
+    drr = var(d.submat(11, 11, 30, 45), 0, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 35 );
+    for (uword j = 0; j < 35; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(x.submat(11, 11, 30, 45), 1, 0);
+    drr = var(d.submat(11, 11, 30, 45), 1, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 35 );
+    for (uword j = 0; j < 35; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    cr = var(x.submat(11, 11, 30, 45), 0, 1);
+    dcr = var(d.submat(11, 11, 30, 45), 0, 1);
+
+    REQUIRE( cr.n_rows == 20 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 20; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    cr = var(x.submat(11, 11, 30, 45), 1, 1);
+    dcr = var(d.submat(11, 11, 30, 45), 1, 1);
+
+    REQUIRE( cr.n_rows == 20 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 20; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    // Now on an SpOp (spop_scalar_times)
+    rr = var(3.0 * x, 0, 0);
+    drr = var(3.0 * d, 0, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(3.0 * x, 1, 0);
+    drr = var(3.0 * d, 1, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    cr = var(4.5 * x, 0, 1);
+    dcr = var(4.5 * d, 0, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    cr = var(4.5 * x, 1, 1);
+    dcr = var(4.5 * d, 1, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    // Now on an SpGlue!
+    SpMat<double> y;
+    y.sprandu(50, 75, 0.3);
+    mat e(y);
+
+    rr = var(x + y);
+    drr = var(d + e);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(x + y, 1);
+    drr = var(d + e, 1);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    cr = var(x + y, 0, 1);
+    dcr = var(d + e, 0, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    cr = var(x + y, 1, 1);
+    dcr = var(d + e, 1, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_var_sparse_cx_test")
+  {
+  // Create a random matrix and do variance testing on it, with varying levels
+  // of nonzero (eventually this becomes a fully dense matrix).
+  for (int i = 0; i < 10; ++i)
+    {
+    SpMat<std::complex<double> > x;
+    x.sprandu(50, 75, ((double) (i + 1)) / 10);
+    cx_mat d(x);
+
+    SpRow<double> rr = var(x);
+    rowvec drr = var(d);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(x, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(x, 1, 0);
+    drr = var(d, 1, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    SpCol<double> cr = var(x, 0, 1);
+    vec dcr = var(d, 0, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    cr = var(x, 1, 1);
+    dcr = var(d, 1, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    // Now on a subview.
+    rr = var(x.submat(11, 11, 30, 45), 0, 0);
+    drr = var(d.submat(11, 11, 30, 45), 0, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 35 );
+    for (uword j = 0; j < 35; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(x.submat(11, 11, 30, 45), 1, 0);
+    drr = var(d.submat(11, 11, 30, 45), 1, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 35 );
+    for (uword j = 0; j < 35; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    cr = var(x.submat(11, 11, 30, 45), 0, 1);
+    dcr = var(d.submat(11, 11, 30, 45), 0, 1);
+
+    REQUIRE( cr.n_rows == 20 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 20; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    cr = var(x.submat(11, 11, 30, 45), 1, 1);
+    dcr = var(d.submat(11, 11, 30, 45), 1, 1);
+
+    REQUIRE( cr.n_rows == 20 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 20; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    // Now on an SpOp (spop_scalar_times)
+    rr = var(3.0 * x, 0, 0);
+    drr = var(3.0 * d, 0, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(3.0 * x, 1, 0);
+    drr = var(3.0 * d, 1, 0);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    cr = var(4.5 * x, 0, 1);
+    dcr = var(4.5 * d, 0, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    cr = var(4.5 * x, 1, 1);
+    dcr = var(4.5 * d, 1, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    // Now on an SpGlue!
+    SpMat<std::complex<double> > y;
+    y.sprandu(50, 75, 0.3);
+    cx_mat e(y);
+
+    rr = var(x + y);
+    drr = var(d + e);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    rr = var(x + y, 1);
+    drr = var(d + e, 1);
+
+    REQUIRE( rr.n_rows == 1 );
+    REQUIRE( rr.n_cols == 75 );
+    for (uword j = 0; j < 75; ++j)
+      {
+      REQUIRE( drr[j] == Approx((double) rr[j]) );
+      }
+
+    cr = var(x + y, 0, 1);
+    dcr = var(d + e, 0, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+
+    cr = var(x + y, 1, 1);
+    dcr = var(d + e, 1, 1);
+
+    REQUIRE( cr.n_rows == 50 );
+    REQUIRE( cr.n_cols == 1 );
+    for (uword j = 0; j < 50; ++j)
+      {
+      REQUIRE( dcr[j] == Approx((double) cr[j]) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("fn_var_sparse_alias_test")
+  {
+  sp_mat s;
+  s.sprandu(70, 70, 0.3);
+  mat d(s);
+
+  s = var(s);
+  d = var(d);
+
+  REQUIRE( d.n_rows == s.n_rows );
+  REQUIRE( d.n_cols == s.n_cols );
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    REQUIRE(d[i] == Approx((double) s[i]) );
+    }
+
+  s.sprandu(70, 70, 0.3);
+  d = s;
+
+  s = var(s, 1);
+  d = var(d, 1);
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    REQUIRE( d[i] == Approx((double) s[i]) );
+    }
+  }

--- a/tests/gen_randu.cpp
+++ b/tests/gen_randu.cpp
@@ -1,11 +1,11 @@
 // Copyright 2015 Conrad Sanderson (http://conradsanderson.id.au)
 // Copyright 2015 National ICT Australia (NICTA)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,36 +24,34 @@ TEST_CASE("gen_randu_1")
   {
   const uword n_rows = 100;
   const uword n_cols = 101;
-  
+
   mat A(n_rows,n_cols, fill::randu);
-  
+
   mat B(n_rows,n_cols); B.randu();
-  
+
   mat C; C.randu(n_rows,n_cols);
-  
+
   REQUIRE( (accu(A)/A.n_elem) == Approx(0.5).epsilon(0.01) );
   REQUIRE( (accu(B)/A.n_elem) == Approx(0.5).epsilon(0.01) );
   REQUIRE( (accu(C)/A.n_elem) == Approx(0.5).epsilon(0.01) );
 
   REQUIRE( (mean(vectorise(A))) == Approx(0.5).epsilon(0.01) );
   }
-  
+
 
 
 TEST_CASE("gen_randu_2")
   {
   mat A(50,60,fill::zeros);
-  
+
   A(span(1,48),span(1,58)).randu();
-  
+
   REQUIRE( accu(A.head_cols(1)) == Approx(0.0) );
   REQUIRE( accu(A.head_rows(1)) == Approx(0.0) );
-  
+
   REQUIRE( accu(A.tail_cols(1)) == Approx(0.0) );
   REQUIRE( accu(A.tail_rows(1)) == Approx(0.0) );
-  
+
   REQUIRE( mean(vectorise(A(span(1,48),span(1,58)))) == Approx(double(0.5)).epsilon(0.01) );
   }
-
-
 

--- a/tests/gen_zeros.cpp
+++ b/tests/gen_zeros.cpp
@@ -1,11 +1,11 @@
 // Copyright 2015 Conrad Sanderson (http://conradsanderson.id.au)
 // Copyright 2015 National ICT Australia (NICTA)
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,33 +23,33 @@ using namespace arma;
 TEST_CASE("gen_zeros_1")
   {
   mat A(5,6,fill::zeros);
-  
+
   REQUIRE( accu(A)  == Approx(0.0) );
   REQUIRE( A.n_rows == 5 );
   REQUIRE( A.n_cols == 6 );
-  
+
   mat B(5,6,fill::randu);
-  
+
   B.zeros();
-  
+
   REQUIRE( accu(B)  == Approx(0.0) );
   REQUIRE( B.n_rows == 5 );
   REQUIRE( B.n_cols == 6 );
-  
+
   mat C = zeros<mat>(5,6);
-  
+
   REQUIRE( accu(C)  == Approx(0.0) );
   REQUIRE( C.n_rows == 5 );
   REQUIRE( C.n_cols == 6 );
-  
+
   mat D; D = zeros<mat>(5,6);
-  
+
   REQUIRE( accu(D)  == Approx(0.0) );
   REQUIRE( D.n_rows == 5 );
   REQUIRE( D.n_cols == 6 );
-  
+
   mat E; E = 2*zeros<mat>(5,6);
-  
+
   REQUIRE( accu(E)  == Approx(0.0) );
   REQUIRE( E.n_rows == 5 );
   REQUIRE( E.n_cols == 6 );
@@ -60,37 +60,37 @@ TEST_CASE("gen_zeros_1")
 TEST_CASE("gen_zeros_2")
   {
   mat A(5,6,fill::ones);
-  
+
   A.col(1).zeros();
-  
+
   REQUIRE( accu(A.col(0)) == Approx(double(A.n_rows)) );
   REQUIRE( accu(A.col(1)) == Approx(0.0)              );
   REQUIRE( accu(A.col(2)) == Approx(double(A.n_rows)) );
-  
+
   mat B(5,6,fill::ones);
-  
+
   B.row(1).zeros();
-  
+
   REQUIRE( accu(B.row(0)) == Approx(double(B.n_cols)) );
   REQUIRE( accu(B.row(1)) == Approx(0.0)              );
   REQUIRE( accu(B.row(2)) == Approx(double(B.n_cols)) );
-  
+
   mat C(5,6,fill::ones);
-  
+
   C(span(1,3),span(1,4)).zeros();
-  
+
   REQUIRE( accu(C.head_cols(1)) == Approx(double(5)) );
   REQUIRE( accu(C.head_rows(1)) == Approx(double(6)) );
-  
+
   REQUIRE( accu(C.tail_cols(1)) == Approx(double(5)) );
   REQUIRE( accu(C.tail_rows(1)) == Approx(double(6)) );
-  
+
   REQUIRE( accu(C(span(1,3),span(1,4))) == Approx(0.0) );
 
   mat D(5,6,fill::ones);
-  
+
   D.diag().zeros();
-  
+
   REQUIRE( accu(D.diag()) == Approx(0.0) );
   }
 
@@ -99,17 +99,40 @@ TEST_CASE("gen_zeros_2")
 TEST_CASE("gen_zeros_3")
   {
   mat A(5,6,fill::ones);
-  
+
   uvec indices = { 2, 4, 6 };
-  
+
   A(indices).zeros();
-  
+
   REQUIRE( accu(A) == Approx(double(5*6-3)) );
-  
+
   REQUIRE( A(0)          == Approx(1.0) );
   REQUIRE( A(A.n_elem-1) == Approx(1.0) );
-  
+
   REQUIRE( A(indices(0)) == Approx(0.0) );
   REQUIRE( A(indices(1)) == Approx(0.0) );
   REQUIRE( A(indices(2)) == Approx(0.0) );
+  }
+
+
+
+TEST_CASE("gen_zeros_sp_mat")
+  {
+  SpMat<unsigned int> e(2, 2);
+
+  e(0, 0) = 3.1;
+  e(1, 1) = 2.2;
+
+  e *= zeros<SpMat<unsigned int> >(2, 2);
+
+  REQUIRE( e.n_nonzero == 0 );
+  REQUIRE( (unsigned int) e(0, 0) == 0 );
+  REQUIRE( (unsigned int) e(1, 0) == 0 );
+  REQUIRE( (unsigned int) e(0, 1) == 0 );
+  REQUIRE( (unsigned int) e(1, 1) == 0 );
+
+  // Just test compilation here.
+  e = zeros<SpMat<unsigned int> >(5, 5);
+  e *= zeros<SpMat<unsigned int> >(5, 5);
+  e %= zeros<SpMat<unsigned int> >(5, 5);
   }

--- a/tests/hdf5.cpp
+++ b/tests/hdf5.cpp
@@ -1,0 +1,719 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+#if defined(ARMA_USE_HDF5)
+
+TEST_CASE("hdf5_u8_test")
+  {
+  arma::Mat<u8> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<u8> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<u8> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_u16_test")
+  {
+  arma::Mat<u16> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<u16> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<u16> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_u32_test")
+  {
+  arma::Mat<u32> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<u32> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<u32> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+#ifdef ARMA_USE_U64S64
+TEST_CASE("hdf5_u64_test")
+  {
+  arma::Mat<u64> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<u64> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<u64> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+#endif
+
+
+
+TEST_CASE("hdf5_s8_test")
+  {
+  arma::Mat<s8> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<s8> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<s8> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_s16_test")
+  {
+  arma::Mat<s16> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<s16> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<s16> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_s32_test")
+  {
+  arma::Mat<s32> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<s32> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<s32> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+#ifdef ARMA_USE_U64S64
+TEST_CASE("hdf5_s64_test")
+  {
+  arma::Mat<s64> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<s64> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<s64> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+#endif
+
+
+
+TEST_CASE("hdf5_char_test")
+  {
+  arma::Mat<char> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<char> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<char> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_int_test")
+  {
+  arma::Mat<signed int> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<signed int> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<signed int> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_uint_test")
+  {
+  arma::Mat<unsigned int> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<unsigned int> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<unsigned int> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_short_test")
+  {
+  arma::Mat<signed short> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<signed short> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<signed short> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_ushort_test")
+  {
+  arma::Mat<unsigned short> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<unsigned short> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<unsigned short> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_long_test")
+  {
+  arma::Mat<signed long> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<signed long> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<signed long> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_ulong_test")
+  {
+  arma::Mat<unsigned long> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<unsigned long> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<unsigned long> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+#ifdef ARMA_USE_U64S64
+TEST_CASE("hdf5_llong_test")
+  {
+  arma::Mat<signed long long> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<signed long long> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<signed long long> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_ullong_test")
+  {
+  arma::Mat<unsigned long long> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<unsigned long long> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<unsigned long long> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+#endif
+
+
+
+TEST_CASE("hdf5_float_test")
+  {
+  arma::Mat<float> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<float> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<float> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_double_test")
+  {
+  arma::Mat<double> a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<double> b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<double> c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_complex_float_test")
+  {
+  arma::Mat<std::complex<float> > a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<std::complex<float> > b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == b[i] );
+    }
+
+  // Now autoload.
+  arma::Mat<std::complex<float> > c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_complex_double_test")
+  {
+  arma::Mat<std::complex<double> > a;
+  a.randu(20, 20);
+
+  // Save first.
+  a.save("file.h5", hdf5_binary);
+
+  // Load as different matrix.
+  arma::Mat<std::complex<double> > b;
+  b.load("file.h5", hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    REQUIRE( a[i] == b[i] );
+
+  // Now autoload.
+  arma::Mat<std::complex<double> > c;
+  c.load("file.h5");
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  remove("file.h5");
+  }
+
+#endif

--- a/tests/spcol.cpp
+++ b/tests/spcol.cpp
@@ -1,0 +1,211 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2011-2012 Matthew Amidon
+// Copyright 2011-2012 James Cline
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("spcol_insert_test")
+  {
+  SpCol<double> sp;
+  sp.set_size(10, 1);
+  // Ensure everything is empty.
+  for (size_t i = 0; i < 10; i++)
+    REQUIRE( sp(i) == 0.0 );
+
+  // Add an element.
+  sp(5, 0) = 43.234;
+  REQUIRE( sp.n_nonzero == 1 );
+  REQUIRE( (double) sp(5, 0) == Approx(43.234) );
+
+  // Remove the element.
+  sp(5, 0) = 0.0;
+  REQUIRE( sp.n_nonzero == 0 );
+  }
+
+TEST_CASE("col_iterator_test")
+  {
+  SpCol<double> x(5, 1);
+  x(3) = 3.1;
+  x(0) = 4.2;
+  x(1) = 3.3;
+  x(1) = 5.5; // overwrite
+  x(2) = 4.5;
+  x(4) = 6.4;
+
+  SpCol<double>::iterator it = x.begin();
+  REQUIRE( (double) *it == Approx(4.2) );
+  REQUIRE( it.row() == 0 );
+  REQUIRE( it.col() == 0 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(5.5) );
+  REQUIRE( it.row() == 1);
+  REQUIRE( it.col() == 0);
+  it++;
+
+  REQUIRE( (double) *it == Approx(4.5) );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 0 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(3.1) );
+  REQUIRE( it.row() == 3 );
+  REQUIRE( it.col() == 0 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(6.4) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 0 );
+  it++;
+
+  REQUIRE( it == x.end() );
+
+  // Now let's go backwards.
+  it--; // Get it off the end.
+  REQUIRE( (double) *it == Approx(6.4) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 0 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(3.1) );
+  REQUIRE( it.row() == 3);
+  REQUIRE( it.col() == 0);
+  it--;
+
+  REQUIRE( (double) *it == Approx(4.5) );
+  REQUIRE( it.row() == 2);
+  REQUIRE( it.col() == 0);
+  it--;
+
+  REQUIRE( (double) *it == Approx(5.5) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 0 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(4.2) );
+  REQUIRE( it.row() == 0 );
+  REQUIRE( it.col() == 0 );
+
+  REQUIRE( it == x.begin() );
+
+  // Try removing an element we itreated to.
+  it++;
+  it++;
+  *it = 0;
+  REQUIRE( x.n_nonzero == 4 );
+  }
+
+TEST_CASE("basic_sp_col_operator_test")
+  {
+  // +=, -=, *=, /=, %=
+  SpCol<double> a(6, 1);
+  a(0) = 3.4;
+  a(1) = 2.0;
+
+  SpCol<double> b(6, 1);
+  b(0) = 3.4;
+  b(3) = 0.4;
+
+  double addResult[6] = {6.8, 2.0, 0.0, 0.4, 0.0, 0.0};
+  double subResult[6] = {0.0, 2.0, 0.0, -0.4, 0.0, 0.0};
+
+  SpCol<double> out = a;
+  out += b;
+  REQUIRE( out.n_nonzero == 3 );
+  for (u32 r = 0; r < 6; r++)
+    {
+    REQUIRE( (double) out(r) == Approx(addResult[r]) );
+    }
+
+  out = a;
+  out -= b;
+  REQUIRE( out.n_nonzero == 2 );
+  for (u32 r = 0; r < 6; r++)
+    {
+    REQUIRE( (double) out(r) == Approx(subResult[r]) );
+    }
+  }
+
+/*
+BOOST_AUTO_TEST_CASE(SparseSparseColMultiplicationTest) {
+  SpCol<double> spaa(4, 1);
+  SpMat<double> spbb(1, 4);
+
+  spaa(0, 0) = 321.2;
+  spaa(1, 0) = .123;
+  spaa(2, 0) = 231.4;
+  spaa(3, 0) = .03214;
+
+  spbb(0, 0) = 32.23;
+  spbb(0, 1) = 5.1;
+  spbb(0, 2) = 4.4;
+  spbb(0, 3) = .88;
+
+  SpMat<double> precision = spaa;
+
+  precision *= spbb; //Wolfram alpha insisted on rounding..
+
+  spaa *= spbb;
+
+  for (size_t i = 0; i < 4; i++)
+    for (size_t j = 0; j < 4; j++)
+      BOOST_REQUIRE_CLOSE((double) spaa(i, j), (double) precision(i, j), 1e-5);
+}
+*/
+
+TEST_CASE("spcol_shed_row_test")
+  {
+  // On an SpCol
+  SpCol<int> e(10);
+  e(1) = 5;
+  e(4) = 56;
+  e(5) = 6;
+  e(7) = 4;
+  e(8) = 2;
+  e(9) = -1;
+  e.shed_rows(4, 7);
+
+  REQUIRE( e.n_cols == 1 );
+  REQUIRE( e.n_rows == 6 );
+  REQUIRE( e.n_nonzero == 3 );
+  REQUIRE( (int) e[0] == 0 );
+  REQUIRE( (int) e[1] == 5 );
+  REQUIRE( (int) e[2] == 0 );
+  REQUIRE( (int) e[3] == 0 );
+  REQUIRE( (int) e[4] == 2 );
+  REQUIRE( (int) e[5] == -1 );
+  }
+
+
+
+TEST_CASE("spcol_col_constructor")
+  {
+  SpMat<double> m(100, 100);
+  m.sprandu(100, 100, 0.3);
+
+  SpCol<double> c = m.col(0);
+
+  vec v(c);
+
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( v(i) == (double) c(i) );
+    }
+  }

--- a/tests/spmat.cpp
+++ b/tests/spmat.cpp
@@ -1,0 +1,2745 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2011-2012 Matthew Amidon
+// Copyright 2011-2012 James Cline
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+// Does the matrix correctly report when it is empty?
+TEST_CASE("empty_test")
+  {
+  bool testPassed = true;
+
+  sp_imat test;
+  REQUIRE( test.is_empty() );
+
+  test.set_size(3, 4);
+  REQUIRE( test.is_empty() == false );
+  }
+
+// Can we insert items into the matrix correctly?
+TEST_CASE("insertion_test")
+  {
+  int correctResult[3][4] =
+      {{1, 0, 0, 0},
+       {2, 3, 1, 0},
+       {0, 9, 4, 0}};
+
+  // Now run the same test for the Armadillo sparse matrix.
+  SpMat<int> arma_test;
+  arma_test.set_size(3, 4);
+
+  // Fill the matrix (hopefully).
+  arma_test(0, 0) = 1;
+  arma_test(1, 0) = 2;
+  arma_test(1, 1) = 3;
+  arma_test(2, 1) = 9;
+  arma_test(1, 2) = 1;
+  arma_test(2, 2) = 4;
+
+  for (size_t i = 0; i < 3; i++)
+    {
+    for (size_t j = 0; j < 4; j++)
+      {
+      REQUIRE( (int) arma_test(i, j) == correctResult[i][j] );
+      }
+    }
+  }
+
+// Does sparse-sparse matrix multiplication work?
+TEST_CASE("full_sparse_sparse_matrix_multiplication_test")
+  {
+  // Now perform the test again for SpMat.
+  SpMat<int> spa(3, 3);
+  SpMat<int> spb(3, 2);
+  int correctResult[3][2] =
+      {{ 46,  60},
+       { 40,  52},
+       {121, 160}};
+
+  spa(0, 0) = 1;
+  spa(0, 1) = 10;
+  spa(0, 2) = 3;
+  spa(1, 0) = 3;
+  spa(1, 1) = 4;
+  spa(1, 2) = 5;
+  spa(2, 0) = 12;
+  spa(2, 1) = 13;
+  spa(2, 2) = 14;
+
+  spb(0, 0) = 1;
+  spb(0, 1) = 2;
+  spb(1, 0) = 3;
+  spb(1, 1) = 4;
+  spb(2, 0) = 5;
+  spb(2, 1) = 6;
+
+  spa *= spb;
+
+  REQUIRE( spa.n_rows == 3 );
+  REQUIRE( spa.n_cols == 2 );
+
+  for (size_t i = 0; i < 3; i++)
+    {
+    for (size_t j = 0; j < 2; j++)
+      {
+      REQUIRE( (int) spa(i, j) == correctResult[i][j] );
+      }
+    }
+  }
+
+TEST_CASE("sparse_sparse_matrix_multiplication_test")
+  {
+  SpMat<double> spaa(10, 10);
+  spaa(1, 5) = 0.4;
+  spaa(0, 4) = 0.3;
+  spaa(0, 8) = 1.2;
+  spaa(3, 0) = 1.1;
+  spaa(3, 1) = 1.1;
+  spaa(3, 2) = 1.1;
+  spaa(4, 4) = 0.2;
+  spaa(4, 9) = 0.1;
+  spaa(6, 2) = 4.1;
+  spaa(6, 8) = 4.1;
+  spaa(7, 5) = 1.0;
+  spaa(8, 9) = 0.4;
+  spaa(9, 4) = 0.4;
+
+  double correctResultB[10][10] =
+    {{ 0.00, 0.00, 0.00, 0.00, 0.06, 0.00, 0.00, 0.00, 0.00, 0.51 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.33, 0.44, 0.00, 0.00, 1.32, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.08, 0.00, 0.00, 0.00, 0.00, 0.02 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 1.64 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.16, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.08, 0.00, 0.00, 0.00, 0.00, 0.04 }};
+
+  spaa *= spaa;
+
+  for (size_t i = 0; i < 10; i++)
+    {
+    for (size_t j = 0; j < 10; j++)
+      {
+      REQUIRE( (double) spaa(i, j) == Approx(correctResultB[i][j]) );
+      }
+    }
+  }
+
+TEST_CASE("hadamard_product_test")
+  {
+  SpMat<int> a(4, 4), b(4, 4);
+
+  a(1, 1) = 1;
+  a(2, 1) = 1;
+  a(3, 3) = 1;
+  a(3, 0) = 1;
+  a(0, 2) = 1;
+
+  b(1, 1) = 1;
+  b(2, 2) = 1;
+  b(3, 3) = 1;
+  b(3, 0) = 1;
+  b(0, 3) = 1;
+  b(3, 1) = 1;
+
+  double correctResult[4][4] =
+    {{ 0, 0, 0, 0 },
+     { 0, 1, 0, 0 },
+     { 0, 0, 0, 0 },
+     { 1, 0, 0, 1 }};
+
+  a %= b;
+
+  for (size_t i = 0; i < 4; i++)
+    {
+    for (size_t j = 0; j < 4; j++)
+      {
+      REQUIRE( a(i, j) == correctResult[i][j] );
+      }
+    }
+
+
+  SpMat<double> c, d;
+  c.sprandu(30, 25, 0.1);
+  d.sprandu(30, 25, 0.1);
+
+  mat e, f;
+  e = c;
+  f = d;
+
+  c %= d;
+  e %= f;
+
+  for (uword i = 0; i < 25; ++i)
+    {
+    for(uword j = 0; j < 30; ++j)
+      {
+      REQUIRE( (double) c(j, i) == Approx(e(j, i)) );
+      }
+    }
+  }
+
+TEST_CASE("division_test")
+  {
+  SpMat<double> a(2, 2), b(2, 2);
+
+  a(0, 1) = 0.5;
+
+  b(0, 1) = 1.0;
+  b(1, 0) = 5.0;
+
+  a /= b;
+
+  REQUIRE( std::isnan((double) a(0, 0)) );
+  REQUIRE( (double) a(0, 1) == Approx(0.5) );
+  REQUIRE( (double) a(1, 0) == Approx(1e-5) );
+  REQUIRE( std::isnan((double) a(1, 1)) );
+  }
+
+TEST_CASE("insert_delete_test")
+  {
+  SpMat<double> sp;
+  sp.set_size(10, 10);
+
+  // Ensure everything is empty.
+  for (size_t i = 0; i < 100; i++)
+    {
+    REQUIRE( sp(i) == 0.0 );
+    }
+
+  // Add an element.
+  sp(5, 5) = 43.234;
+  REQUIRE( sp.n_nonzero == 1 );
+  REQUIRE( (double) sp(5, 5) == Approx(43.234) );
+
+  // Remove the element.
+  sp(5, 5) = 0.0;
+  REQUIRE( sp.n_nonzero == 0 );
+  }
+
+TEST_CASE("value_operator_test")
+  {
+  // Test operators that work with a single value.
+  // =(double), /=(double), *=(double)
+  SpMat<double> sp(3, 4);
+  double correctResult[3][4] = {{1.5, 0.0, 0.0, 0.0},
+                                {2.1, 3.2, 0.9, 0.0},
+                                {0.0, 9.3, 4.0, -1.5}};
+  sp(0, 0) = 1.5;
+  sp(1, 0) = 2.1;
+  sp(1, 1) = 3.2;
+  sp(1, 2) = 0.9;
+  sp(2, 1) = 9.3;
+  sp(2, 2) = 4.0;
+  sp(2, 3) = -1.5;
+
+  // operator=(double)
+  SpMat<double> work = sp;
+  work = 5.0;
+  REQUIRE( work.n_nonzero == 1 );
+  REQUIRE( work.n_elem == 1 );
+  REQUIRE( (double) work(0) == Approx(5.0) );
+
+  // operator*=(double)
+  work = sp;
+  work *= 2;
+  REQUIRE( work.n_nonzero == 7 );
+  for (size_t i = 0; i < 3; i++)
+    {
+    for (size_t j = 0; j < 4; j++)
+      {
+      REQUIRE((double) work(i, j) == Approx(correctResult[i][j] * 2.0) );
+      }
+    }
+
+  // operator/=(double)
+  work = sp;
+  work /= 5.5;
+  REQUIRE( work.n_nonzero == 7 );
+  for (size_t i = 0; i < 3; i++)
+    {
+    for (size_t j = 0; j < 4; j++)
+      {
+      REQUIRE((double) work(i, j) == Approx(correctResult[i][j] / 5.5) );
+      }
+    }
+  }
+
+TEST_CASE("iterator_test")
+  {
+  SpMat<double> x(5, 5);
+  x(4, 1) = 3.1;
+  x(1, 2) = 4.2;
+  x(1, 3) = 3.3;
+  x(1, 3) = 5.5; // overwrite
+  x(2, 3) = 4.5;
+  x(4, 4) = 6.4;
+
+  SpMat<double>::iterator it = x.begin();
+  REQUIRE( (double) *it == Approx(3.1) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 1 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(4.2) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 2 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(5.5) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 3 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(4.5) );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 3 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(6.4) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 4 );
+  it++;
+
+  REQUIRE( it == x.end() );
+
+  // Now let's go backwards.
+  it--; // Get it off the end.
+  REQUIRE( (double) *it == Approx(6.4) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 4 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(4.5) );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 3 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(5.5) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 3 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(4.2) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 2 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(3.1) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 1 );
+
+  REQUIRE( it == x.begin() );
+
+  // Try removing an element we iterated to.
+  it++;
+  it++;
+  *it = 0;
+  REQUIRE( x.n_nonzero == 4 );
+}
+
+TEST_CASE("row_iterator_test")
+  {
+  SpMat<double> x(5, 5);
+  x(4, 1) = 3.1;
+  x(1, 2) = 4.2;
+  x(1, 3) = 3.3;
+  x(1, 3) = 5.5; // overwrite
+  x(2, 3) = 4.5;
+  x(4, 4) = 6.4;
+
+  SpMat<double>::row_iterator it = x.begin_row();
+  REQUIRE( (double) *it == Approx(4.2) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 2 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(5.5) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 3 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(4.5) );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 3 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(3.1) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 1 );
+  it++;
+
+  REQUIRE( (double) *it == Approx(6.4) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 4 );
+  it++;
+
+//  REQUIRE( it == x.end_row() );
+
+  // Now let's go backwards.
+  it--; // Get it off the end.
+  REQUIRE( (double) *it == Approx(6.4) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 4 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(3.1) );
+  REQUIRE( it.row() == 4 );
+  REQUIRE( it.col() == 1 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(4.5) );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 3 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(5.5) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 3 );
+  it--;
+
+  REQUIRE( (double) *it == Approx(4.2) );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 2 );
+
+  REQUIRE( it == x.begin_row() );
+
+  // Try removing an element we itreated to.
+  it++;
+  it++;
+  *it = 0;
+  REQUIRE( x.n_nonzero == 4 );
+  }
+
+TEST_CASE("basic_sp_mat_operator_test")
+  {
+  // +=, -=, *=, /=, %=
+  SpMat<double> a(6, 5);
+  a(0, 0) = 3.4;
+  a(4, 1) = 4.1;
+  a(5, 1) = 1.5;
+  a(3, 2) = 2.6;
+  a(4, 2) = 3.0;
+  a(1, 3) = 9.8;
+  a(4, 3) = 0.1;
+  a(2, 4) = 0.2;
+  a(3, 4) = 0.2;
+  a(4, 4) = 0.2;
+  a(5, 4) = 8.3;
+
+  SpMat<double> b(6, 5);
+  b(0, 0) = 3.4;
+  b(3, 0) = 0.4;
+  b(3, 1) = 0.5;
+  b(4, 1) = 1.2;
+  b(4, 2) = 3.0;
+  b(5, 2) = 1.1;
+  b(1, 3) = 0.6;
+  b(3, 3) = 1.0;
+  b(4, 4) = 7.3;
+  b(5, 4) = 7.4;
+
+  double addResult[6][5] = {{6.8 , 0   , 0   , 0   , 0   },
+                            {0   , 0   , 0   , 10.4, 0   },
+                            {0   , 0   , 0   , 0   , 0.2 },
+                            {0.4 , 0.5 , 2.6 , 1.0 , 0.2 },
+                            {0   , 5.3 , 6.0 , 0.1 , 7.5 },
+                            {0   , 1.5 , 1.1 , 0   , 15.7}};
+
+  double subResult[6][5] = {{0   , 0   , 0   , 0   , 0   },
+                            {0   , 0   , 0   , 9.2 , 0   },
+                            {0   , 0   , 0   , 0   , 0.2 },
+                            {-0.4, -0.5, 2.6 , -1.0, 0.2 },
+                            {0   , 2.9 , 0   , 0.1 , -7.1},
+                            {0   , 1.5 , -1.1, 0   , 0.9 }};
+
+  SpMat<double> out = a;
+  out += b;
+  REQUIRE( out.n_nonzero == 15 );
+  for (uword r = 0; r < 6; r++)
+    {
+    for (uword c = 0; c < 5; c++)
+      {
+      REQUIRE( (double) out(r, c) == Approx(addResult[r][c]) );
+      }
+    }
+
+  out = a;
+  out -= b;
+  REQUIRE( out.n_nonzero == 13 );
+  for (uword r = 0; r < 6; r++)
+    {
+    for (uword c = 0; c < 5; c++)
+      {
+      REQUIRE( (double) out(r, c) == Approx(subResult[r][c]) );
+      }
+    }
+  }
+
+TEST_CASE("min_max_test")
+  {
+  SpMat<double> a(6, 5);
+  a(0, 0) = 3.4;
+  a(4, 1) = 4.1;
+  a(5, 1) = 1.5;
+  a(3, 2) = 2.6;
+  a(4, 2) = 3.0;
+  a(1, 3) = 9.8;
+  a(4, 3) = 0.1;
+  a(2, 4) = 0.2;
+  a(3, 4) = -0.2;
+  a(4, 4) = 0.2;
+  a(5, 4) = 8.3;
+
+  uword index, row, col;
+  REQUIRE( a.min() == Approx(-0.2) );
+  REQUIRE( a.min(index) == Approx(-0.2) );
+  REQUIRE( index == 27 );
+  REQUIRE( a.min(row, col) == Approx(-0.2) );
+  REQUIRE( row == 3 );
+  REQUIRE( col == 4 );
+
+  REQUIRE( a.max() == Approx(9.8) );
+  REQUIRE( a.max(index) == Approx(9.8) );
+  REQUIRE( index == 19 );
+  REQUIRE( a.max(row, col) == Approx(9.8) );
+  REQUIRE( row == 1 );
+  REQUIRE( col == 3 );
+  }
+
+TEST_CASE("swap_row_test")
+  {
+  SpMat<double> a(6, 5);
+  a(0, 0) = 3.4;
+  a(4, 1) = 4.1;
+  a(5, 1) = 1.5;
+  a(3, 2) = 2.6;
+  a(4, 2) = 3.0;
+  a(1, 3) = 9.8;
+  a(4, 3) = 0.1;
+  a(2, 4) = 0.2;
+  a(3, 4) = -0.2;
+  a(4, 4) = 0.2;
+  a(5, 4) = 8.3;
+
+  /**
+   * [[3.4  0.0  0.0  0.0  0.0]
+   *  [0.0  0.0  0.0  9.8  0.0]
+   *  [0.0  0.0  0.0  0.0  0.2]
+   *  [0.0  0.0  2.6  0.0 -0.2]
+   *  [0.0  4.1  3.0  0.1  0.2]
+   *  [0.0  1.5  0.0  0.0  8.3]]
+   */
+  double swapOne[6][5] =
+    {{ 0.0,  0.0,  2.6,  0.0, -0.2},
+     { 0.0,  0.0,  0.0,  9.8,  0.0},
+     { 0.0,  0.0,  0.0,  0.0,  0.2},
+     { 3.4,  0.0,  0.0,  0.0,  0.0},
+     { 0.0,  4.1,  3.0,  0.1,  0.2},
+     { 0.0,  1.5,  0.0,  0.0,  8.3}};
+
+  double swapTwo[6][5] =
+    {{ 0.0,  0.0,  2.6,  0.0, -0.2},
+     { 0.0,  0.0,  0.0,  9.8,  0.0},
+     { 0.0,  0.0,  0.0,  0.0,  0.2},
+     { 3.4,  0.0,  0.0,  0.0,  0.0},
+     { 0.0,  1.5,  0.0,  0.0,  8.3},
+     { 0.0,  4.1,  3.0,  0.1,  0.2}};
+
+  a.swap_rows(0, 3);
+
+  for (uword row = 0; row < a.n_rows; row++)
+    {
+    for (uword col = 0; col < a.n_cols; col++)
+      {
+      REQUIRE( (double) a(row, col) == Approx(swapOne[row][col]) );
+      }
+    }
+
+  a.swap_rows(4, 5);
+
+  for (uword row = 0; row < a.n_rows; row++)
+    {
+    for (uword col = 0; col < a.n_cols; col++)
+      {
+      REQUIRE( (double) a(row, col) == Approx(swapTwo[row][col]) );
+      }
+    }
+  }
+
+TEST_CASE("swap_col_test")
+  {
+  SpMat<double> a(6, 5);
+  a(0, 0) = 3.4;
+  a(4, 1) = 4.1;
+  a(5, 1) = 1.5;
+  a(3, 2) = 2.6;
+  a(4, 2) = 3.0;
+  a(1, 3) = 9.8;
+  a(4, 3) = 0.1;
+  a(2, 4) = 0.2;
+  a(3, 4) = -0.2;
+  a(4, 4) = 0.2;
+  a(5, 4) = 8.3;
+
+  mat b(6, 5);
+  b.zeros(6, 5);
+  b(0, 0) = 3.4;
+  b(4, 1) = 4.1;
+  b(5, 1) = 1.5;
+  b(3, 2) = 2.6;
+  b(4, 2) = 3.0;
+  b(1, 3) = 9.8;
+  b(4, 3) = 0.1;
+  b(2, 4) = 0.2;
+  b(3, 4) = -0.2;
+  b(4, 4) = 0.2;
+  b(5, 4) = 8.3;
+
+  /**
+   * [[3.4  0.0  0.0  0.0  0.0]
+   *  [0.0  0.0  0.0  9.8  0.0]
+   *  [0.0  0.0  0.0  0.0  0.2]
+   *  [0.0  0.0  2.6  0.0 -0.2]
+   *  [0.0  4.1  3.0  0.1  0.2]
+   *  [0.0  1.5  0.0  0.0  8.3]]
+   */
+
+  a.swap_cols(2, 3);
+  b.swap_cols(2, 3);
+
+  for (uword row = 0; row < a.n_rows; row++)
+    {
+    for (uword col = 0; col < a.n_cols; col++)
+      {
+      REQUIRE( (double) a(row, col) == Approx(b(row, col)) );
+      }
+    }
+
+  a.swap_cols(0, 4);
+  b.swap_cols(0, 4);
+
+  for (uword row = 0; row < a.n_rows; row++)
+    {
+    for (uword col = 0; col < a.n_cols; col++)
+      {
+      REQUIRE( (double) a(row, col) == Approx(b(row, col)) );
+      }
+    }
+
+  a.swap_cols(1, 4);
+  b.swap_cols(1, 4);
+
+  for (uword row = 0; row < a.n_rows; row++)
+    {
+    for (uword col = 0; col < a.n_cols; col++)
+      {
+      REQUIRE( (double) a(row, col) == Approx(b(row, col)) );
+      }
+    }
+  }
+
+TEST_CASE("shed_col_test")
+  {
+  SpMat<int> a(2, 2);
+  a(0, 0) = 1;
+  a(1, 1) = 1;
+
+  /**
+   * [[1 0]
+   *  [0 1]]
+   *
+   * becomes
+   *
+   * [[0]
+   *  [1]]
+   */
+
+  a.shed_col(0);
+  REQUIRE( a.n_cols == 1 );
+  REQUIRE( a.n_rows == 2 );
+  REQUIRE( a.n_elem == 2 );
+  REQUIRE( a.n_nonzero == 1 );
+  REQUIRE( a(0, 0) == 0 );
+  REQUIRE( a(1, 0) == 1 );
+  }
+
+TEST_CASE("shed_cols_test")
+  {
+  SpMat<int> a(3, 3);
+  a(0, 0) = 1;
+  a(1, 1) = 1;
+  a(2, 2) = 1;
+  SpMat<int> b(3, 3);
+  b(0, 0) = 1;
+  b(1, 1) = 1;
+  b(2, 2) = 1;
+  SpMat<int> c(3, 3);
+  c(0, 0) = 1;
+  c(1, 1) = 1;
+  c(2, 2) = 1;
+
+  /**
+   * [[1 0 0]
+   *  [0 1 0]
+   *  [0 0 1]]
+   *
+   * becomes
+   *
+   * [[0]
+   *  [0]
+   *  [1]]
+   */
+
+  a.shed_cols(0, 1);
+  REQUIRE( a.n_cols == 1 );
+  REQUIRE( a.n_rows == 3 );
+  REQUIRE( a.n_elem == 3 );
+  REQUIRE( a.n_nonzero == 1 );
+  REQUIRE( a(0, 0) == 0 );
+  REQUIRE( a(1, 0) == 0 );
+  REQUIRE( a(2, 0) == 1 );
+
+  b.shed_cols(1, 2);
+  REQUIRE( b.n_cols == 1 );
+  REQUIRE( b.n_rows == 3 );
+  REQUIRE( b.n_elem == 3 );
+  REQUIRE( b.n_nonzero == 1 );
+  REQUIRE( b(0, 0) == 1 );
+  REQUIRE( b(1, 0) == 0 );
+  REQUIRE( b(2, 0) == 0 );
+
+  c.shed_cols(0, 0);
+  c.shed_cols(1, 1);
+  REQUIRE( c.n_cols == 1 );
+  REQUIRE( c.n_rows == 3 );
+  REQUIRE( c.n_elem == 3 );
+  REQUIRE( c.n_nonzero == 1 );
+  REQUIRE( c(0, 0) == 0 );
+  REQUIRE( c(1, 0) == 1 );
+  REQUIRE( c(2, 0) == 0 );
+  }
+
+TEST_CASE("shed_row_test")
+  {
+  SpMat<int> a(3, 3);
+  a(0, 0) = 1;
+  a(1, 1) = 1;
+  a(2, 2) = 1;
+  Mat<int> b(3, 3);
+  b.zeros(3, 3);
+  b(0, 0) = 1;
+  b(1, 1) = 1;
+  b(2, 2) = 1;
+
+  /**
+   * [[1 0 0]
+   *  [0 1 0]
+   *  [0 0 1]]
+   *
+   * becomes
+   *
+   * [[1 0 0]
+   *  [0 1 0]]
+   */
+  a.shed_row(2);
+  b.shed_row(2);
+  REQUIRE( a.n_cols == 3 );
+  REQUIRE( a.n_rows == 2 );
+  REQUIRE( a.n_elem == 6 );
+  REQUIRE( a.n_nonzero == 2 );
+  for (uword row = 0; row < a.n_rows; row++)
+    {
+    for (uword col = 0; col < a.n_cols; col++)
+      {
+      REQUIRE( (double) a(row, col) == Approx(b(row, col)) );
+      }
+    }
+  }
+
+TEST_CASE("shed_rows_test")
+  {
+  SpMat<int> a(5, 5);
+  a(0, 0) = 1;
+  a(1, 1) = 1;
+  a(2, 2) = 1;
+  a(3, 3) = 1;
+  a(4, 4) = 1;
+  Mat<int> b(5, 5);
+  b.zeros(5, 5);
+  b(0, 0) = 1;
+  b(1, 1) = 1;
+  b(2, 2) = 1;
+  b(3, 3) = 1;
+  b(4, 4) = 1;
+
+  SpMat<int> c = a;
+  Mat<int> d = b;
+
+  /**
+   * [[1 0 0 0 0]
+   *  [0 1 0 0 0]
+   *  [0 0 1 0 0]
+   *  [0 0 0 1 0]
+   *  [0 0 0 0 1]]
+   *
+   * becomes
+   *
+   * [[1 0 0 0 0]
+   *  [0 1 0 0 0]]
+   */
+  a.shed_rows(2,4);
+  b.shed_rows(2,4);
+  REQUIRE( a.n_cols == 5 );
+  REQUIRE( a.n_rows == 2 );
+  REQUIRE( a.n_elem == 10 );
+  REQUIRE( a.n_nonzero == 2 );
+  for (uword row = 0; row < a.n_rows; row++)
+    {
+    for (uword col = 0; col < a.n_cols; col++)
+      {
+      REQUIRE( (double) a(row, col) == Approx(b(row, col)) );
+      }
+    }
+
+  c.shed_rows(0, 2);
+  d.shed_rows(0, 2);
+  REQUIRE( c.n_cols == 5 );
+  REQUIRE( c.n_rows == 2 );
+  REQUIRE( c.n_elem == 10 );
+  REQUIRE( c.n_nonzero == 2 );
+  for (uword row = 0; row < c.n_rows; ++row)
+    {
+    for (uword col = 0; col < c.n_cols; ++col)
+      {
+      REQUIRE( (int) c(row, col) == d(row, col) );
+      }
+    }
+  }
+
+TEST_CASE("sp_mat_reshape_columnwise_test")
+  {
+  // Input matrix:
+  // [[0 2 0]
+  //  [1 3 0]
+  //  [0 0 5]
+  //  [0 4 6]]
+  //
+  // Output matrix:
+  // [[0 0 0 0]
+  //  [1 2 4 5]
+  //  [0 3 0 6]]
+  SpMat<unsigned int> ref(4, 3);
+  ref(1, 0) = 1;
+  ref(0, 1) = 2;
+  ref(1, 1) = 3;
+  ref(3, 1) = 4;
+  ref(2, 2) = 5;
+  ref(3, 2) = 6;
+
+  // Now reshape.
+  ref.reshape(3, 4);
+
+  // Check everything.
+  REQUIRE( ref.n_cols == 4 );
+  REQUIRE( ref.n_rows == 3 );
+
+  REQUIRE( (unsigned int) ref(0, 0) == 0 );
+  REQUIRE( (unsigned int) ref(1, 0) == 1 );
+  REQUIRE( (unsigned int) ref(2, 0) == 0 );
+  REQUIRE( (unsigned int) ref(0, 1) == 0 );
+  REQUIRE( (unsigned int) ref(1, 1) == 2 );
+  REQUIRE( (unsigned int) ref(2, 1) == 3 );
+  REQUIRE( (unsigned int) ref(0, 2) == 0 );
+  REQUIRE( (unsigned int) ref(1, 2) == 4 );
+  REQUIRE( (unsigned int) ref(2, 2) == 0 );
+  REQUIRE( (unsigned int) ref(0, 3) == 0 );
+  REQUIRE( (unsigned int) ref(1, 3) == 5 );
+  REQUIRE( (unsigned int) ref(2, 3) == 6 );
+  }
+
+TEST_CASE("sp_mat_reshape_rowwise_test")
+  {
+  // Input matrix:
+  // [[0 2 0]
+  //  [1 3 0]
+  //  [0 0 5]
+  //  [0 4 6]]
+  //
+  // Output matrix:
+  // [[0 2 0 1]
+  //  [3 0 0 0]
+  //  [5 0 4 6]]
+  SpMat<unsigned int> ref(4, 3);
+  ref(1, 0) = 1;
+  ref(0, 1) = 2;
+  ref(1, 1) = 3;
+  ref(3, 1) = 4;
+  ref(2, 2) = 5;
+  ref(3, 2) = 6;
+
+  // Now reshape.
+  ref.reshape(3, 4, 1 /* row-wise */);
+
+  // Check everything.
+  REQUIRE( ref.n_cols == 4 );
+  REQUIRE( ref.n_rows == 3 );
+
+  REQUIRE( (unsigned int) ref(0, 0) == 0 );
+  REQUIRE( (unsigned int) ref(1, 0) == 3 );
+  REQUIRE( (unsigned int) ref(2, 0) == 5 );
+  REQUIRE( (unsigned int) ref(0, 1) == 2 );
+  REQUIRE( (unsigned int) ref(1, 1) == 0 );
+  REQUIRE( (unsigned int) ref(2, 1) == 0 );
+  REQUIRE( (unsigned int) ref(0, 2) == 0 );
+  REQUIRE( (unsigned int) ref(1, 2) == 0 );
+  REQUIRE( (unsigned int) ref(2, 2) == 4 );
+  REQUIRE( (unsigned int) ref(0, 3) == 1 );
+  REQUIRE( (unsigned int) ref(1, 3) == 0 );
+  REQUIRE( (unsigned int) ref(2, 3) == 6 );
+  }
+
+TEST_CASE("sp_mat_zeros_tests")
+  {
+  SpMat<double> m(4, 3);
+  m(1, 0) = 1;
+  m(0, 1) = 2;
+  m(1, 1) = 3;
+  m(3, 1) = 4;
+  m(2, 2) = 5;
+  m(3, 2) = 6;
+
+  // Now zero it out.
+  SpMat<double> d = m;
+
+  d.zeros();
+
+  REQUIRE( d.values[0] == 0 );
+  REQUIRE( d.row_indices[0] == 0);
+  REQUIRE( d.col_ptrs[0] == 0 );
+  REQUIRE( d.col_ptrs[1] == 0 );
+  REQUIRE( d.col_ptrs[2] == 0 );
+  REQUIRE( d.col_ptrs[3] == 0 );
+  REQUIRE( d.n_cols == 3 );
+  REQUIRE( d.n_rows == 4 );
+  REQUIRE( d.n_elem == 12 );
+  REQUIRE( d.n_nonzero == 0 );
+
+  // Now zero it out again.
+  d = m;
+  d.zeros(10);
+
+  REQUIRE( d.values[0] == 0 );
+  REQUIRE( d.row_indices[0] == 0);
+  REQUIRE( d.col_ptrs[0] == 0 );
+  REQUIRE( d.col_ptrs[1] == 0 );
+  REQUIRE( d.n_cols == 1 );
+  REQUIRE( d.n_rows == 10 );
+  REQUIRE( d.n_elem == 10 );
+  REQUIRE( d.n_nonzero == 0 );
+
+  // Now zero it out again.
+  d = m;
+  d.zeros(5, 5);
+
+  REQUIRE( d.values[0] == 0 );
+  REQUIRE( d.row_indices[0] == 0);
+  REQUIRE( d.col_ptrs[0] == 0 );
+  REQUIRE( d.col_ptrs[1] == 0 );
+  REQUIRE( d.col_ptrs[2] == 0 );
+  REQUIRE( d.col_ptrs[3] == 0 );
+  REQUIRE( d.col_ptrs[4] == 0 );
+  REQUIRE( d.col_ptrs[5] == 0 );
+  REQUIRE( d.n_cols == 5 );
+  REQUIRE( d.n_rows == 5 );
+  REQUIRE( d.n_elem == 25 );
+  REQUIRE( d.n_nonzero == 0 );
+  }
+
+
+
+/**
+ * Check that eye() works.
+ */
+TEST_CASE("sp_mat_eye_test")
+  {
+  SpMat<double> e = eye<SpMat<double> >(5, 5);
+
+  REQUIRE( e.n_elem == 25 );
+  REQUIRE( e.n_rows == 5 );
+  REQUIRE( e.n_cols == 5 );
+  REQUIRE( e.n_nonzero == 5 );
+
+  for (uword i = 0; i < 5; i++)
+    {
+    for (uword j = 0; j < 5; j++)
+      {
+      if (i == j)
+        REQUIRE( (double) e(i, j) == Approx(1.0) );
+      else
+        REQUIRE( (double) e(i, j) == Approx(1e-5) );
+      }
+    }
+
+  // Just check that these compile and run.
+  e = eye<SpMat<double> >(5, 5);
+  e *= eye<SpMat<double> >(5, 5);
+  e %= eye<SpMat<double> >(5, 5);
+  e /= eye<SpMat<double> >(5, 5);
+  }
+
+/**
+ * Check that pow works.
+ *
+TEST_CASE("sp_mat_pow_test")
+  {
+  SpMat<double> a(3, 3);
+  a(0, 2) = 4.3;
+  a(1, 1) = -5.5;
+  a(2, 2) = -6.3;
+
+  a += pow(a, 2);
+
+  REQUIRE( (double) a(0, 0) == 0 );
+  REQUIRE( (double) a(1, 0) == 0 );
+  REQUIRE( (double) a(2, 0) == 0 );
+  REQUIRE( (double) a(0, 1) == 0 );
+  REQUIRE( (double) a(1, 1) == Approx(24.75) );
+  REQUIRE( (double) a(2, 1) == 0 );
+  REQUIRE( (double) a(0, 2) == Approx(22.79) );
+  REQUIRE( (double) a(1, 2) == 0 );
+  REQUIRE( (double) a(2, 2) == Approx(33.39) );
+
+  a = pow(a, 2);
+  a *= pow(a, 2);
+  a %= pow(a, 2);
+  a /= pow(a, 2);
+  }
+*/
+
+
+// I hate myself.
+#undef TEST_OPERATOR
+#define TEST_OPERATOR(EOP_TEST, EOP) \
+TEST_CASE(EOP_TEST) \
+  {\
+  SpMat<double> a(3, 3);\
+  a(0, 2) = 4.3;\
+  a(1, 1) = -5.5;\
+  a(2, 2) = -6.3;\
+  a(1, 0) = 0.001;\
+  Mat<double> b(3, 3);\
+  b.zeros();\
+  b(0, 2) = 4.3;\
+  b(1, 1) = -5.5;\
+  b(2, 2) = -6.3;\
+  b(1, 0) = 0.001;\
+  \
+  SpMat<double> c = EOP(a);\
+  Mat<double> d = EOP(b);\
+  \
+  if (c(0, 0) == c(0, 0) && d(0, 0) == d(0, 0))\
+    REQUIRE( c(0, 0) == d(0, 0) );\
+  if (c(1, 0) == c(1, 0) && d(1, 0) == d(1, 0))\
+    REQUIRE( c(1, 0) == d(1, 0) );\
+  if (c(2, 0) == c(2, 0) && d(2, 0) == d(2, 0))\
+    REQUIRE( c(2, 0) == d(2, 0) );\
+  if (c(0, 1) == c(0, 1) && d(0, 1) == d(0, 1))\
+    REQUIRE( c(0, 1) == d(0, 1) );\
+  if (c(1, 1) == c(1, 1) && d(1, 1) == d(1, 1))\
+    REQUIRE( c(1, 1) == d(1, 1) );\
+  if (c(2, 1) == c(2, 1) && d(2, 1) == d(2, 1))\
+    REQUIRE( c(2, 1) == d(2, 1) );\
+  if (c(0, 2) == c(0, 2) && d(0, 2) == d(0, 2))\
+    REQUIRE( c(0, 2) == d(0, 2) );\
+  if (c(1, 2) == c(1, 2) && d(1, 2) == d(1, 2))\
+    REQUIRE( c(1, 2) == d(1, 2) );\
+  if (c(2, 2) == c(2, 2) && d(2, 2) == d(2, 2))\
+    REQUIRE( c(2, 2) == d(2, 2) );\
+  \
+  c -= EOP(a);\
+  d -= EOP(b);\
+  \
+  if (c(0, 0) == c(0, 0) && d(0, 0) == d(0, 0))\
+    REQUIRE( c(0, 0) == d(0, 0) );\
+  if (c(1, 0) == c(1, 0) && d(1, 0) == d(1, 0))\
+    REQUIRE( c(1, 0) == d(1, 0) );\
+  if (c(2, 0) == c(2, 0) && d(2, 0) == d(2, 0))\
+    REQUIRE( c(2, 0) == d(2, 0) );\
+  if (c(0, 1) == c(0, 1) && d(0, 1) == d(0, 1))\
+    REQUIRE( c(0, 1) == d(0, 1) );\
+  if (c(1, 1) == c(1, 1) && d(1, 1) == d(1, 1))\
+    REQUIRE( c(1, 1) == d(1, 1) );\
+  if (c(2, 1) == c(2, 1) && d(2, 1) == d(2, 1))\
+    REQUIRE( c(2, 1) == d(2, 1) );\
+  if (c(0, 2) == c(0, 2) && d(0, 2) == d(0, 2))\
+    REQUIRE( c(0, 2) == d(0, 2) );\
+  if (c(1, 2) == c(1, 2) && d(1, 2) == d(1, 2))\
+    REQUIRE( c(1, 2) == d(1, 2) );\
+  if (c(2, 2) == c(2, 2) && d(2, 2) == d(2, 2))\
+    REQUIRE( c(2, 2) == d(2, 2) );\
+  \
+  c %= EOP(a);\
+  d %= EOP(b);\
+  \
+  if (c(0, 0) == c(0, 0) && d(0, 0) == d(0, 0))\
+    REQUIRE( c(0, 0) == d(0, 0) );\
+  if (c(1, 0) == c(1, 0) && d(1, 0) == d(1, 0))\
+    REQUIRE( c(1, 0) == d(1, 0) );\
+  if (c(2, 0) == c(2, 0) && d(2, 0) == d(2, 0))\
+    REQUIRE( c(2, 0) == d(2, 0) );\
+  if (c(0, 1) == c(0, 1) && d(0, 1) == d(0, 1))\
+    REQUIRE( c(0, 1) == d(0, 1) );\
+  if (c(1, 1) == c(1, 1) && d(1, 1) == d(1, 1))\
+    REQUIRE( c(1, 1) == d(1, 1) );\
+  if (c(2, 1) == c(2, 1) && d(2, 1) == d(2, 1))\
+    REQUIRE( c(2, 1) == d(2, 1) );\
+  if (c(0, 2) == c(0, 2) && d(0, 2) == d(0, 2))\
+    REQUIRE( c(0, 2) == d(0, 2) );\
+  if (c(1, 2) == c(1, 2) && d(1, 2) == d(1, 2))\
+    REQUIRE( c(1, 2) == d(1, 2) );\
+  if (c(2, 2) == c(2, 2) && d(2, 2) == d(2, 2))\
+    REQUIRE( c(2, 2) == d(2, 2) );\
+  \
+  c *= EOP(a);\
+  d *= EOP(b);\
+  \
+  if (c(0, 0) == c(0, 0) && d(0, 0) == d(0, 0))\
+    REQUIRE( c(0, 0) == d(0, 0) );\
+  if (c(1, 0) == c(1, 0) && d(1, 0) == d(1, 0))\
+    REQUIRE( c(1, 0) == d(1, 0) );\
+  if (c(2, 0) == c(2, 0) && d(2, 0) == d(2, 0))\
+    REQUIRE( c(2, 0) == d(2, 0) );\
+  if (c(0, 1) == c(0, 1) && d(0, 1) == d(0, 1))\
+    REQUIRE( c(0, 1) == d(0, 1) );\
+  if (c(1, 1) == c(1, 1) && d(1, 1) == d(1, 1))\
+    REQUIRE( c(1, 1) == d(1, 1) );\
+  if (c(2, 1) == c(2, 1) && d(2, 1) == d(2, 1))\
+    REQUIRE( c(2, 1) == d(2, 1) );\
+  if (c(0, 2) == c(0, 2) && d(0, 2) == d(0, 2))\
+    REQUIRE( c(0, 2) == d(0, 2) );\
+  if (c(1, 2) == c(1, 2) && d(1, 2) == d(1, 2))\
+    REQUIRE( c(1, 2) == d(1, 2) );\
+  if (c(2, 2) == c(2, 2) && d(2, 2) == d(2, 2))\
+    REQUIRE( c(2, 2) == d(2, 2) );\
+  \
+  c /= EOP(a);\
+  d /= EOP(b);\
+  \
+  if (c(0, 0) == c(0, 0) && d(0, 0) == d(0, 0))\
+    REQUIRE( c(0, 0) == d(0, 0) );\
+  if (c(1, 0) == c(1, 0) && d(1, 0) == d(1, 0))\
+    REQUIRE( c(1, 0) == d(1, 0) );\
+  if (c(2, 0) == c(2, 0) && d(2, 0) == d(2, 0))\
+    REQUIRE( c(2, 0) == d(2, 0) );\
+  if (c(0, 1) == c(0, 1) && d(0, 1) == d(0, 1))\
+    REQUIRE( c(0, 1) == d(0, 1) );\
+  if (c(1, 1) == c(1, 1) && d(1, 1) == d(1, 1))\
+    REQUIRE( c(1, 1) == d(1, 1) );\
+  if (c(2, 1) == c(2, 1) && d(2, 1) == d(2, 1))\
+    REQUIRE( c(2, 1) == d(2, 1) );\
+  if (c(0, 2) == c(0, 2) && d(0, 2) == d(0, 2))\
+    REQUIRE( c(0, 2) == d(0, 2) );\
+  if (c(1, 2) == c(1, 2) && d(1, 2) == d(1, 2))\
+    REQUIRE( c(1, 2) == d(1, 2) );\
+  if (c(2, 2) == c(2, 2) && d(2, 2) == d(2, 2))\
+    REQUIRE( c(2, 2) == d(2, 2) );\
+  }
+
+// Now run all the operators...
+TEST_OPERATOR("sp_mat_abs_test", abs)
+//TEST_OPERATOR("sp_mat_eps_test", eps);
+//TEST_OPERATOR(expTest, exp);
+//TEST_OPERATOR(exp2Test, exp2);
+//TEST_OPERATOR(exp10Test, exp10);
+//TEST_OPERATOR(trunc_expTest, trunc_exp);
+//TEST_OPERATOR(logTest, log);
+//TEST_OPERATOR(log2Test, log2);
+//TEST_OPERATOR(log10Test, log10);
+//TEST_OPERATOR(trunc_logTest, trunc_log);
+TEST_OPERATOR("sp_mat_sqrt_test", sqrt)
+TEST_OPERATOR("sp_mat_square_test", square)
+TEST_OPERATOR("sp_mat_floor_test", floor)
+TEST_OPERATOR("sp_mat_ceil_test", ceil)
+//TEST_OPERATOR(cosTest, cos);
+//TEST_OPERATOR(acosTest, acos);
+//TEST_OPERATOR(coshTest, cosh);
+//TEST_OPERATOR(acoshTest, acosh);
+//TEST_OPERATOR(sinTest, sin);
+//TEST_OPERATOR(asinTest, asin);
+//TEST_OPERATOR(sinhTest, sinh);
+//TEST_OPERATOR(asinhTest, asinh);
+//TEST_OPERATOR(tanTest, tan);
+//TEST_OPERATOR(tanhTest, tanh);
+//TEST_OPERATOR(atanTest, atan);
+//TEST_OPERATOR(atanhTest, atanh);
+
+/*
+TEST_CASE("spmat_diskio_tests")
+  {
+  std::string file_names[] = {"raw_ascii.txt",
+                              "raw_binary.bin",
+                              "arma_ascii.csv",
+                              "csv_ascii.csv",
+                              "arma_binary.bin",
+                              "pgm_binary.bin",
+                              "coord_ascii.txt"};
+  diskio dio;
+  SpMat<int> m(4, 3);
+  m(0, 0) = 1;
+  m(3, 0) = 2;
+  m(0, 2) = 3;
+  m(3, 2) = 4;
+  m(2, 1) = 5;
+  m(1, 2) = 6;
+
+  // Save the matrix.
+  REQUIRE( dio.save_raw_ascii(m, file_names[0]) );
+//  REQUIRE( dio.save_raw_binary(m, file_names[1]) );
+//  REQUIRE( dio.save_arma_ascii(m, file_names[2]) );
+//  REQUIRE( dio.save_csv_ascii(m, file_names[3]) );
+  REQUIRE( dio.save_arma_binary(m, file_names[4]) );
+//  REQUIRE( dio.save_pgm_binary(m, file_names[5]) );
+  REQUIRE( dio.save_coord_ascii(m, file_names[6]) );
+
+  // Load the files.
+  SpMat<int> lm[7];
+  std::string err;
+  REQUIRE( dio.load_raw_ascii(lm[0], file_names[0], err) );
+//  REQUIRE( dio.load_raw_binary(lm[1], file_names[1], err) );
+//  REQUIRE( dio.load_arma_ascii(lm[2], file_names[2], err) );
+//  REQUIRE( dio.load_csv_ascii(lm[3], file_names[3], err) );
+  REQUIRE( dio.load_arma_binary(lm[4], file_names[4], err) );
+//  REQUIRE( dio.load_pgm_binary(lm[5], file_names[5], err) );
+  REQUIRE( dio.load_coord_ascii(lm[6], file_names[6], err) );
+
+  // Now make sure all the matrices are identical.
+  for (uword i = 0; i < 7; i++)
+    {
+    for (uword r = 0; r < 4; r++)
+      {
+      for (uword c = 0; c < 3; c++)
+        {
+        REQUIRE( m(r, c) == lm[i](r, c) );
+        }
+      }
+    }
+
+  for (size_t i = 0; i < 7; ++i)
+    {
+    remove(file_names[i].c_str());
+    }
+  }
+*/
+
+
+TEST_CASE("min_test")
+  {
+  SpCol<double> a(5);
+
+  a(0) = 3.0;
+  a(2) = 1.0;
+
+  double res = min(a);
+  REQUIRE( res == Approx(1e-5) );
+
+  a(0) = -3.0;
+  a(2) = -1.0;
+
+  res = min(a);
+  REQUIRE( res == Approx(-3.0) );
+
+  a(0) = 1.3;
+  a(1) = 2.4;
+  a(2) = 3.1;
+  a(3) = 4.4;
+  a(4) = 1.4;
+
+  res = min(a);
+  REQUIRE( res == Approx(1.3) );
+
+  SpRow<double> b(5);
+
+  b(0) = 3.0;
+  b(2) = 1.0;
+
+  res = min(b);
+  REQUIRE( res == Approx(1e-5) );
+
+  b(0) = -3.0;
+  b(2) = -1.0;
+
+  res = min(b);
+  REQUIRE( res == Approx(-3.0) );
+
+  b(0) = 1.3;
+  b(1) = 2.4;
+  b(2) = 3.1;
+  b(3) = 4.4;
+  b(4) = 1.4;
+
+  res = min(b);
+  REQUIRE( res == Approx(1.3) );
+
+  SpMat<double> c(6, 5);
+
+  c(0, 0) = 1.0;
+  c(1, 0) = 3.0;
+  c(2, 0) = 4.0;
+  c(3, 0) = 0.6;
+  c(4, 0) = 1.4;
+  c(5, 0) = 1.2;
+  c(3, 2) = 1.3;
+  c(2, 3) = -4.0;
+  c(4, 3) = -1.4;
+  c(5, 2) = -3.4;
+  c(5, 3) = -4.1;
+
+  SpMat<double> r = min(c, 0);
+  REQUIRE( r.n_rows == 1 );
+  REQUIRE( r.n_cols == 5 );
+  REQUIRE( (double) r(0, 0) == Approx(0.6) );
+  REQUIRE( (double) r(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) r(0, 2) == Approx(-3.4) );
+  REQUIRE( (double) r(0, 3) == Approx(-4.1) );
+  REQUIRE( (double) r(0, 4) == Approx(1e-5) );
+
+  r = min(c, 1);
+  REQUIRE( r.n_rows == 6 );
+  REQUIRE( r.n_cols == 1 );
+  REQUIRE( (double) r(0, 0) == Approx(1e-5) );
+  REQUIRE( (double) r(1, 0) == Approx(1e-5) );
+  REQUIRE( (double) r(2, 0) == Approx(-4.0) );
+  REQUIRE( (double) r(3, 0) == Approx(1e-5) );
+  REQUIRE( (double) r(4, 0) == Approx(-1.4) );
+  REQUIRE( (double) r(5, 0) == Approx(-4.1) );
+  }
+
+
+TEST_CASE("max_test")
+  {
+  SpCol<double> a(5);
+
+  a(0) = -3.0;
+  a(2) = -1.0;
+
+  double resa = max(a);
+  REQUIRE( resa == Approx(1e-5) );
+
+  a(0) = 3.0;
+  a(2) = 1.0;
+
+  resa = max(a);
+  REQUIRE( resa == Approx(3.0) );
+
+  a(0) = -1.3;
+  a(1) = -2.4;
+  a(2) = -3.1;
+  a(3) = -4.4;
+  a(4) = -1.4;
+
+  resa = max(a);
+  REQUIRE( resa == Approx(-1.3) );
+
+  SpRow<double> b(5);
+
+  b(0) = -3.0;
+  b(2) = -1.0;
+
+  resa = max(b);
+  REQUIRE( resa == Approx(1e-5) );
+
+  b(0) = 3.0;
+  b(2) = 1.0;
+
+  resa = max(b);
+  REQUIRE( resa == Approx(3.0) );
+
+  b(0) = -1.3;
+  b(1) = -2.4;
+  b(2) = -3.1;
+  b(3) = -4.4;
+  b(4) = -1.4;
+
+  resa = max(b);
+  REQUIRE( resa == Approx(-1.3) );
+
+  SpMat<double> c(6, 5);
+
+  c(0, 0) = 1.0;
+  c(1, 0) = 3.0;
+  c(2, 0) = 4.0;
+  c(3, 0) = 0.6;
+  c(4, 0) = -1.4;
+  c(5, 0) = 1.2;
+  c(3, 2) = 1.3;
+  c(2, 3) = -4.0;
+  c(4, 3) = -1.4;
+  c(5, 2) = -3.4;
+  c(5, 3) = -4.1;
+
+  SpMat<double> res = max(c, 0);
+  REQUIRE( res.n_rows == 1 );
+  REQUIRE( res.n_cols == 5 );
+  REQUIRE( (double) res(0, 0) == Approx(4.0) );
+  REQUIRE( (double) res(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) res(0, 2) == Approx(1.3) );
+  REQUIRE( (double) res(0, 3) == Approx(1e-5) );
+  REQUIRE( (double) res(0, 4) == Approx(1e-5) );
+
+  res = max(c, 1);
+  REQUIRE( res.n_rows == 6 );
+  REQUIRE( res.n_cols == 1 );
+  REQUIRE( (double) res(0, 0) == Approx(1.0) );
+  REQUIRE( (double) res(1, 0) == Approx(3.0) );
+  REQUIRE( (double) res(2, 0) == Approx(4.0) );
+  REQUIRE( (double) res(3, 0) == Approx(1.3) );
+  REQUIRE( (double) res(4, 0) == Approx(1e-5) );
+  REQUIRE( (double) res(5, 0) == Approx(1.2) );
+  }
+
+
+TEST_CASE("spmat_min_cx_test")
+{
+  SpCol<std::complex<double> > a(5);
+
+  a(0) = std::complex<double>(3.0, -2.0);
+  a(2) = std::complex<double>(1.0, 1.0);
+
+  std::complex<double> res = min(a);
+  REQUIRE( res.real() == Approx(1e-5) );
+  REQUIRE( res.imag() == Approx(1e-5) );
+
+  a(0) = std::complex<double>(-3.0, -2.0);
+  a(2) = std::complex<double>(-1.0, -1.0);
+
+  res = min(a);
+  REQUIRE( res.real() == Approx(1e-5) );
+  REQUIRE( res.imag() == Approx(1e-5) );
+
+  a(0) = std::complex<double>(1.0, 0.5);
+  a(1) = std::complex<double>(2.4, 1.4);
+  a(2) = std::complex<double>(0.5, 0.5);
+  a(3) = std::complex<double>(2.0, 2.0);
+  a(4) = std::complex<double>(1.4, -1.4);
+
+  res = min(a);
+  REQUIRE( res.real() == Approx(0.5) );
+  REQUIRE( res.imag() == Approx(0.5) );
+
+  SpRow<std::complex<double> > b(5);
+
+  b(0) = std::complex<double>(3.0, -2.0);
+  b(2) = std::complex<double>(1.0, 1.0);
+
+  res = min(b);
+  REQUIRE( res.real() == Approx(1e-5) );
+  REQUIRE( res.imag() == Approx(1e-5) );
+
+  b(0) = std::complex<double>(-3.0, -2.0);
+  b(2) = std::complex<double>(-1.0, -1.0);
+
+  res = min(b);
+  REQUIRE( res.real() == Approx(1e-5) );
+  REQUIRE( res.imag() == Approx(1e-5) );
+
+  b(0) = std::complex<double>(1.0, 0.5);
+  b(1) = std::complex<double>(2.4, 1.4);
+  b(2) = std::complex<double>(0.5, 0.5);
+  b(3) = std::complex<double>(2.0, 2.0);
+  b(4) = std::complex<double>(1.4, -1.4);
+
+  res = min(b);
+  REQUIRE( res.real() == Approx(0.5) );
+  REQUIRE( res.imag() == Approx(0.5) );
+
+  SpMat<std::complex<double> > c(4, 3);
+
+  c(0, 0) = std::complex<double>(1.0, 2.0);
+  c(0, 1) = std::complex<double>(0.5, 0.5);
+  c(0, 2) = std::complex<double>(2.0, 4.0);
+  c(1, 1) = std::complex<double>(-1.0, -2.0);
+  c(2, 1) = std::complex<double>(-3.0, -3.0);
+  c(3, 1) = std::complex<double>(0.25, 0.25);
+
+  SpMat<std::complex<double> > r = min(c, 0);
+  REQUIRE( r.n_rows == 1 );
+  REQUIRE( r.n_cols == 3 );
+  REQUIRE( ((std::complex<double>) r(0, 0)).real() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(0, 0)).imag() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(0, 1)).real() == Approx(0.25) );
+  REQUIRE( ((std::complex<double>) r(0, 1)).imag() == Approx(0.25) );
+  REQUIRE( ((std::complex<double>) r(0, 2)).real() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(0, 2)).imag() == Approx(1e-5) );
+
+  r = min(c, 1);
+  REQUIRE( r.n_rows == 4 );
+  REQUIRE( r.n_cols == 1 );
+  REQUIRE( ((std::complex<double>) r(0, 0)).real() == Approx(0.5) );
+  REQUIRE( ((std::complex<double>) r(0, 0)).imag() == Approx(0.5) );
+  REQUIRE( ((std::complex<double>) r(1, 0)).real() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(1, 0)).imag() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(2, 0)).real() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(2, 0)).imag() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(3, 0)).real() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(3, 0)).imag() == Approx(1e-5) );
+}
+
+
+
+TEST_CASE("spmat_max_cx_test")
+{
+  SpCol<std::complex<double> > a(5);
+
+  a(0) = std::complex<double>(3.0, -2.0);
+  a(2) = std::complex<double>(1.0, 1.0);
+
+  std::complex<double> res = max(a);
+  REQUIRE( res.real() == Approx(3.0) );
+  REQUIRE( res.imag() == Approx(-2.0) );
+
+  a(0) = std::complex<double>(0);
+  a(2) = std::complex<double>(0);
+
+  res = max(a);
+  REQUIRE( res.real() == Approx(1e-5) );
+  REQUIRE( res.imag() == Approx(1e-5) );
+
+  a(0) = std::complex<double>(1.0, 0.5);
+  a(1) = std::complex<double>(2.4, 1.4);
+  a(2) = std::complex<double>(0.5, 0.5);
+  a(3) = std::complex<double>(2.0, 2.0);
+  a(4) = std::complex<double>(1.4, -1.4);
+
+  res = max(a);
+  REQUIRE( res.real() == Approx(2.0) );
+  REQUIRE( res.imag() == Approx(2.0) );
+
+  SpRow<std::complex<double> > b(5);
+
+  b(0) = std::complex<double>(3.0, -2.0);
+  b(2) = std::complex<double>(1.0, 1.0);
+
+  res = max(b);
+  REQUIRE( res.real() == Approx(3.0) );
+  REQUIRE( res.imag() == Approx(-2.0) );
+
+  b(0) = std::complex<double>(0);
+  b(2) = std::complex<double>(0);
+
+  res = max(b);
+  REQUIRE( res.real() == Approx(1e-5) );
+  REQUIRE( res.imag() == Approx(1e-5) );
+
+  b(0) = std::complex<double>(1.0, 0.5);
+  b(1) = std::complex<double>(2.4, 1.4);
+  b(2) = std::complex<double>(0.5, 0.5);
+  b(3) = std::complex<double>(2.0, 2.0);
+  b(4) = std::complex<double>(1.4, -1.4);
+
+  res = max(b);
+  REQUIRE( res.real() == Approx(2.0) );
+  REQUIRE( res.imag() == Approx(2.0) );
+
+  SpMat<std::complex<double> > c(4, 3);
+
+  c(0, 0) = std::complex<double>(1.0, 2.0);
+  c(0, 1) = std::complex<double>(0.5, 0.5);
+  c(1, 1) = std::complex<double>(-1.0, -2.0);
+  c(2, 1) = std::complex<double>(-3.0, -3.0);
+  c(3, 1) = std::complex<double>(0.25, 0.25);
+
+  SpMat<std::complex<double> > r = max(c, 0);
+  REQUIRE( r.n_rows == 1 );
+  REQUIRE( r.n_cols == 3 );
+  REQUIRE( ((std::complex<double>) r(0, 0)).real() == Approx(1.0) );
+  REQUIRE( ((std::complex<double>) r(0, 0)).imag() == Approx(2.0) );
+  REQUIRE( ((std::complex<double>) r(0, 1)).real() == Approx(-3.0) );
+  REQUIRE( ((std::complex<double>) r(0, 1)).imag() == Approx(-3.0) );
+  REQUIRE( ((std::complex<double>) r(0, 2)).real() == Approx(1e-5) );
+  REQUIRE( ((std::complex<double>) r(0, 2)).imag() == Approx(1e-5) );
+
+  r = max(c, 1);
+  REQUIRE( r.n_rows == 4 );
+  REQUIRE( r.n_cols == 1 );
+  REQUIRE( ((std::complex<double>) r(0, 0)).real() == Approx(1.0) );
+  REQUIRE( ((std::complex<double>) r(0, 0)).imag() == Approx(2.0) );
+  REQUIRE( ((std::complex<double>) r(1, 0)).real() == Approx(-1.0) );
+  REQUIRE( ((std::complex<double>) r(1, 0)).imag() == Approx(-2.0) );
+  REQUIRE( ((std::complex<double>) r(2, 0)).real() == Approx(-3.0) );
+  REQUIRE( ((std::complex<double>) r(2, 0)).imag() == Approx(-3.0) );
+  REQUIRE( ((std::complex<double>) r(3, 0)).real() == Approx(0.25) );
+  REQUIRE( ((std::complex<double>) r(3, 0)).imag() == Approx(0.25) );
+  }
+
+
+
+TEST_CASE("spmat_complex_constructor_test")
+  {
+  // First make two sparse matrices.
+  SpMat<double> a(8, 10);
+  SpMat<double> b(8, 10);
+
+  a(0, 0) = 4;
+  a(4, 2) = 5;
+  a(5, 3) = 6;
+  a(6, 3) = 7;
+  a(1, 4) = 1;
+  a(5, 4) = 6;
+  a(7, 6) = 3;
+  a(0, 7) = 2;
+  a(3, 7) = 3;
+
+  b(0, 0) = 4;
+  b(4, 2) = 5;
+  b(7, 3) = 4;
+  b(1, 4) = 1;
+  b(3, 4) = 6;
+  b(5, 4) = -1;
+  b(6, 4) = 2;
+  b(7, 4) = 3;
+  b(6, 5) = 2;
+  b(6, 6) = 3;
+  b(3, 7) = 4;
+  b(6, 7) = 5;
+
+  SpMat<std::complex<double> > c(a, b);
+
+  REQUIRE( c.n_nonzero == 16 );
+  REQUIRE( (std::complex<double>) c(0, 0) == std::complex<double>(4, 4) );
+  REQUIRE( (std::complex<double>) c(4, 2) == std::complex<double>(5, 5) );
+  REQUIRE( (std::complex<double>) c(5, 3) == std::complex<double>(6, 0) );
+  REQUIRE( (std::complex<double>) c(6, 3) == std::complex<double>(7, 0) );
+  REQUIRE( (std::complex<double>) c(7, 3) == std::complex<double>(0, 4) );
+  REQUIRE( (std::complex<double>) c(1, 4) == std::complex<double>(1, 1) );
+  REQUIRE( (std::complex<double>) c(3, 4) == std::complex<double>(0, 6) );
+  REQUIRE( (std::complex<double>) c(5, 4) == std::complex<double>(6, -1) );
+  REQUIRE( (std::complex<double>) c(6, 4) == std::complex<double>(0, 2) );
+  REQUIRE( (std::complex<double>) c(7, 4) == std::complex<double>(0, 3) );
+  REQUIRE( (std::complex<double>) c(6, 5) == std::complex<double>(0, 2) );
+  REQUIRE( (std::complex<double>) c(6, 6) == std::complex<double>(0, 3) );
+  REQUIRE( (std::complex<double>) c(7, 6) == std::complex<double>(3, 0) );
+  REQUIRE( (std::complex<double>) c(0, 7) == std::complex<double>(2, 0) );
+  REQUIRE( (std::complex<double>) c(3, 7) == std::complex<double>(3, 4) );
+  REQUIRE( (std::complex<double>) c(6, 7) == std::complex<double>(0, 5) );
+  }
+
+
+
+TEST_CASE("spmat_unary_operators_test")
+  {
+  SpMat<int> a(3, 3);
+  SpMat<int> b(3, 3);
+
+  a(0, 0) = 1;
+  a(1, 2) = 4;
+  a(2, 2) = 5;
+
+  b(0, 1) = 1;
+  b(1, 0) = 2;
+  b(1, 2) = -4;
+  b(2, 2) = 5;
+
+  SpMat<int> c = a + b;
+
+  REQUIRE( c.n_nonzero == 4 );
+
+  REQUIRE( (double) c(0, 0) == 1 );
+  REQUIRE( (double) c(1, 0) == 2 );
+  REQUIRE( (double) c(2, 0) == 0 );
+  REQUIRE( (double) c(0, 1) == 1 );
+  REQUIRE( (double) c(1, 1) == 0 );
+  REQUIRE( (double) c(2, 1) == 0 );
+  REQUIRE( (double) c(0, 2) == 0 );
+  REQUIRE( (double) c(1, 2) == 0 );
+  REQUIRE( (double) c(2, 2) == 10 );
+
+  c = a - b;
+
+  REQUIRE( c.n_nonzero == 4 );
+
+  REQUIRE( (double) c(0, 0) == 1 );
+  REQUIRE( (double) c(1, 0) == -2 );
+  REQUIRE( (double) c(2, 0) == 0 );
+  REQUIRE( (double) c(0, 1) == -1 );
+  REQUIRE( (double) c(1, 1) == 0 );
+  REQUIRE( (double) c(2, 1) == 0 );
+  REQUIRE( (double) c(0, 2) == 0 );
+  REQUIRE( (double) c(1, 2) == 8 );
+  REQUIRE( (double) c(2, 2) == 0 );
+
+  c = a % b;
+
+  REQUIRE( c.n_nonzero == 2 );
+
+  REQUIRE( (double) c(0, 0) == 0 );
+  REQUIRE( (double) c(1, 0) == 0 );
+  REQUIRE( (double) c(2, 0) == 0 );
+  REQUIRE( (double) c(0, 1) == 0 );
+  REQUIRE( (double) c(1, 1) == 0 );
+  REQUIRE( (double) c(2, 1) == 0 );
+  REQUIRE( (double) c(0, 2) == 0 );
+  REQUIRE( (double) c(1, 2) == -16 );
+  REQUIRE( (double) c(2, 2) == 25 );
+
+  a(0, 0) = 4;
+  b(0, 0) = 2;
+/*
+  c = a / b;
+
+  REQUIRE( c.n_nonzero == 3 );
+
+  REQUIRE( (double) c(0, 0) == 2 );
+  REQUIRE( (double) c(1, 0) == 0 );
+  REQUIRE( (double) c(2, 0) == 0 );
+  REQUIRE( (double) c(0, 1) == 0 );
+  REQUIRE( (double) c(1, 1) == 0 );
+  REQUIRE( (double) c(2, 1) == 0 );
+  REQUIRE( (double) c(0, 2) == 0 );
+  REQUIRE( (double) c(1, 2) == -1 );
+  REQUIRE( (double) c(2, 2) == 1 );
+*/
+  }
+
+
+
+TEST_CASE("spmat_unary_val_operators_test")
+  {
+  SpMat<double> a(2, 2);
+
+  a(0, 0) = 2.0;
+  a(1, 1) = -3.0;
+
+  SpMat<double> b = a * 3.0;
+
+  REQUIRE( b.n_nonzero == 2 );
+  REQUIRE( (double) b(0, 0) == Approx(6.0) );
+  REQUIRE( (double) b(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 0) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 1) == Approx(-9.0) );
+
+  b = a / 3.0;
+
+  REQUIRE( b.n_nonzero == 2 );
+  REQUIRE( (double) b(0, 0) == Approx(2.0 / 3.0) );
+  REQUIRE( (double) b(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 0) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 1) == Approx(-1.0) );
+  }
+
+
+TEST_CASE("spmat_sparse_unary_multiplication_test")
+  {
+  SpMat<double> spaa(10, 10);
+  spaa(1, 5) = 0.4;
+  spaa(0, 4) = 0.3;
+  spaa(0, 8) = 1.2;
+  spaa(3, 0) = 1.1;
+  spaa(3, 1) = 1.1;
+  spaa(3, 2) = 1.1;
+  spaa(4, 4) = 0.2;
+  spaa(4, 9) = 0.1;
+  spaa(6, 2) = 4.1;
+  spaa(6, 8) = 4.1;
+  spaa(7, 5) = 1.0;
+  spaa(8, 9) = 0.4;
+  spaa(9, 4) = 0.4;
+
+  double correctResultB[10][10] =
+    {{ 0.00, 0.00, 0.00, 0.00, 0.06, 0.00, 0.00, 0.00, 0.00, 0.51 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.33, 0.44, 0.00, 0.00, 1.32, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.08, 0.00, 0.00, 0.00, 0.00, 0.02 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 1.64 },
+     { 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.16, 0.00, 0.00, 0.00, 0.00, 0.00 },
+     { 0.00, 0.00, 0.00, 0.00, 0.08, 0.00, 0.00, 0.00, 0.00, 0.04 }};
+
+  SpMat<double> spab = spaa * spaa;
+
+  for (uword i = 0; i < 10; i++)
+    {
+    for (uword j = 0; j < 10; j++)
+      {
+      REQUIRE( (double) spab(i, j) == Approx(correctResultB[i][j]) );
+      }
+    }
+
+  SpMat<double> spac(15, 15);
+  spac(6, 10) = 0.4;
+  spac(5, 9) = 0.3;
+  spac(5, 13) = 1.2;
+  spac(8, 5) = 1.1;
+  spac(8, 6) = 1.1;
+  spac(8, 7) = 1.1;
+  spac(9, 9) = 0.2;
+  spac(9, 14) = 0.1;
+  spac(11, 7) = 4.1;
+  spac(11, 13) = 4.1;
+  spac(12, 10) = 1.0;
+  spac(13, 14) = 0.4;
+  spac(14, 9) = 0.4;
+
+  spab = spaa * spac.submat(5, 5, 14, 14);
+
+  for (uword i = 0; i < 10; i++)
+    {
+    for (uword j = 0; j < 10; j++)
+      {
+      REQUIRE( (double) spab(i, j) == Approx(correctResultB[i][j]) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("spmat_unary_operator_test_2")
+  {
+  SpMat<double> a(3, 3);
+  a(0, 0) = 1;
+  a(0, 2) = 3.5;
+  a(1, 2) = 4.0;
+  a(2, 2) = -3.0;
+
+  mat b(3, 3);
+  b.fill(3.0);
+
+  mat c = a + b;
+
+  REQUIRE( c(0, 0) == Approx(4.0) );
+  REQUIRE( c(1, 0) == Approx(3.0) );
+  REQUIRE( c(2, 0) == Approx(3.0) );
+  REQUIRE( c(0, 1) == Approx(3.0) );
+  REQUIRE( c(1, 1) == Approx(3.0) );
+  REQUIRE( c(2, 1) == Approx(3.0) );
+  REQUIRE( c(0, 2) == Approx(6.5) );
+  REQUIRE( c(1, 2) == Approx(7.0) );
+  REQUIRE( c(2, 2) == Approx(1e-5) );
+
+  c = a - b;
+
+  REQUIRE( c(0, 0) == Approx(-2.0) );
+  REQUIRE( c(1, 0) == Approx(-3.0) );
+  REQUIRE( c(2, 0) == Approx(-3.0) );
+  REQUIRE( c(0, 1) == Approx(-3.0) );
+  REQUIRE( c(1, 1) == Approx(-3.0) );
+  REQUIRE( c(2, 1) == Approx(-3.0) );
+  REQUIRE( c(0, 2) == Approx(0.5) );
+  REQUIRE( c(1, 2) == Approx(1.0) );
+  REQUIRE( c(2, 2) == Approx(-6.0) );
+
+  SpMat<double> d = a % b;
+
+  REQUIRE( d.n_nonzero == 4 );
+  REQUIRE( (double) d(0, 0) == Approx(3.0) );
+  REQUIRE( (double) d(1, 0) == Approx(1e-5) );
+  REQUIRE( (double) d(2, 0) == Approx(1e-5) );
+  REQUIRE( (double) d(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) d(1, 1) == Approx(1e-5) );
+  REQUIRE( (double) d(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) d(0, 2) == Approx(10.5) );
+  REQUIRE( (double) d(1, 2) == Approx(12.0) );
+  REQUIRE( (double) d(2, 2) == Approx(-9.0) );
+
+  d = a / b;
+
+  REQUIRE( d.n_nonzero == 4 );
+  REQUIRE( (double) d(0, 0) == Approx((1.0 / 3.0)) );
+  REQUIRE( (double) d(1, 0) == Approx(1e-5) );
+  REQUIRE( (double) d(2, 0) == Approx(1e-5) );
+  REQUIRE( (double) d(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) d(1, 1) == Approx(1e-5) );
+  REQUIRE( (double) d(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) d(0, 2) == Approx((3.5 / 3.0)) );
+  REQUIRE( (double) d(1, 2) == Approx((4.0 / 3.0)) );
+  REQUIRE( (double) d(2, 2) == Approx(-1.0) );
+
+  c = a * b;
+
+  REQUIRE( (double) c(0, 0) == Approx(13.5) );
+  REQUIRE( (double) c(1, 0) == Approx(12.0) );
+  REQUIRE( (double) c(2, 0) == Approx(-9.0) );
+  REQUIRE( (double) c(0, 1) == Approx(13.5) );
+  REQUIRE( (double) c(1, 1) == Approx(12.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-9.0) );
+  REQUIRE( (double) c(0, 2) == Approx(13.5) );
+  REQUIRE( (double) c(1, 2) == Approx(12.0) );
+  REQUIRE( (double) c(2, 2) == Approx(-9.0) );
+
+  c = b * a;
+
+  REQUIRE( (double) c(0, 0) == Approx(3.0) );
+  REQUIRE( (double) c(1, 0) == Approx(3.0) );
+  REQUIRE( (double) c(2, 0) == Approx(3.0) );
+  REQUIRE( (double) c(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(0, 2) == Approx(13.5) );
+  REQUIRE( (double) c(1, 2) == Approx(13.5) );
+  REQUIRE( (double) c(2, 2) == Approx(13.5) );
+  }
+
+
+
+TEST_CASE("spmat_mat_operator_tests")
+  {
+  SpMat<double> a(3, 3);
+  a(0, 0) = 2.0;
+  a(1, 2) = 3.5;
+  a(2, 1) = -2.0;
+  a(2, 2) = 4.5;
+
+  mat b(3, 3);
+  b.fill(2.0);
+
+  mat c(b);
+
+  c += a;
+
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.5) );
+  REQUIRE( (double) c(2, 2) == Approx(6.5) );
+
+  c = b + a;
+
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.5) );
+  REQUIRE( (double) c(2, 2) == Approx(6.5) );
+
+  c = b;
+  c -= a;
+
+  REQUIRE( (double) c(0, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(-1.5) );
+  REQUIRE( (double) c(2, 2) == Approx(-2.5) );
+
+  c = b - a;
+
+  REQUIRE( (double) c(0, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(-1.5) );
+  REQUIRE( (double) c(2, 2) == Approx(-2.5) );
+
+  c = b;
+  c *= a;
+
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(4.0) );
+  REQUIRE( (double) c(2, 0) == Approx(4.0) );
+  REQUIRE( (double) c(0, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(1, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(16.0) );
+  REQUIRE( (double) c(1, 2) == Approx(16.0) );
+  REQUIRE( (double) c(2, 2) == Approx(16.0) );
+
+  mat e = b * a;
+
+  REQUIRE( (double) e(0, 0) == Approx(4.0) );
+  REQUIRE( (double) e(1, 0) == Approx(4.0) );
+  REQUIRE( (double) e(2, 0) == Approx(4.0) );
+  REQUIRE( (double) e(0, 1) == Approx(-4.0) );
+  REQUIRE( (double) e(1, 1) == Approx(-4.0) );
+  REQUIRE( (double) e(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) e(0, 2) == Approx(16.0) );
+  REQUIRE( (double) e(1, 2) == Approx(16.0) );
+  REQUIRE( (double) e(2, 2) == Approx(16.0) );
+
+  c = b;
+  c %= a;
+
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(2, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 2) == Approx(7.0) );
+  REQUIRE( (double) c(2, 2) == Approx(9.0) );
+
+  SpMat<double> d = b % a;
+
+  REQUIRE( d.n_nonzero == 4 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(7.0) );
+  REQUIRE( (double) c(2, 2) == Approx(9.0) );
+
+  c = b;
+  c /= a;
+
+  REQUIRE( c(0, 0) == Approx(1.0) );
+  REQUIRE( std::isinf(c(1, 0)) );
+  REQUIRE( std::isinf(c(2, 0)) );
+  REQUIRE( std::isinf(c(0, 1)) );
+  REQUIRE( std::isinf(c(1, 1)) );
+  REQUIRE( c(2, 1) == Approx(-1.0) );
+  REQUIRE( std::isinf(c(0, 2)) );
+  REQUIRE( c(1, 2) == Approx(2.0 / 3.5) );
+  REQUIRE( c(2, 2) == Approx(2.0 / 4.5) );
+  }
+
+
+TEST_CASE("spmat_empty_hadamard")
+  {
+  SpMat<double> x(5, 5), y(5, 5), z;
+
+  z = x % y;
+
+  REQUIRE( z.n_nonzero == 0 );
+  REQUIRE( z.n_rows == 5 );
+  REQUIRE( z.n_cols == 5 );
+  }
+
+
+
+TEST_CASE("spmat_sparse_dense_in_place")
+  {
+  SpMat<double> a;
+  a.sprandu(50, 50, 0.1);
+  mat b;
+  b.randu(50, 50);
+  mat d( a);
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) a(r, c) != 0)
+        REQUIRE( (double) a(r, c) == Approx(d(r, c)) );
+      else
+        REQUIRE( d(r, c) == Approx(1e-5) );
+      }
+    }
+
+  SpMat<double> x;
+  mat y;
+
+  x = a;
+  y = d;
+
+  x *= b;
+  y *= b;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) a(r, c) != 0)
+        REQUIRE( (double) a(r, c) == Approx(d(r, c)) );
+      else
+        REQUIRE( d(r, c) == Approx(1e-5) );
+      }
+    }
+
+  x = a;
+  y = d;
+
+  x /= b;
+  y /= b;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) a(r, c) != 0)
+        REQUIRE( (double) a(r, c) == Approx(d(r, c)) );
+      else
+        REQUIRE( d(r, c) == Approx(1e-5) );
+      }
+    }
+
+  x = a;
+  y = d;
+
+  x %= b;
+  y %= b;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) a(r, c) != 0)
+        REQUIRE( (double) a(r, c) == Approx(d(r, c)) );
+      else
+        REQUIRE(d(r, c) == Approx(1e-5) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("spmat_sparse_dense_not_in_place")
+  {
+  SpMat<double> a;
+  a.sprandu(50, 50, 0.1);
+  mat b;
+  b.randu(50, 50);
+  mat d(a);
+
+  SpMat<double> x;
+  mat y;
+  mat z;
+
+  y = a + b;
+  z = d + b;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for(uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+      }
+    }
+
+  y = a - b;
+  z = d - b;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+      }
+    }
+
+  y = a * b;
+  z = d * b;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+      }
+    }
+
+  y = a % b;
+  z = d % b;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+      }
+    }
+
+  y = a / b;
+  z = d / b;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+      }
+    }
+
+  y = b + a;
+  z = b + d;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+    }
+  }
+
+  y = b - a;
+  z = b - d;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+      }
+    }
+
+  y = b * a;
+  z = b * d;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+      }
+    }
+
+  y = b % a;
+  z = b % d;
+
+  for (uword c = 0; c < 50; ++c)
+    {
+    for (uword r = 0; r < 50; ++r)
+      {
+      if ((double) y(r, c) != 0)
+        REQUIRE( (double) y(r, c) == Approx(z(r, c)) );
+      else
+        REQUIRE( z(r, c) == Approx(1e-5) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("spmat_batch_insert_test")
+  {
+  Mat<uword> locations(2, 5);
+  locations(1, 0) = 1;
+  locations(0, 0) = 2;
+  locations(1, 1) = 1;
+  locations(0, 1) = 7;
+  locations(1, 2) = 4;
+  locations(0, 2) = 0;
+  locations(1, 3) = 4;
+  locations(0, 3) = 9;
+  locations(1, 4) = 5;
+  locations(0, 4) = 0;
+
+  Col<double> values(5);
+  values[0] = 1.5;
+  values[1] = -15.15;
+  values[2] = 2.2;
+  values[3] = 3.0;
+  values[4] = 5.0;
+
+  SpMat<double> m(locations, values, 10, 10, true);
+
+  REQUIRE( m.n_nonzero == 5 );
+  REQUIRE( m.n_rows == 10 );
+  REQUIRE( m.n_cols == 10 );
+  REQUIRE( (double) m(2, 1) == Approx(1.5) );
+  REQUIRE( (double) m(7, 1) == Approx(-15.15) );
+  REQUIRE( (double) m(0, 4) == Approx(2.2) );
+  REQUIRE( (double) m(9, 4) == Approx(3.0) );
+  REQUIRE( (double) m(0, 5) == Approx(5.0) );
+  REQUIRE( m.col_ptrs[11] == std::numeric_limits<uword>::max() );
+
+  // Auto size detection.
+  SpMat<double> n(locations, values, true);
+
+  REQUIRE( n.n_nonzero == 5 );
+  REQUIRE( n.n_rows == 10 );
+  REQUIRE( n.n_cols == 6 );
+  REQUIRE( (double) n(2, 1) == Approx(1.5) );
+  REQUIRE( (double) n(7, 1) == Approx(-15.15) );
+  REQUIRE( (double) n(0, 4) == Approx(2.2) );
+  REQUIRE( (double) n(9, 4) == Approx(3.0) );
+  REQUIRE( (double) n(0, 5) == Approx(5.0) );
+  REQUIRE( n.col_ptrs[7] == std::numeric_limits<uword>::max() );
+  }
+
+
+
+TEST_CASE("spmat_batch_insert_unsorted_test")
+  {
+  Mat<uword> locations(2, 5);
+  locations(1, 0) = 4;
+  locations(0, 0) = 0;
+  locations(1, 1) = 1;
+  locations(0, 1) = 2;
+  locations(1, 2) = 4;
+  locations(0, 2) = 9;
+  locations(1, 3) = 5;
+  locations(0, 3) = 0;
+  locations(1, 4) = 1;
+  locations(0, 4) = 7;
+
+  Col<double> values(5);
+  values[1] = 1.5;
+  values[4] = -15.15;
+  values[0] = 2.2;
+  values[2] = 3.0;
+  values[3] = 5.0;
+
+  SpMat<double> m(locations, values, 10, 10, true);
+
+  REQUIRE( m.n_nonzero == 5 );
+  REQUIRE( m.n_rows == 10 );
+  REQUIRE( m.n_cols == 10 );
+  REQUIRE( (double) m(2, 1) == Approx(1.5) );
+  REQUIRE( (double) m(7, 1) == Approx(-15.15) );
+  REQUIRE( (double) m(0, 4) == Approx(2.2) );
+  REQUIRE( (double) m(9, 4) == Approx(3.0) );
+  REQUIRE( (double) m(0, 5) == Approx(5.0) );
+
+  // Auto size detection.
+  SpMat<double> n(locations, values, true);
+
+  REQUIRE( n.n_nonzero == 5 );
+  REQUIRE( n.n_rows == 10 );
+  REQUIRE( n.n_cols == 6 );
+  REQUIRE( (double) n(2, 1) == Approx(1.5) );
+  REQUIRE( (double) n(7, 1) == Approx(-15.15) );
+  REQUIRE( (double) n(0, 4) == Approx(2.2) );
+  REQUIRE( (double) n(9, 4) == Approx(3.0) );
+  REQUIRE( (double) n(0, 5) == Approx(5.0) );
+  }
+
+
+
+TEST_CASE("spmat_batch_insert_empty_test")
+  {
+  Mat<uword> locations(2, 0);
+  Col<double> values;
+
+  SpMat<double> m(locations, values, 10, 10, false);
+
+  REQUIRE( m.n_nonzero == 0 );
+  REQUIRE( m.n_rows == 10 );
+  REQUIRE( m.n_cols == 10 );
+  REQUIRE( m.col_ptrs[11] == std::numeric_limits<uword>::max() );
+
+  SpMat<double> n(locations, values, false);
+
+  REQUIRE( n.n_nonzero == 0 );
+  REQUIRE( n.n_rows == 0 );
+  REQUIRE( n.n_cols == 0 );
+  REQUIRE( n.col_ptrs[1] == std::numeric_limits<uword>::max() );
+
+  SpMat<double> o(locations, values, 10, 10, true);
+
+  REQUIRE( o.n_nonzero == 0 );
+  REQUIRE( o.n_rows == 10 );
+  REQUIRE( o.n_cols == 10 );
+  REQUIRE( o.col_ptrs[11] == std::numeric_limits<uword>::max() );
+
+  SpMat<double> p(locations, values, true);
+
+  REQUIRE( p.n_nonzero == 0 );
+  REQUIRE( p.n_rows == 0 );
+  REQUIRE( p.n_cols == 0 );
+  REQUIRE( p.col_ptrs[1] == std::numeric_limits<uword>::max() );
+  }
+
+
+// Make sure a matrix is the same as the other one.
+template<typename T1, typename T2>
+void CheckMatrices(const T1& a, const T2& b)
+{
+  REQUIRE( a.n_rows == b.n_rows );
+  REQUIRE( a.n_cols == b.n_cols );
+  for (uword i = 0; i < a.n_elem; ++i)
+    REQUIRE( (double) a[i] == Approx((double) b[i]) );
+}
+
+// Test the constructor written by Dirk.
+TEST_CASE("spmat_dirk_constructor_test")
+  {
+  // Come up with some values and stuff.
+  vec values = "4.0 2.0 1.0 3.2 1.2 3.5";
+  Col<uword> row_indices = "1 3 1 2 4 5";
+  Col<uword> col_ptrs = "0 2 2 3 4 6";
+
+  // Ok, now make a matrix.
+  sp_mat M(row_indices, col_ptrs, values, 6, 5);
+
+  // Make the equivalent dense matrix.
+  mat D(6, 5);
+  D.fill(0);
+  D(1, 0) = 4.0;
+  D(3, 0) = 2.0;
+  D(1, 2) = 1.0;
+  D(2, 3) = 3.2;
+  D(4, 4) = 1.2;
+  D(5, 4) = 3.5;
+
+  // So now let's just do a bunch of operations and make sure everything is the
+  // same.
+  sp_mat dm = M * M.t();
+  mat dd = D * D.t();
+
+  CheckMatrices(dm, dd);
+
+  dm = M.t() * M;
+  dd = D.t() * D;
+
+  CheckMatrices(dm, dd);
+
+  sp_mat am = M + M;
+  mat ad = D + D;
+
+  CheckMatrices(am, ad);
+
+  dm = M + D;
+  ad = D + M;
+
+  CheckMatrices(dm, ad);
+  }
+
+
+
+TEST_CASE("spmat_clear_test")
+  {
+  sp_mat x;
+  x.sprandu(10, 10, 0.6);
+
+  x.clear();
+
+  REQUIRE( x.n_cols == 0 );
+  REQUIRE( x.n_rows == 0 );
+  REQUIRE( x.n_nonzero == 0 );
+  }
+
+
+
+TEST_CASE("spmat_batch_insert_zeroes_test")
+  {
+  Mat<uword> locations(2, 5);
+  locations(1, 0) = 1;
+  locations(0, 0) = 2;
+  locations(1, 1) = 1;
+  locations(0, 1) = 7;
+  locations(1, 2) = 4;
+  locations(0, 2) = 0;
+  locations(1, 3) = 4;
+  locations(0, 3) = 9;
+  locations(1, 4) = 5;
+  locations(0, 4) = 0;
+
+  Col<double> values(5);
+  values[0] = 1.5;
+  values[1] = -15.15;
+  values[2] = 2.2;
+  values[3] = 0.0;
+  values[4] = 5.0;
+
+  SpMat<double> m(locations, values, 10, 10, false, true);
+
+  REQUIRE( m.n_nonzero == 4 );
+  REQUIRE( m.n_rows == 10 );
+  REQUIRE( m.n_cols == 10 );
+  REQUIRE( (double) m(2, 1) == Approx(1.5) );
+  REQUIRE( (double) m(7, 1) == Approx(-15.15) );
+  REQUIRE( (double) m(0, 4) == Approx(2.2) );
+  REQUIRE( (double) m(9, 4) == Approx(1e-5) );
+  REQUIRE( (double) m(0, 5) == Approx(5.0) );
+
+  // Auto size detection.
+  SpMat<double> n(locations, values, false);
+
+  REQUIRE( n.n_nonzero == 4 );
+  REQUIRE( n.n_rows == 10 );
+  REQUIRE( n.n_cols == 6 );
+  REQUIRE( (double) n(2, 1) == Approx(1.5) );
+  REQUIRE( (double) n(7, 1) == Approx(-15.15) );
+  REQUIRE( (double) n(0, 4) == Approx(2.2) );
+  REQUIRE( (double) n(9, 4) == Approx(1e-5) );
+  REQUIRE( (double) n(0, 5) == Approx(5.0) );
+  }
+
+
+
+TEST_CASE("spmat_batch_insert_unsorted_case_zeroes")
+  {
+  Mat<uword> locations(2, 5);
+  locations(1, 0) = 4;
+  locations(0, 0) = 0;
+  locations(1, 1) = 1;
+  locations(0, 1) = 2;
+  locations(1, 2) = 4;
+  locations(0, 2) = 9;
+  locations(1, 3) = 5;
+  locations(0, 3) = 0;
+  locations(1, 4) = 1;
+  locations(0, 4) = 7;
+
+  Col<double> values(5);
+  values[1] = 1.5;
+  values[4] = -15.15;
+  values[0] = 2.2;
+  values[2] = 0.0;
+  values[3] = 5.0;
+
+  SpMat<double> m(locations, values, 10, 10, true);
+
+  REQUIRE( m.n_nonzero == 4 );
+  REQUIRE( m.n_rows == 10 );
+  REQUIRE( m.n_cols == 10 );
+  REQUIRE( (double) m(2, 1) == Approx(1.5) );
+  REQUIRE( (double) m(7, 1) == Approx(-15.15) );
+  REQUIRE( (double) m(0, 4) == Approx(2.2) );
+  REQUIRE( (double) m(9, 4) == Approx(1e-5) );
+  REQUIRE( (double) m(0, 5) == Approx(5.0) );
+  REQUIRE( m.col_ptrs[11] == std::numeric_limits<uword>::max() );
+
+  // Auto size detection.
+  SpMat<double> n(locations, values, true);
+
+  REQUIRE( n.n_nonzero == 4 );
+  REQUIRE( n.n_rows == 10 );
+  REQUIRE( n.n_cols == 6 );
+  REQUIRE( (double) n(2, 1) == Approx(1.5) );
+  REQUIRE( (double) n(7, 1) == Approx(-15.15) );
+  REQUIRE( (double) n(0, 4) == Approx(2.2) );
+  REQUIRE( (double) n(9, 4) == Approx(1e-5) );
+  REQUIRE( (double) n(0, 5) == Approx(5.0) );
+  REQUIRE( n.col_ptrs[7] == std::numeric_limits<uword>::max() );
+  }
+
+
+
+TEST_CASE("spmat_const_row_col_iterator_test")
+  {
+  mat X;
+  X.zeros(5, 5);
+  for (uword i = 0; i < 5; ++i)
+    {
+    X.col(i) += i;
+    }
+
+  for (uword i = 0; i < 5; ++i)
+    {
+    X.row(i) += 3 * i;
+    }
+
+  // Make sure default constructor works okay.
+  mat::const_row_col_iterator it;
+  // Make sure ++ operator, operator* and comparison operators work fine.
+  size_t count = 0;
+  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+    {
+    // Check iterator value.
+    REQUIRE( *it == (count % 5) * 3 + (count / 5) );
+
+    // Check iterator position.
+    REQUIRE( it.row() == count % 5 );
+    REQUIRE( it.col() == count / 5 );
+
+    count++;
+    }
+  REQUIRE( count == 25 );
+  it = X.end_row_col();
+  do
+    {
+    it--;
+    count--;
+
+    // Check iterator value.
+    REQUIRE( *it == (count % 5) * 3 + (count / 5) );
+
+    // Check iterator position.
+    REQUIRE( it.row() == count % 5 );
+    REQUIRE( it.col() == count / 5 );
+    } while (it != X.begin_row_col());
+
+  REQUIRE( count == 0 );
+  }
+
+
+
+TEST_CASE("spmat_row_col_iterator_test")
+  {
+  mat X;
+  X.zeros(5, 5);
+  for (size_t i = 0; i < 5; ++i)
+    {
+    X.col(i) += i;
+    }
+
+  for (size_t i = 0; i < 5; ++i)
+    {
+    X.row(i) += 3 * i;
+    }
+
+  // Make sure default constructor works okay.
+  mat::row_col_iterator it;
+  // Make sure ++ operator, operator* and comparison operators work fine.
+  size_t count = 0;
+  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+    {
+    // Check iterator value.
+    REQUIRE( *it == (count % 5) * 3 + (count / 5) );
+
+    // Check iterator position.
+    REQUIRE( it.row() == count % 5 );
+    REQUIRE( it.col() == count / 5 );
+
+    count++;
+    }
+  REQUIRE( count == 25 );
+  it = X.end_row_col();
+  do
+    {
+    it--;
+    count--;
+
+    // Check iterator value.
+    REQUIRE( *it == (count % 5) * 3 + (count / 5) );
+
+    // Check iterator position.
+    REQUIRE( it.row() == count % 5 );
+    REQUIRE( it.col() == count / 5 );
+    } while (it != X.begin_row_col());
+
+  REQUIRE( count == 0 );
+  }
+
+
+
+TEST_CASE("spmat_const_sprow_col_iterator_test")
+  {
+  sp_mat X(5, 5);
+  for (size_t i = 0; i < 5; ++i)
+    {
+    X.col(i) += i;
+    }
+
+  for (size_t i = 0; i < 5; ++i)
+    {
+    X.row(i) += 3 * i;
+    }
+
+  // Make sure default constructor works okay.
+  sp_mat::const_row_col_iterator it;
+  // Make sure ++ operator, operator* and comparison operators work fine.
+  size_t count = 1;
+  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+    {
+    // Check iterator value.
+    REQUIRE( *it == (count % 5) * 3 + (count / 5) );
+
+    // Check iterator position.
+    REQUIRE( it.row() == count % 5 );
+    REQUIRE( it.col() == count / 5 );
+
+    count++;
+    }
+  REQUIRE( count == 25 );
+  it = X.end_row_col();
+  do
+    {
+    it--;
+    count--;
+
+    // Check iterator value.
+    REQUIRE( *it == (count % 5) * 3 + (count / 5) );
+
+    // Check iterator position.
+    REQUIRE( it.row() == count % 5 );
+    REQUIRE( it.col() == count / 5 );
+    } while (it != X.begin_row_col());
+
+  REQUIRE( count == 1 );
+  }
+
+
+
+TEST_CASE("spmat_sprow_col_iterator_test")
+  {
+  sp_mat X(5, 5);
+  for (size_t i = 0; i < 5; ++i)
+    {
+    X.col(i) += i;
+    }
+
+  for (size_t i = 0; i < 5; ++i)
+    {
+    X.row(i) += 3 * i;
+    }
+
+  // Make sure default constructor works okay.
+  sp_mat::row_col_iterator it;
+  // Make sure ++ operator, operator* and comparison operators work fine.
+  size_t count = 1;
+  for (it = X.begin_row_col(); it != X.end_row_col(); it++)
+    {
+    // Check iterator value.
+    REQUIRE( *it == (count % 5) * 3 + (count / 5) );
+
+    // Check iterator position.
+    REQUIRE( it.row() == count % 5 );
+    REQUIRE( it.col() == count / 5 );
+
+    count++;
+    }
+  REQUIRE( count == 25 );
+  it = X.end_row_col();
+  do
+    {
+    it--;
+    count--;
+
+    // Check iterator value.
+    REQUIRE( *it == (count % 5) * 3 + (count / 5) );
+
+    // Check iterator position.
+    REQUIRE( it.row() == count % 5 );
+    REQUIRE( it.col() == count / 5 );
+    } while (it != X.begin_row_col());
+
+  REQUIRE( count == 1 );
+  }

--- a/tests/sprow.cpp
+++ b/tests/sprow.cpp
@@ -1,0 +1,61 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("sprow_shed_col_test")
+  {
+
+  SpRow<int> d(10);
+  d[3] = 2;
+  d[4] = 6;
+  d[6] = 2;
+  d[7] = 9;
+  d[8] = 1;
+  d[9] = -2;
+
+  d.shed_cols(4, 7);
+  REQUIRE( d.n_cols == 6 );
+  REQUIRE( d.n_rows == 1 );
+  REQUIRE( d.n_elem == 6 );
+  REQUIRE( d.n_nonzero == 3 );
+  REQUIRE( d[0] == 0 );
+  REQUIRE( d[1] == 0 );
+  REQUIRE( d[2] == 0 );
+  REQUIRE( d[3] == 2 );
+  REQUIRE( d[4] == 1 );
+  REQUIRE( d[5] == -2 );
+  }
+
+
+
+TEST_CASE("sprow_row_constructor_test")
+  {
+  SpMat<double> m(100, 100);
+  m.sprandu(100, 100, 0.3);
+
+  SpRow<double> r = m.row(0);
+
+  rowvec v(r);
+
+  for (uword i = 0; i < 100; ++i)
+    {
+    REQUIRE( v(i) == (double) r(i) );
+    }
+  }

--- a/tests/spsubview.cpp
+++ b/tests/spsubview.cpp
@@ -1,0 +1,1449 @@
+// Copyright 2011-2017 Ryan Curtin (http://www.ratml.org/)
+// Copyright 2017 National ICT Australia (NICTA)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+#include <armadillo>
+
+#include "catch.hpp"
+
+using namespace arma;
+
+TEST_CASE("sp_subview_tests")
+  {
+  Mat<double> ref(4,4);
+  ref.eye(4,4);
+
+  SpMat<double> X(4,4);
+  X.eye(4,4);
+
+  /*
+   * [[1,0,0,0]     [[2,0,0,0]
+   *  [0,1,0,0]  ->  [0,2,0,0]
+   *  [0,0,1,0]      [0,0,2,0]
+   *  [0,0,0,1]]     [0,0,0,1]]
+   */
+  ref.submat(0, 0, 2, 2) *= 2;
+  X.submat(0, 0, 2, 2) *= 2;
+
+  for (uword i = 0; i < 4; i++)
+    {
+    for (uword j = 0; j < 4; j++)
+      {
+      REQUIRE( (double) ref(i, j) == Approx((double) X(i, j)) );
+      }
+    }
+
+  /*
+   * [[2,0,0,0]     [[2,0,0,0]
+   *  [0,2,0,0]  ->  [0,1,0,0]
+   *  [0,0,2,0]      [0,0,1,0]
+   *  [0,0,0,1]]     [0,0,0,.5]]
+   */
+  ref.submat(1, 1, 3, 3) /= 2;
+  X.submat(1, 1, 3, 3) /= 2;
+
+  for (uword i = 0; i < 4; i++)
+    {
+    for (uword j = 0; j < 4; j++)
+      {
+      REQUIRE( (double) ref(i, j) == Approx((double) X(i, j)) );
+      }
+    }
+
+  span s(1, 2);
+  ref.submat(s, s) += 10;
+  X.submat(s, s) += 10;
+
+  for (uword i = 0; i < 4; i++)
+    {
+    for (uword j = 0; j < 4; j++)
+      {
+      REQUIRE( (double) ref(i, j) == Approx((double) X(i, j)) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("sp_subview_const_test")
+  {
+  Mat<double> ref(4, 4);
+  ref.eye(4, 4);
+
+  SpMat<double> X(4, 4);
+  X.eye(4, 4);
+
+  const SpSubview<double> subX = X.submat(span(0, 2), span::all);
+/*
+  X.print("x");
+  for (size_t i = 0; i < 3; ++i)
+  {
+    for (size_t j = 0; j < 4; ++j)
+    {
+      printf("%f ", subX(i, j));
+    }
+    printf("\n");
+  }
+*/
+  }
+
+
+
+TEST_CASE("sp_subview_multiplication_test")
+  {
+  // Ensure matrix multiplication with subviews works correctly.
+  SpMat<double> a(2, 5);
+  SpMat<double> b(5, 2);
+
+  a(1, 3) = 1;
+  a(0, 0) = 2;
+  a(1, 2) = 1.5;
+
+  b(4, 1) = 3;
+  b(3, 0) = 2;
+  b(1, 0) = 1;
+  b(0, 0) = 0.6;
+
+  b *= a;
+
+  REQUIRE( b.n_cols == 5 );
+  REQUIRE( b.n_rows == 5 );
+  REQUIRE( b.n_elem == 25 );
+  REQUIRE( b.n_nonzero == 5 );
+
+  REQUIRE( (double) b(0, 0) == Approx(1.2) );
+  REQUIRE( (double) b(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(0, 2) == Approx(1e-5) );
+  REQUIRE( (double) b(0, 3) == Approx(1e-5) );
+  REQUIRE( (double) b(0, 4) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 0) == Approx(2.0) );
+  REQUIRE( (double) b(1, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 2) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 3) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 4) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 0) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 2) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 3) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 4) == Approx(1e-5) );
+  REQUIRE( (double) b(3, 0) == Approx(4.0) );
+  REQUIRE( (double) b(3, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(3, 2) == Approx(1e-5) );
+  REQUIRE( (double) b(3, 3) == Approx(1e-5) );
+  REQUIRE( (double) b(3, 4) == Approx(1e-5) );
+  REQUIRE( (double) b(4, 0) == Approx(1e-5) );
+  REQUIRE( (double) b(4, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(4, 2) == Approx(4.5) );
+  REQUIRE( (double) b(4, 3) == Approx(3.0) );
+  REQUIRE( (double) b(4, 4) == Approx(1e-5) );
+  }
+
+
+
+TEST_CASE("sp_subview_multiplication_test_2")
+  {
+  // Ensure matrix multiplication with subviews works correctly.
+  SpMat<double> a(4, 5);
+  SpMat<double> b(5, 2);
+
+  a(2, 3) = 1;
+  a(3, 1) = 1.4;
+  a(0, 0) = 2;
+  a(1, 0) = 2;
+  a(2, 2) = 1.5;
+
+  b(4, 1) = 3;
+  b(3, 0) = 2;
+  b(1, 0) = 1;
+  b(0, 0) = 0.6;
+
+  b *= a.rows(1, 2);
+
+  REQUIRE( b.n_cols == 5 );
+  REQUIRE( b.n_rows == 5 );
+  REQUIRE( b.n_elem == 25 );
+  REQUIRE( b.n_nonzero == 5 );
+
+  REQUIRE( (double) b(0, 0) == Approx(1.2) );
+  REQUIRE( (double) b(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(0, 2) == Approx(1e-5) );
+  REQUIRE( (double) b(0, 3) == Approx(1e-5) );
+  REQUIRE( (double) b(0, 4) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 0) == Approx(2.0) );
+  REQUIRE( (double) b(1, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 2) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 3) == Approx(1e-5) );
+  REQUIRE( (double) b(1, 4) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 0) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 2) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 3) == Approx(1e-5) );
+  REQUIRE( (double) b(2, 4) == Approx(1e-5) );
+  REQUIRE( (double) b(3, 0) == Approx(4.0) );
+  REQUIRE( (double) b(3, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(3, 2) == Approx(1e-5) );
+  REQUIRE( (double) b(3, 3) == Approx(1e-5) );
+  REQUIRE( (double) b(3, 4) == Approx(1e-5) );
+  REQUIRE( (double) b(4, 0) == Approx(1e-5) );
+  REQUIRE( (double) b(4, 1) == Approx(1e-5) );
+  REQUIRE( (double) b(4, 2) == Approx(4.5) );
+  REQUIRE( (double) b(4, 3) == Approx(3.0) );
+  REQUIRE( (double) b(4, 4) == Approx(1e-5) );
+  }
+
+
+
+TEST_CASE("sp_subview_unary_operators_test")
+  {
+  SpMat<int> a(3, 3);
+  SpMat<int> b(5, 5);
+
+  a(0, 0) = 1;
+  a(1, 2) = 4;
+  a(2, 2) = 5;
+
+  b(2, 3) = 1;
+  b(3, 2) = 2;
+  b(3, 4) = -4;
+  b(4, 4) = 5;
+
+  SpMat<int> c = a + b.submat(2, 2, 4, 4);
+
+  REQUIRE( c.n_nonzero == 4 );
+
+  REQUIRE( (double) c(0, 0) == 1 );
+  REQUIRE( (double) c(1, 0) == 2 );
+  REQUIRE( (double) c(2, 0) == 0 );
+  REQUIRE( (double) c(0, 1) == 1 );
+  REQUIRE( (double) c(1, 1) == 0 );
+  REQUIRE( (double) c(2, 1) == 0 );
+  REQUIRE( (double) c(0, 2) == 0 );
+  REQUIRE( (double) c(1, 2) == 0 );
+  REQUIRE( (double) c(2, 2) == 10 );
+
+  c = a - b.submat(2, 2, 4, 4);
+
+  REQUIRE( c.n_nonzero == 4 );
+
+  REQUIRE( (double) c(0, 0) == 1 );
+  REQUIRE( (double) c(1, 0) == -2 );
+  REQUIRE( (double) c(2, 0) == 0 );
+  REQUIRE( (double) c(0, 1) == -1 );
+  REQUIRE( (double) c(1, 1) == 0 );
+  REQUIRE( (double) c(2, 1) == 0 );
+  REQUIRE( (double) c(0, 2) == 0 );
+  REQUIRE( (double) c(1, 2) == 8 );
+  REQUIRE( (double) c(2, 2) == 0 );
+
+  c = a % b.submat(2, 2, 4, 4);
+
+  REQUIRE( c.n_nonzero == 2 );
+
+  REQUIRE( (double) c(0, 0) == 0 );
+  REQUIRE( (double) c(1, 0) == 0 );
+  REQUIRE( (double) c(2, 0) == 0 );
+  REQUIRE( (double) c(0, 1) == 0 );
+  REQUIRE( (double) c(1, 1) == 0 );
+  REQUIRE( (double) c(2, 1) == 0 );
+  REQUIRE( (double) c(0, 2) == 0 );
+  REQUIRE( (double) c(1, 2) == -16 );
+  REQUIRE( (double) c(2, 2) == 25 );
+
+  a(0, 0) = 4;
+  b(2, 2) = 2;
+/*
+  c = a / b.submat(2, 2, 4, 4);
+
+  REQUIRE( c.n_nonzero == 3 );
+
+  REQUIRE( (double) c(0, 0) == 2 );
+  REQUIRE( (double) c(1, 0) == 0 );
+  REQUIRE( (double) c(2, 0) == 0 );
+  REQUIRE( (double) c(0, 1) == 0 );
+  REQUIRE( (double) c(1, 1) == 0 );
+  REQUIRE( (double) c(2, 1) == 0 );
+  REQUIRE( (double) c(0, 2) == 0 );
+  REQUIRE( (double) c(1, 2) == -1 );
+  REQUIRE( (double) c(2, 2) == 1 );
+*/
+  }
+
+
+TEST_CASE("sp_subview_mat_operator_tests")
+  {
+  SpMat<double> a(6, 10);
+  a(2, 2) = 2.0;
+  a(3, 4) = 3.5;
+  a(4, 3) = -2.0;
+  a(4, 4) = 4.5;
+  a(5, 1) = 3.2;
+  a(0, 1) = 1.3;
+  a(1, 1) = -4.0;
+  a(5, 3) = 5.3;
+
+  mat b(3, 3);
+  b.fill(2.0);
+
+  mat c(b);
+
+  c += a.submat(2, 2, 4, 4);
+
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.5) );
+  REQUIRE( (double) c(2, 2) == Approx(6.5) );
+
+  c = b + a.submat(2, 2, 4, 4);
+
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.5) );
+  REQUIRE( (double) c(2, 2) == Approx(6.5) );
+
+  c = b;
+  c -= a.submat(2, 2, 4, 4);
+
+  REQUIRE( (double) c(0, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(-1.5) );
+  REQUIRE( (double) c(2, 2) == Approx(-2.5) );
+
+  c = b - a.submat(2, 2, 4, 4);
+
+  REQUIRE( (double) c(0, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(-1.5) );
+  REQUIRE( (double) c(2, 2) == Approx(-2.5) );
+
+  c = b;
+  c *= a.submat(2, 2, 4, 4);
+
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(4.0) );
+  REQUIRE( (double) c(2, 0) == Approx(4.0) );
+  REQUIRE( (double) c(0, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(1, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(16.0) );
+  REQUIRE( (double) c(1, 2) == Approx(16.0) );
+  REQUIRE( (double) c(2, 2) == Approx(16.0) );
+
+  mat e = b * a.submat(2, 2, 4, 4);
+
+  REQUIRE( (double) e(0, 0) == Approx(4.0) );
+  REQUIRE( (double) e(1, 0) == Approx(4.0) );
+  REQUIRE( (double) e(2, 0) == Approx(4.0) );
+  REQUIRE( (double) e(0, 1) == Approx(-4.0) );
+  REQUIRE( (double) e(1, 1) == Approx(-4.0) );
+  REQUIRE( (double) e(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) e(0, 2) == Approx(16.0) );
+  REQUIRE( (double) e(1, 2) == Approx(16.0) );
+  REQUIRE( (double) e(2, 2) == Approx(16.0) );
+
+  c = b;
+  c %= a.submat(2, 2, 4, 4);
+
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(2, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(0, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 2) == Approx(7.0) );
+  REQUIRE( (double) c(2, 2) == Approx(9.0) );
+
+  SpMat<double> d = b % a.submat(2, 2, 4, 4);
+
+  REQUIRE( d.n_nonzero == 4 );
+  REQUIRE( (double) d(0, 0) == Approx(4.0) );
+  REQUIRE( (double) d(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) d(1, 2) == Approx(7.0) );
+  REQUIRE( (double) d(2, 2) == Approx(9.0) );
+
+  c = b;
+  c /= a.submat(2, 2, 4, 4);
+
+  REQUIRE( c(0, 0) == Approx(1.0) );
+  REQUIRE( std::isinf(c(1, 0)) );
+  REQUIRE( std::isinf(c(2, 0)) );
+  REQUIRE( std::isinf(c(0, 1)) );
+  REQUIRE( std::isinf(c(1, 1)) );
+  REQUIRE( c(2, 1) == Approx(-1.0) );
+  REQUIRE( std::isinf(c(0, 2)) );
+  REQUIRE( c(1, 2) == Approx(2.0 / 3.5) );
+  REQUIRE( c(2, 2) == Approx(2.0 / 4.5) );
+  }
+
+
+
+TEST_CASE("sp_subview_base_test")
+  {
+  SpMat<double> a(6, 10);
+  a(2, 2) = 2.0;
+  a(3, 4) = 3.5;
+  a(4, 3) = -2.0;
+  a(4, 4) = 4.5;
+  a(5, 1) = 3.2;
+  a(0, 1) = 1.3;
+  a(1, 1) = -4.0;
+  a(5, 3) = 5.3;
+
+  mat b(3, 3);
+  b.fill(2.0);
+
+  SpMat<double> c = a;
+  c.submat(2, 2, 4, 4) = b;
+
+  REQUIRE( c.n_nonzero == 13 );
+  REQUIRE( (double) c(2, 2) == Approx(2.0) );
+  REQUIRE( (double) c(3, 2) == Approx(2.0) );
+  REQUIRE( (double) c(4, 2) == Approx(2.0) );
+  REQUIRE( (double) c(2, 3) == Approx(2.0) );
+  REQUIRE( (double) c(3, 3) == Approx(2.0) );
+  REQUIRE( (double) c(4, 3) == Approx(2.0) );
+  REQUIRE( (double) c(2, 4) == Approx(2.0) );
+  REQUIRE( (double) c(3, 4) == Approx(2.0) );
+  REQUIRE( (double) c(4, 4) == Approx(2.0) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) += b;
+
+  REQUIRE( c.n_nonzero == 12 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(3, 2) == Approx(2.0) );
+  REQUIRE( (double) c(4, 2) == Approx(2.0) );
+  REQUIRE( (double) c(2, 3) == Approx(2.0) );
+  REQUIRE( (double) c(3, 3) == Approx(2.0) );
+  REQUIRE( (double) c(4, 3) == Approx(1e-5) );
+  REQUIRE( (double) c(2, 4) == Approx(2.0) );
+  REQUIRE( (double) c(3, 4) == Approx(5.5) );
+  REQUIRE( (double) c(4, 4) == Approx(6.5) );
+
+  Mat<double> d = a.submat(2, 2, 4, 4) + b;
+  c = a.submat(2, 2, 4, 4) + b;
+
+  REQUIRE( c.n_nonzero == 8 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(1e-5) );
+  REQUIRE( (double) c(0, 2) == Approx(2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.5) );
+  REQUIRE( (double) c(2, 2) == Approx(6.5) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) -= b;
+
+  REQUIRE( c.n_nonzero == 12 );
+  REQUIRE( (double) c(2, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(3, 2) == Approx(-2.0) );
+  REQUIRE( (double) c(4, 2) == Approx(-2.0) );
+  REQUIRE( (double) c(2, 3) == Approx(-2.0) );
+  REQUIRE( (double) c(3, 3) == Approx(-2.0) );
+  REQUIRE( (double) c(4, 3) == Approx(-4.0) );
+  REQUIRE( (double) c(2, 4) == Approx(-2.0) );
+  REQUIRE( (double) c(3, 4) == Approx(1.5) );
+  REQUIRE( (double) c(4, 4) == Approx(2.5) );
+
+  c = a.submat(2, 2, 4, 4) - b;
+
+  REQUIRE( c.n_nonzero == 8 );
+  REQUIRE( (double) c(0, 0) == Approx(1e-5) );
+  REQUIRE( (double) c(1, 0) == Approx(-2.0) );
+  REQUIRE( (double) c(2, 0) == Approx(-2.0) );
+  REQUIRE( (double) c(0, 1) == Approx(-2.0) );
+  REQUIRE( (double) c(1, 1) == Approx(-2.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(0, 2) == Approx(-2.0) );
+  REQUIRE( (double) c(1, 2) == Approx(1.5) );
+  REQUIRE( (double) c(2, 2) == Approx(2.5) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) *= b;
+
+  REQUIRE( c.n_nonzero == 13 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(3, 2) == Approx(7.0) );
+  REQUIRE( (double) c(4, 2) == Approx(5.0) );
+  REQUIRE( (double) c(2, 3) == Approx(4.0) );
+  REQUIRE( (double) c(3, 3) == Approx(7.0) );
+  REQUIRE( (double) c(4, 3) == Approx(5.0) );
+  REQUIRE( (double) c(2, 4) == Approx(4.0) );
+  REQUIRE( (double) c(3, 4) == Approx(7.0) );
+  REQUIRE( (double) c(4, 4) == Approx(5.0) );
+
+  c = a.submat(2, 2, 4, 4) * b;
+
+  REQUIRE( c.n_nonzero == 9 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 0) == Approx(7.0) );
+  REQUIRE( (double) c(2, 0) == Approx(5.0) );
+  REQUIRE( (double) c(0, 1) == Approx(4.0) );
+  REQUIRE( (double) c(1, 1) == Approx(7.0) );
+  REQUIRE( (double) c(2, 1) == Approx(5.0) );
+  REQUIRE( (double) c(0, 2) == Approx(4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(7.0) );
+  REQUIRE( (double) c(2, 2) == Approx(5.0) );
+
+  c = a.submat(2, 2, 4, 4) % b;
+
+  REQUIRE( c.n_nonzero == 4 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(7.0) );
+  REQUIRE( (double) c(2, 2) == Approx(9.0) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) %= b;
+
+  REQUIRE( c.n_nonzero == 8 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(4, 3) == Approx(-4.0) );
+  REQUIRE( (double) c(3, 4) == Approx(7.0) );
+  REQUIRE( (double) c(4, 4) == Approx(9.0) );
+
+  c = a.submat(2, 2, 4, 4) / b;
+
+  REQUIRE( c.n_nonzero == 4 );
+  REQUIRE( (double) c(0, 0) == Approx(1.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-1.0) );
+  REQUIRE( (double) c(1, 2) == Approx(3.5 / 2.0) );
+  REQUIRE( (double) c(2, 2) == Approx(4.5 / 2.0) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) /= b;
+
+  REQUIRE( c.n_nonzero == 8 );
+  REQUIRE( (double) c(2, 2) == Approx(1.0) );
+  REQUIRE( (double) c(4, 3) == Approx(-1.0) );
+  REQUIRE( (double) c(3, 4) == Approx(3.5 / 2.0) );
+  REQUIRE( (double) c(4, 4) == Approx(4.5 / 2.0) );
+  }
+
+
+
+TEST_CASE("sp_subview_sp_mat_test")
+  {
+  SpMat<double> a(6, 10);
+  a(2, 2) = 2.0;
+  a(3, 4) = 3.5;
+  a(4, 3) = -2.0;
+  a(4, 4) = 4.5;
+  a(5, 1) = 3.2;
+  a(0, 1) = 1.3;
+  a(1, 1) = -4.0;
+  a(5, 3) = 5.3;
+
+  SpMat<double> b(3, 3);
+  b(0, 0) = 2.0;
+  b(1, 2) = 1.5;
+  b(2, 1) = 2.0;
+
+  SpMat<double> c = a;
+  c.submat(2, 2, 4, 4) = b;
+
+  REQUIRE( c.n_nonzero == 7 );
+  REQUIRE( (double) c(2, 2) == Approx(2.0) );
+  REQUIRE( (double) c(3, 4) == Approx(1.5) );
+  REQUIRE( (double) c(4, 3) == Approx(2.0) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) += b;
+
+  REQUIRE( c.n_nonzero == 7 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(3, 4) == Approx(5.0) );
+  REQUIRE( (double) c(4, 4) == Approx(4.5) );
+
+  c = a.submat(2, 2, 4, 4) + b;
+
+  REQUIRE( c.n_nonzero == 3 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.0) );
+  REQUIRE( (double) c(2, 2) == Approx(4.5) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) -= b;
+
+  REQUIRE( c.n_nonzero == 7 );
+  REQUIRE( (double) c(2, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(3, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(4, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(2, 3) == Approx(1e-5) );
+  REQUIRE( (double) c(3, 3) == Approx(1e-5) );
+  REQUIRE( (double) c(4, 3) == Approx(-4.0) );
+  REQUIRE( (double) c(2, 4) == Approx(1e-5) );
+  REQUIRE( (double) c(3, 4) == Approx(2.0) );
+  REQUIRE( (double) c(4, 4) == Approx(4.5) );
+
+  c = a.submat(2, 2, 4, 4) - b;
+
+  REQUIRE( c.n_nonzero == 3 );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(2.0) );
+  REQUIRE( (double) c(2, 2) == Approx(4.5) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) *= b;
+
+  REQUIRE( c.n_nonzero == 8 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(3, 3) == Approx(7.0) );
+  REQUIRE( (double) c(4, 3) == Approx(9.0) );
+  REQUIRE( (double) c(4, 4) == Approx(-3.0) );
+
+  c = a.submat(2, 2, 4, 4) * b;
+
+  REQUIRE( c.n_nonzero == 4 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 1) == Approx(7.0) );
+  REQUIRE( (double) c(2, 1) == Approx(9.0) );
+  REQUIRE( (double) c(2, 2) == Approx(-3.0) );
+  c = a.submat(2, 2, 4, 4) % b;
+
+  REQUIRE( c.n_nonzero == 3 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.25) );
+  REQUIRE( (double) c(2, 2) == Approx(1e-5) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) %= b;
+
+  REQUIRE( c.n_nonzero == 7 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(4, 3) == Approx(-4.0) );
+  REQUIRE( (double) c(3, 4) == Approx(5.25) );
+  REQUIRE( (double) c(4, 4) == Approx(1e-5) );
+
+//  c = a.submat(2, 2, 4, 4) / b;
+
+//  REQUIRE( c.n_nonzero == 9 );
+//  REQUIRE( (double) c(0, 0) == Approx(1.0) );
+//  REQUIRE( (double) c(1, 0) != (double) c(1, 0) );
+//  REQUIRE( (double) c(2, 0) != (double) c(2, 0) );
+//  REQUIRE( (double) c(0, 1) != (double) c(0, 1) );
+//  REQUIRE( (double) c(1, 1) != (double) c(1, 1) );
+//  REQUIRE( (double) c(2, 1) == Approx(-1.0) );
+//  REQUIRE( (double) c(0, 2) != (double) c(0, 2) );
+//  REQUIRE( (double) c(1, 2) == Approx((3.5 / 1.5)) );
+//  REQUIRE( std::isinf((double) c(2, 2)) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) /= b;
+
+  REQUIRE( c.n_nonzero == 13 );
+  REQUIRE( (double) c(2, 2) == Approx(1.0) );
+  REQUIRE( (double) c(3, 2) != (double) c(3, 2));
+  REQUIRE( (double) c(4, 2) != (double) c(4, 2));
+  REQUIRE( (double) c(2, 3) != (double) c(2, 3));
+  REQUIRE( (double) c(3, 3) != (double) c(3, 3));
+  REQUIRE( (double) c(4, 3) == Approx(-1.0) );
+  REQUIRE( (double) c(2, 4) != (double) c(2, 4) );
+  REQUIRE( (double) c(3, 4) == Approx((3.5 / 1.5)) );
+  REQUIRE( std::isinf((double) c(4, 4)) );
+  }
+
+
+
+TEST_CASE("sp_subview_sp_subview_tests")
+  {
+  SpMat<double> a(6, 10);
+  a(2, 2) = 2.0;
+  a(3, 4) = 3.5;
+  a(4, 3) = -2.0;
+  a(4, 4) = 4.5;
+  a(5, 1) = 3.2;
+  a(0, 1) = 1.3;
+  a(1, 1) = -4.0;
+  a(5, 3) = 5.3;
+
+  SpMat<double> b(5, 5);
+  b(0, 0) = 1.0;
+  b(0, 1) = 1.0;
+  b(0, 2) = 1.0;
+  b(0, 3) = 1.0;
+  b(0, 4) = 1.0;
+  b(1, 0) = 1.0;
+  b(2, 0) = 1.0;
+  b(3, 0) = 1.0;
+  b(4, 0) = 1.0;
+  b(4, 1) = 1.0;
+  b(4, 2) = 1.0;
+  b(4, 3) = 1.0;
+  b(4, 4) = 1.0;
+  b(3, 4) = 1.0;
+  b(2, 4) = 1.0;
+  b(1, 4) = 1.0;
+  b(1, 1) = 2.0;
+  b(2, 3) = 1.5;
+  b(3, 2) = 2.0;
+
+  SpMat<double> c = a;
+  c.submat(2, 2, 4, 4) = b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 7 );
+  REQUIRE( (double) c(2, 2) == Approx(2.0) );
+  REQUIRE( (double) c(3, 4) == Approx(1.5) );
+  REQUIRE( (double) c(4, 3) == Approx(2.0) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) += b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 7 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(3, 4) == Approx(5.0) );
+  REQUIRE( (double) c(4, 4) == Approx(4.5) );
+
+  c = a.submat(2, 2, 4, 4) + b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 3 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.0) );
+  REQUIRE( (double) c(2, 2) == Approx(4.5) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) -= b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 7 );
+  REQUIRE( (double) c(2, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(3, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(4, 2) == Approx(1e-5) );
+  REQUIRE( (double) c(2, 3) == Approx(1e-5) );
+  REQUIRE( (double) c(3, 3) == Approx(1e-5) );
+  REQUIRE( (double) c(4, 3) == Approx(-4.0) );
+  REQUIRE( (double) c(2, 4) == Approx(1e-5) );
+  REQUIRE( (double) c(3, 4) == Approx(2.0) );
+  REQUIRE( (double) c(4, 4) == Approx(4.5) );
+
+  c = a.submat(2, 2, 4, 4) - b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 3 );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(2.0) );
+  REQUIRE( (double) c(2, 2) == Approx(4.5) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) *= b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 8 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(3, 3) == Approx(7.0) );
+  REQUIRE( (double) c(4, 3) == Approx(9.0) );
+  REQUIRE( (double) c(4, 4) == Approx(-3.0) );
+  c = a.submat(2, 2, 4, 4) * b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 4 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(1, 1) == Approx(7.0) );
+  REQUIRE( (double) c(2, 1) == Approx(9.0) );
+  REQUIRE( (double) c(2, 2) == Approx(-3.0) );
+
+  c = a.submat(2, 2, 4, 4) % b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 3 );
+  REQUIRE( (double) c(0, 0) == Approx(4.0) );
+  REQUIRE( (double) c(2, 1) == Approx(-4.0) );
+  REQUIRE( (double) c(1, 2) == Approx(5.25) );
+  REQUIRE( (double) c(2, 2) == Approx(1e-5) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) %= b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 7 );
+  REQUIRE( (double) c(2, 2) == Approx(4.0) );
+  REQUIRE( (double) c(4, 3) == Approx(-4.0) );
+  REQUIRE( (double) c(3, 4) == Approx(5.25) );
+  REQUIRE( (double) c(4, 4) == Approx(1e-5) );
+
+//  c = a.submat(2, 2, 4, 4) / b.submat(1, 1, 3, 3);
+
+//  REQUIRE( c.n_nonzero == 9 );
+//  REQUIRE( (double) c(0, 0) == Approx(1.0) );
+//  REQUIRE( (double) c(1, 0) != (double) c(1, 0) );
+//  REQUIRE( (double) c(2, 0) != (double) c(2, 0) );
+//  REQUIRE( (double) c(0, 1) != (double) c(0, 1) );
+//  REQUIRE( (double) c(1, 1) != (double) c(1, 1) );
+//  REQUIRE( (double) c(2, 1) == Approx(-1.0) );
+//  REQUIRE( (double) c(0, 2) != (double) c(0, 2) );
+//  REQUIRE( (double) c(1, 2) == Approx((3.5 / 1.5)) );
+//  REQUIRE( std::isinf((double) c(2, 2)) );
+
+  c = a;
+  c.submat(2, 2, 4, 4) /= b.submat(1, 1, 3, 3);
+
+  REQUIRE( c.n_nonzero == 13 );
+  REQUIRE( (double) c(2, 2) == Approx(1.0) );
+  REQUIRE( (double) c(3, 2) != (double) c(3, 2) );
+  REQUIRE( (double) c(4, 2) != (double) c(4, 2) );
+  REQUIRE( (double) c(2, 3) != (double) c(2, 3) );
+  REQUIRE( (double) c(3, 3) != (double) c(3, 3) );
+  REQUIRE( (double) c(4, 3) == Approx(-1.0) );
+  REQUIRE( (double) c(2, 4) != (double) c(2, 4) );
+  REQUIRE( (double) c(3, 4) == Approx((3.5 / 1.5)) );
+  REQUIRE( std::isinf((double) c(4, 4)) );
+  }
+
+
+
+TEST_CASE("sp_subview_iterators_test")
+  {
+  SpMat<double> b(5, 5);
+  b(0, 0) = 1.0;
+  b(0, 1) = 1.0;
+  b(0, 2) = 1.0;
+  b(0, 3) = 1.0;
+  b(0, 4) = 1.0;
+  b(1, 0) = 1.0;
+  b(2, 0) = 1.0;
+  b(3, 0) = 1.0;
+  b(4, 0) = 1.0;
+  b(4, 1) = 1.0;
+  b(4, 2) = 1.0;
+  b(4, 3) = 1.0;
+  b(4, 4) = 1.0;
+  b(3, 4) = 1.0;
+  b(2, 4) = 1.0;
+  b(1, 4) = 1.0;
+  b(1, 1) = 2.0;
+  b(2, 3) = 1.5;
+  b(3, 2) = 2.0;
+
+  // [[1.0 1.0 1.0 1.0 1.0]
+  //  [1.0 2.0 0.0 0.0 1.0]
+  //  [1.0 0.0 0.0 1.5 1.0]
+  //  [1.0 0.0 2.0 0.0 1.0]
+  //  [1.0 1.0 1.0 1.0 1.0]]
+  SpSubview<double> s = b.submat(1, 1, 3, 3);
+
+  SpSubview<double>::iterator it = s.begin();
+
+  REQUIRE( it.pos() == 0 );
+  REQUIRE( it.skip_pos == 6 );
+  REQUIRE( it.row() == 0 );
+  REQUIRE( it.col() == 0 );
+  REQUIRE( (double) (*it) == Approx(2.0) );
+
+  ++it;
+
+  REQUIRE( it.pos() == 1 );
+  REQUIRE( it.skip_pos == 8 );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 1 );
+  REQUIRE( (double) (*it) == Approx(2.0) );
+
+  ++it;
+
+  REQUIRE( it.pos() == 2 );
+  REQUIRE( it.skip_pos == 10 );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 2 );
+  REQUIRE( (double) (*it) == Approx(1.5) );
+
+  *it = 4.3;
+
+  REQUIRE( (double) (*it) == Approx(4.3) );
+
+  ++it;
+
+  REQUIRE( it.pos() == s.n_nonzero );
+
+  --it;
+
+  REQUIRE( it.pos() == 2 );
+  REQUIRE( it.skip_pos == 10 );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 2 );
+  REQUIRE( (double) (*it) == Approx(4.3) );
+
+  --it;
+
+  REQUIRE( it.pos() == 1 );
+  REQUIRE( it.skip_pos == 8 );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 1 );
+  REQUIRE( (double) (*it) == Approx(2.0) );
+
+  --it;
+
+  REQUIRE( it.pos() == 0 );
+  REQUIRE( it.skip_pos == 6 );
+  REQUIRE( it.row() == 0 );
+  REQUIRE( it.col() == 0 );
+  REQUIRE( (double) (*it) == Approx(2.0) );
+
+  SpMat<double> c(5, 5);
+  c(1, 1) = 2.0;
+  c(2, 3) = 1.5;
+  c(3, 2) = 2.0;
+
+  SpSubview<double> ss = c.submat(1, 1, 3, 3);
+
+  SpSubview<double>::iterator sit = ss.begin();
+
+  REQUIRE( sit.pos() == 0 );
+  REQUIRE( sit.skip_pos == 0 );
+  REQUIRE( sit.row() == 0 );
+  REQUIRE( sit.col() == 0 );
+  REQUIRE( (double) (*sit) == Approx(2.0) );
+
+  ++sit;
+
+  REQUIRE( sit.pos() == 1 );
+  REQUIRE( sit.skip_pos == 0 );
+  REQUIRE( sit.row() == 2 );
+  REQUIRE( sit.col() == 1 );
+  REQUIRE( (double) (*sit) == Approx(2.0) );
+
+  ++sit;
+
+  REQUIRE( sit.pos() == 2 );
+  REQUIRE( sit.skip_pos == 0 );
+  REQUIRE( sit.row() == 1 );
+  REQUIRE( sit.col() == 2 );
+  REQUIRE( (double) (*sit) == Approx(1.5) );
+
+  *sit = 4.2;
+
+  REQUIRE( (double) (*sit) == Approx(4.2) );
+
+  ++sit;
+
+  REQUIRE( sit.pos() == ss.n_nonzero );
+
+  --sit;
+
+  REQUIRE( sit.pos() == 2 );
+  REQUIRE( sit.skip_pos == 0 );
+  REQUIRE( sit.row() == 1 );
+  REQUIRE( sit.col() == 2 );
+  REQUIRE( (double) (*sit) == Approx(4.2) );
+
+  --sit;
+
+  REQUIRE( sit.pos() == 1 );
+  REQUIRE( sit.skip_pos == 0 );
+  REQUIRE( sit.row() == 2 );
+  REQUIRE( sit.col() == 1 );
+  REQUIRE( (double) (*sit) == Approx(2.0) );
+
+  --sit;
+
+  REQUIRE( sit.pos() == 0 );
+  REQUIRE( sit.skip_pos == 0 );
+  REQUIRE( sit.row() == 0 );
+  REQUIRE( sit.col() == 0 );
+  REQUIRE( (double) (*sit) == Approx(2.0) );
+  }
+
+
+TEST_CASE("sp_subview_row_iterators_test")
+  {
+  SpMat<double> b(5, 5);
+  b(0, 0) = 1.0;
+  b(0, 1) = 1.0;
+  b(0, 2) = 1.0;
+  b(0, 3) = 1.0;
+  b(0, 4) = 1.0;
+  b(1, 0) = 1.0;
+  b(2, 0) = 1.0;
+  b(3, 0) = 1.0;
+  b(4, 0) = 1.0;
+  b(4, 1) = 1.0;
+  b(4, 2) = 1.0;
+  b(4, 3) = 1.0;
+  b(4, 4) = 1.0;
+  b(3, 4) = 1.0;
+  b(2, 4) = 1.0;
+  b(1, 4) = 1.0;
+  b(1, 1) = 2.0;
+  b(2, 3) = 1.5;
+  b(3, 2) = 2.0;
+
+  // [[1.0 1.0 1.0 1.0 1.0]
+  //  [1.0 2.0 0.0 0.0 1.0]
+  //  [1.0 0.0 0.0 1.5 1.0]
+  //  [1.0 0.0 2.0 0.0 1.0]
+  //  [1.0 1.0 1.0 1.0 1.0]]
+  SpSubview<double> s = b.submat(1, 1, 3, 3);
+
+  SpSubview<double>::row_iterator it = s.begin_row();
+
+  REQUIRE( it.pos() == 0 );
+  REQUIRE( it.row() == 0 );
+  REQUIRE( it.col() == 0 );
+  REQUIRE( it.actual_pos == 6 );
+  REQUIRE( (double) (*it) == Approx(2.0) );
+
+  ++it;
+
+  REQUIRE( it.pos() == 1 );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 2 );
+  REQUIRE( it.actual_pos == 12 );
+  REQUIRE( (double) (*it) == Approx(1.5) );
+
+  ++it;
+
+  REQUIRE( it.pos() == 2 );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 1 );
+  REQUIRE( it.actual_pos == 9 );
+  REQUIRE( (double) (*it) == Approx(2.0) );
+
+  ++it;
+
+  REQUIRE( it.pos() == s.n_nonzero );
+
+  --it;
+
+  REQUIRE( it.pos() == 2 );
+  REQUIRE( it.row() == 2 );
+  REQUIRE( it.col() == 1 );
+  REQUIRE( it.actual_pos == 9 );
+  REQUIRE( (double) (*it) == Approx(2.0) );
+
+  (*it) = 4.0;
+
+  REQUIRE( (double) (*it) == Approx(4.0) );
+
+  --it;
+
+  REQUIRE( it.pos() == 1 );
+  REQUIRE( it.row() == 1 );
+  REQUIRE( it.col() == 2 );
+  REQUIRE( it.actual_pos == 12 );
+  REQUIRE( (double) (*it) == Approx(1.5) );
+
+  --it;
+
+  REQUIRE( it.pos() == 0 );
+  REQUIRE( it.row() == 0 );
+  REQUIRE( it.col() == 0 );
+  REQUIRE( it.actual_pos == 6 );
+  REQUIRE( (double) (*it) == Approx(2.0) );
+
+  // now a different matrix
+  SpMat<double> c(5, 5);
+  c(1, 1) = 2.0;
+  c(2, 3) = 1.5;
+  c(3, 2) = 2.0;
+
+  SpSubview<double> ss = c.submat(0, 0, 3, 3);
+
+  SpSubview<double>::row_iterator sit = ss.begin_row();
+
+  REQUIRE( sit.pos() == 0 );
+  REQUIRE( sit.row() == 1 );
+  REQUIRE( sit.col() == 1 );
+  REQUIRE( (double) (*sit) == Approx(2.0) );
+
+  ++sit;
+
+  REQUIRE( sit.pos() == 1 );
+  REQUIRE( sit.row() == 2 );
+  REQUIRE( sit.col() == 3 );
+  REQUIRE( (double) (*sit) == Approx(1.5) );
+
+  ++sit;
+
+  REQUIRE( sit.pos() == 2 );
+  REQUIRE( sit.row() == 3 );
+  REQUIRE( sit.col() == 2 );
+  REQUIRE( (double) (*sit) == Approx(2.0) );
+
+  ++sit;
+
+  REQUIRE( sit.pos() == ss.n_nonzero );
+
+  --sit;
+
+  REQUIRE( sit.pos() == 2 );
+  REQUIRE( sit.row() == 3 );
+  REQUIRE( sit.col() == 2 );
+  REQUIRE( (double) (*sit) == Approx(2.0) );
+
+  (*sit) = 4.0;
+
+  REQUIRE( (double) (*sit) == Approx(4.0) );
+
+  --sit;
+
+  REQUIRE( sit.pos() == 1 );
+  REQUIRE( sit.row() == 2 );
+  REQUIRE( sit.col() == 3 );
+  REQUIRE( (double) (*sit) == Approx(1.5) );
+
+  --sit;
+
+  REQUIRE( sit.pos() == 0 );
+  REQUIRE( sit.row() == 1 );
+  REQUIRE( sit.col() == 1 );
+  REQUIRE( (double) (*sit) == Approx(2.0) );
+  }
+
+
+TEST_CASE("sp_subview_sp_base_add_subtract_modulo")
+  {
+  SpMat<double> m;
+  m.sprandu(100, 100, 0.1);
+
+  SpMat<double> n;
+  n.sprandu(50, 50, 0.1);
+
+  Mat<double> x(m);
+  Mat<double> y(n);
+
+  m.submat(25, 25, 74, 74) += n;
+  x.submat(25, 25, 74, 74) += y;
+
+  for (uword c = 0; c < 100; ++c)
+    {
+    for (uword r = 0; r < 100; ++r)
+      {
+      REQUIRE( (double) m(r, c) == Approx(x(r, c)) );
+      }
+    }
+
+  m.sprandu(100, 100, 0.1);
+  n.sprandu(50, 50, 0.1);
+
+  x = m;
+  y = n;
+
+  m.submat(25, 25, 74, 74) -= n;
+  x.submat(25, 25, 74, 74) -= y;
+
+  for (uword c = 0; c < 100; ++c)
+    {
+    for (uword r = 0; r < 100; ++r)
+      {
+      REQUIRE( (double) m(r, c) == Approx(x(r, c)) );
+      }
+    }
+
+  m.sprandu(100, 100, 0.1);
+  n.sprandu(50, 50, 0.1);
+
+  x = m;
+  y = n;
+
+  m.submat(25, 25, 74, 74) %= n;
+  x.submat(25, 25, 74, 74) %= y;
+
+  for( uword c = 0; c < 100; ++c)
+    {
+    for( uword r = 0; r < 100; ++r)
+      {
+      REQUIRE( (double) m(r, c) == Approx(x(r, c)) );
+      }
+    }
+  }
+
+TEST_CASE("sp_subview_hadamard")
+  {
+  SpMat<double> x;
+  x.sprandu(100, 100, 0.1);
+  Mat<double> d(x);
+
+  SpMat<double> y;
+  y.sprandu(200, 200, 0.1);
+  Mat<double> dy(y);
+
+  x %= y.submat(50, 50, 149, 149);
+  d %= dy.submat(50, 50, 149, 149);
+
+  for (uword c = 0; c < 100; ++c)
+    {
+    for (uword r = 0; r < 100; ++r)
+      {
+      REQUIRE( (double) x(r, c) == Approx(d(r, c)) );
+      }
+    }
+  }
+
+
+TEST_CASE("sp_subview_subviews_test")
+  {
+  SpMat<double> m(20, 20);
+  m.sprandu(20, 20, 0.3);
+
+  // Get a subview.
+  SpSubview<double> s = m.submat(1, 1, 10, 10); // 10x10
+  const SpSubview<double> c = m.submat(1, 1, 10, 10);
+
+  SpSubview<double> t = s.row(1);
+  const SpSubview<double> d = c.row(1);
+
+  REQUIRE( t.n_rows == 1 );
+  REQUIRE( t.n_cols == 10 );
+  REQUIRE( d.n_rows == 1 );
+  REQUIRE( d.n_cols == 10 );
+  REQUIRE( t.aux_row1 == 2 );
+  REQUIRE( t.aux_col1 == 1 );
+  for (uword i = 0; i < 10; ++i)
+    {
+    REQUIRE( (double) t[i] == (double) m(2, i + 1) );
+    REQUIRE( d[i] == (double) m(2, i + 1) );
+    }
+
+  SpSubview<double> t1 = s.col(2);
+  const SpSubview<double> d1 = c.col(2);
+
+  REQUIRE( t1.n_rows == 10 );
+  REQUIRE( t1.n_cols == 1 );
+  REQUIRE( d1.n_rows == 10 );
+  REQUIRE( d1.n_cols == 1 );
+  for (uword i = 0; i < 10; ++i)
+    {
+    REQUIRE( (double) t1[i] == (double) m(i + 1, 3) );
+    REQUIRE( d1[i] == (double) m(i + 1, 3) );
+    }
+
+  SpSubview<double> t2 = s.rows(3, 5);
+  const SpSubview<double> d2 = c.rows(3, 5);
+
+  REQUIRE( t2.n_rows == 3 );
+  REQUIRE( t2.n_cols == 10 );
+  REQUIRE( d2.n_rows == 3 );
+  REQUIRE( d2.n_cols == 10 );
+  for (uword j = 0; j < 3; ++j)
+    {
+    for (uword i = 0; i < 10; ++i)
+      {
+      REQUIRE( (double) t2(j, i) == (double) m(4 + j, i + 1) );
+      REQUIRE( d2(j, i) == (double) m(4 + j, i + 1) );
+      }
+    }
+
+  SpSubview<double> t3 = s.cols(4, 6);
+  const SpSubview<double> d3 = c.cols(4, 6);
+
+  REQUIRE( t3.n_rows == 10 );
+  REQUIRE( t3.n_cols == 3 );
+  REQUIRE( d3.n_rows == 10 );
+  REQUIRE( d3.n_cols == 3 );
+  for (uword j = 0; j < 3; ++j)
+    {
+    for (uword i = 0; i < 10; ++i)
+      {
+      REQUIRE( (double) t3(i, j) == (double) m(i + 1, 5 + j) );
+      REQUIRE( d3(i, j) == (double) m(i + 1, 5 + j) );
+      }
+    }
+
+  SpSubview<double> t4 = s.submat(1, 1, 6, 6);
+  const SpSubview<double> d4 = c.submat(1, 1, 6, 6);
+
+  REQUIRE( t4.n_rows == 6 );
+  REQUIRE( t4.n_cols == 6 );
+  REQUIRE( d4.n_rows == 6 );
+  REQUIRE( d4.n_cols == 6 );
+  for (uword j = 0; j < 6; ++j)
+    {
+    for (uword i = 0; i < 6; ++i)
+      {
+      REQUIRE( (double) t4(i, j) == (double) m(i + 2, 2 + j) );
+      REQUIRE( d4(i, j) == (double) m(i + 2, 2 + j) );
+      }
+    }
+
+  SpSubview<double> t5 = s.submat(span(2, 8), span(2, 5));
+  const SpSubview<double> d5 = c.submat(span(2, 8), span(2, 5));
+
+  REQUIRE( t5.n_rows == 7 );
+  REQUIRE( t5.n_cols == 4 );
+  REQUIRE( d5.n_rows == 7 );
+  REQUIRE( d5.n_cols == 4 );
+  for (uword j = 0; j < 4; ++j)
+    {
+    for (uword i = 0; i < 7; ++i)
+      {
+      REQUIRE( (double) t5(i, j) == (double) m(i + 3, 3 + j) );
+      REQUIRE( d5(i, j) == (double) m(i + 3, 3 + j) );
+      }
+    }
+
+  SpSubview<double> t6 = s(4, span(1, 5));
+  const SpSubview<double> d6 = c(4, span(1, 5));
+
+  REQUIRE( t6.n_rows == 1 );
+  REQUIRE( t6.n_cols == 5 );
+  REQUIRE( d6.n_rows == 1 );
+  REQUIRE( d6.n_cols == 5 );
+  for (uword i = 0; i < 5; ++i)
+    {
+    REQUIRE( (double) t6(i) == (double) m(5, 2 + i) );
+    REQUIRE( d6(i) == (double) m(5, 2 + i) );
+    }
+
+  SpSubview<double> t7 = s(span(1, 5), 4);
+  const SpSubview<double> d7 = c(span(1, 5), 4);
+
+  REQUIRE( t7.n_rows == 5 );
+  REQUIRE( t7.n_cols == 1 );
+  REQUIRE( d7.n_rows == 5 );
+  REQUIRE( d7.n_cols == 1 );
+  for (uword i = 0; i < 5; ++i)
+    {
+    REQUIRE( (double) t7(i) == (double) m(2 + i, 5) );
+    REQUIRE( d7(i) == (double) m(2 + i, 5) );
+    }
+
+  SpSubview<double> t8 = s(span(1, 9), span(7, 8));
+  const SpSubview<double> d8 = c(span(1, 9), span(7, 8));
+
+  REQUIRE( t8.n_rows == 9 );
+  REQUIRE( t8.n_cols == 2 );
+  REQUIRE( d8.n_rows == 9 );
+  REQUIRE( d8.n_cols == 2 );
+  for (uword j = 0; j < 2; ++j)
+    {
+    for (uword i = 0; i < 9; ++i)
+      {
+      REQUIRE( (double) t8(i, j) == (double) m(i + 2, 8 + j) );
+      REQUIRE( d8(i, j) == (double) m(i + 2, 8 + j) );
+      }
+    }
+  }
+
+
+
+TEST_CASE("sp_subview_assignment_sp_base")
+  {
+  mat d(51, 51);
+  d.fill(7.0); // Why not?
+  mat dd(d);
+
+  sp_mat e;
+  e.sprandu(50, 50, 0.3);
+  mat ed(e); // Dense copy.
+
+  d.submat(0, 0, 49, 49) = e;
+  dd.submat(0, 0, 49, 49) = ed;
+
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    REQUIRE( d[i] == Approx(dd[i]) );
+    }
+  }
+
+
+
+TEST_CASE("sp_subview_addition_sp_base")
+  {
+  mat d(51, 51);
+  d.fill(7.0); // Why not?
+  mat dd(d);
+
+  sp_mat e;
+  e.sprandu(50, 50, 0.3);
+  mat ed(e); // Dense copy.
+
+  d.submat(0, 0, 49, 49) += e;
+  dd.submat(0, 0, 49, 49) += ed;
+
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    REQUIRE( d[i] == Approx(dd[i]) );
+    }
+  }
+
+
+TEST_CASE("sp_subview_subtraction_sp_base")
+  {
+  mat d(51, 51);
+  d.fill(7.0); // Why not?
+  mat dd(d);
+
+  sp_mat e;
+  e.sprandu(50, 50, 0.3);
+  mat ed(e); // Dense copy.
+
+  d.submat(0, 0, 49, 49) -= e;
+  dd.submat(0, 0, 49, 49) -= ed;
+
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    REQUIRE( d[i] == Approx(dd[i]) );
+    }
+  }
+
+
+
+TEST_CASE("sp_subview_schur_sp_base")
+  {
+  mat d(51, 51);
+  d.fill(7.0); // Why not?
+  mat dd(d);
+
+  sp_mat e;
+  e.sprandu(50, 50, 0.3);
+  mat ed(e); // Dense copy.
+
+  d.submat(0, 0, 49, 49) %= e;
+  dd.submat(0, 0, 49, 49) %= ed;
+
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    REQUIRE( d[i] == Approx(dd[i]) );
+    }
+  }
+
+
+
+TEST_CASE("sp_subview_division_sp_base")
+  {
+  mat d(51, 51);
+  d.fill(7.0); // Why not?
+  mat dd(d);
+
+  sp_mat e;
+  e.sprandu(50, 50, 0.3);
+  mat ed(e); // Dense copy.
+
+  d.submat(0, 0, 49, 49) /= e;
+  dd.submat(0, 0, 49, 49) /= ed;
+
+  for (uword i = 0; i < d.n_elem; ++i)
+    {
+    if (std::isinf(d[i]))
+      REQUIRE( std::isinf(dd[i]) );
+    else
+      REQUIRE( d[i] == Approx(dd[i]) );
+    }
+  }


### PR DESCRIPTION
* Using `GNUInstallDirs` is the only portable way to
  change the libdir. The current solution is not a
  Kitware supported solution. Distributions' build
  systems are designed to use upstream hooks to
  specify the libdir/includedir etc using
  `GNUInstallDirs` variables. This also simplifies
  the build system by getting rid of all the
  custom variables.
* Install `.pc` files unconditionally, regardless of
  whether pkg-config was found. Whether `.pc` files
  are installed should solely depend on whether the
  library is being installed.