### PR TITLE
Improve numerical precision and fix out-of-bound error

### DIFF
--- a/include/armadillo_bits/newarp_GenEigsSolver_meat.hpp
+++ b/include/armadillo_bits/newarp_GenEigsSolver_meat.hpp
@@ -119,7 +119,7 @@ GenEigsSolver<eT, SelectionRule, OpType>::restart(uword k)
 
   for(uword i = k; i < ncv; i++)
     {
-    if(cx_attrib::is_complex(ritz_val(i), eps) && cx_attrib::is_conj(ritz_val(i), ritz_val(i + 1), eps))
+    if(cx_attrib::is_complex(ritz_val(i), eT(0)) && (i < ncv - 1) && cx_attrib::is_conj(ritz_val(i), ritz_val(i + 1), eT(0)))
       {
       // H - mu * I = Q1 * R1
       // H <- R1 * Q1 + mu * I = Q1' * H * Q1

--- a/include/armadillo_bits/newarp_UpperHessenbergEigen_meat.hpp
+++ b/include/armadillo_bits/newarp_UpperHessenbergEigen_meat.hpp
@@ -121,24 +121,21 @@ UpperHessenbergEigen<eT>::eigenvectors()
   
   arma_debug_check( (computed == false), "newarp::UpperHessenbergEigen::eigenvectors(): need to call compute() first" );
 
-  // in fact Lapack will set the imaginary parts of real eigenvalues to be exact zero
-  // here we just use a small value
-  eT prec = std::numeric_limits<eT>::epsilon();
-  
+  // Lapack will set the imaginary parts of real eigenvalues to be exact zero
   Mat< std::complex<eT> > evecs(n, n);
   
   std::complex<eT>* col_ptr = evecs.memptr();
   
   for(blas_int i = 0; i < n; i++)
     {
-    if(cx_attrib::is_real(evals(i), prec))
+    if(cx_attrib::is_real(evals(i), eT(0)))
       {
       // for real eigenvector, normalise and copy
       eT z_norm = norm(mat_Z.col(i));
       
       for(blas_int j = 0; j < n; j++)
         {
-        col_ptr[j] = std::complex<eT>(mat_Z(j, i) / z_norm, 0);
+        col_ptr[j] = std::complex<eT>(mat_Z(j, i) / z_norm, eT(0));
         }
 
       col_ptr += n;


### PR DESCRIPTION
This PR fixes #26 , which is caused by imprecise tests of complex numbers. Additional safeguard is added to avoid potential out-of-bound error.