### PR TITLE
HDF5 group name support

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -5904,7 +5904,10 @@ Applicable to <i>Mat</i> only.
                         <td style="vertical-align: top;">
 Numerical data stored in portable <a href="https://en.wikipedia.org/wiki/Hierarchical_Data_Format">HDF5</a> binary format.
 <ul>
-<li>For saving, the default dataset name within the HDF5 file is "dataset" unless explicitly specified via the <i>hdf5_name()</i> argument</li>
+<li>For saving, the default dataset name within the HDF5 file is "dataset"
+unless explicitly specified via the <i>hdf5_name()</i> argument; an HDF5 dataset
+name (e.g. <i>"dataset"</i>) or full
+path may be specified (e.g. <i>"/group_name/dataset"</i>)</li>
 <li>For loading, if the dataset has not been specified via the <i>hdf5_name()</i> argument,
 the order of operations is:
 (1) try loading a dataset named "dataset",
@@ -5912,7 +5915,7 @@ the order of operations is:
 (3) try loading the first available dataset</li>
 <li><b>Caveat</b>:
 support for HDF5 must be enabled within Armadillo's <a href="#config_hpp">configuration</a>;
-the <i>hdf5.h</i> header file must be available on your system and you will need to link with the hdf5 library (eg. -lhdf5)
+the <i>hdf5.h</i> header file must be available on your system and you will need to link with the hdf5 library (eg. -lhdf5) if <i>ARMA_USE_WRAPPER</i> is not specified.
 </li>
 </ul>
 <br>

--- a/include/armadillo_bits/def_hdf5.hpp
+++ b/include/armadillo_bits/def_hdf5.hpp
@@ -49,6 +49,9 @@
   #define arma_H5Fclose     H5Fclose
   #define arma_H5Fis_hdf5   H5Fis_hdf5
 
+  #define arma_H5Gcreate    H5Gcreate
+  #define arma_H5Gclose     H5Gclose
+
   #define arma_H5T_NATIVE_UCHAR   H5T_NATIVE_UCHAR
   #define arma_H5T_NATIVE_CHAR    H5T_NATIVE_CHAR
   #define arma_H5T_NATIVE_SHORT   H5T_NATIVE_SHORT
@@ -97,6 +100,9 @@ extern "C"
   hid_t  arma_H5Fcreate(const char* name, unsigned flags, hid_t fcpl_id, hid_t fapl_id);
   herr_t arma_H5Fclose(hid_t file_id);
   htri_t arma_H5Fis_hdf5(const char* name);
+
+  hid_t  arma_H5Gcreate(hid_t loc_id, const char* name, hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id);
+  herr_t arma_H5Gclose(hid_t group_id);
   
   // Wrapper variables that represent the hid_t values for the H5T_NATIVE_*
   // types.  Note that H5T_NATIVE_UCHAR itself is a macro that resolves to about

--- a/include/armadillo_bits/diskio_meat.hpp
+++ b/include/armadillo_bits/diskio_meat.hpp
@@ -1293,7 +1293,6 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const hdf5_name& spec)
     while ((loc = full_name.find("/")) != std::string::npos)
       {
       // Create another group...
-      std::cout << full_name << ", loc " << loc << "\n";
       if (loc != 0) // Ignore the first /, if there is a leading /.
         {
         hid_t gid = arma_H5Gcreate((groups.size() == 0) ? file : groups[groups.size() - 1], full_name.substr(0, loc).c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);

--- a/include/armadillo_bits/diskio_meat.hpp
+++ b/include/armadillo_bits/diskio_meat.hpp
@@ -1269,7 +1269,7 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const hdf5_name& spec)
     
     const std::string tmp_name = diskio::gen_tmp_name(spec.filename);
     
-    // Set up the file according to HDF5's preferences  
+    // Set up the file according to HDF5's preferences
     hid_t file = arma_H5Fcreate(tmp_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
     
     // We need to create a dataset, datatype, and dataspace
@@ -1286,10 +1286,26 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const hdf5_name& spec)
     // MATLAB forces the users to specify a name at save time for HDF5;
     // Octave will use the default of 'dataset' unless otherwise specified.
     // If the user hasn't specified a dataset name, we will use 'dataset'
+    // We may have to split out the group name from the dataset name.
+    std::vector<hid_t> groups;
+    std::string full_name = spec.dsname;
+    size_t loc;
+    while ((loc = full_name.find("/")) != std::string::npos)
+      {
+      // Create another group...
+      std::cout << full_name << ", loc " << loc << "\n";
+      if (loc != 0) // Ignore the first /, if there is a leading /.
+        {
+        hid_t gid = arma_H5Gcreate((groups.size() == 0) ? file : groups[groups.size() - 1], full_name.substr(0, loc).c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+        groups.push_back(gid);
+        }
+
+      full_name = full_name.substr(loc + 1);
+      }
     
-    const std::string dataset_name = (spec.dsname.empty() == false) ? spec.dsname : std::string("dataset");
-    
-    hid_t dataset = arma_H5Dcreate(file, dataset_name.c_str(), datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    const std::string dataset_name = (full_name.empty() == false) ? full_name : std::string("dataset");
+
+    hid_t dataset = arma_H5Dcreate(groups.size() == 0 ? file : groups[groups.size() - 1], dataset_name.c_str(), datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
     
     // H5Dwrite does not make a distinction between row-major and column-major;
     // it just writes the memory.  MATLAB and Octave store HDF5 matrices as
@@ -1301,6 +1317,10 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const hdf5_name& spec)
     arma_H5Dclose(dataset);
     arma_H5Tclose(datatype);
     arma_H5Sclose(dataspace);
+    for (size_t i = 0; i < groups.size(); ++i)
+      {
+      arma_H5Gclose(groups[i]);
+      }
     arma_H5Fclose(file);
     
     if(save_okay == true) { save_okay = diskio::safe_rename(tmp_name, spec.filename); }

--- a/include/armadillo_bits/gmm_diag_meat.hpp
+++ b/include/armadillo_bits/gmm_diag_meat.hpp
@@ -793,7 +793,7 @@ gmm_diag<eT>::learn
     
     reset(X.n_rows, N_gaus);
     
-    if(print_mode)  { get_stream_err2() << "gmm_diag::learn(): generating initial means\n"; get_stream_err2().flush(); }
+    if(print_mode)  { get_cerr_stream() << "gmm_diag::learn(): generating initial means\n"; get_cerr_stream().flush(); }
     
          if(dist_mode == eucl_dist)  { generate_initial_means<1>(X, seed_mode); }
     else if(dist_mode == maha_dist)  { generate_initial_means<2>(X, seed_mode); }
@@ -804,14 +804,14 @@ gmm_diag<eT>::learn
   
   if(km_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cerr_stream());
     
     bool status = false;
     
          if(dist_mode == eucl_dist)  { status = km_iterate<1>(X, km_iter, print_mode, "gmm_diag::learn(): k-means"); }
     else if(dist_mode == maha_dist)  { status = km_iterate<2>(X, km_iter, print_mode, "gmm_diag::learn(): k-means"); }
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cerr_stream());
     
     if(status == false)  { arma_debug_warn("gmm_diag::learn(): k-means algorithm failed; not enough data, or too many gaussians requested"); init(orig); return false; }
     }
@@ -823,7 +823,7 @@ gmm_diag<eT>::learn
   
   if(seed_mode != keep_existing)
     {
-    if(print_mode)  { get_stream_err2() << "gmm_diag::learn(): generating initial covariances\n"; get_stream_err2().flush(); }
+    if(print_mode)  { get_cerr_stream() << "gmm_diag::learn(): generating initial covariances\n"; get_cerr_stream().flush(); }
     
          if(dist_mode == eucl_dist)  { generate_initial_params<1>(X, var_floor_actual); }
     else if(dist_mode == maha_dist)  { generate_initial_params<2>(X, var_floor_actual); }
@@ -834,11 +834,11 @@ gmm_diag<eT>::learn
   
   if(em_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cerr_stream());
     
     const bool status = em_iterate(X, em_iter, var_floor_actual, print_mode);
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cerr_stream());
     
     if(status == false)  { arma_debug_warn("gmm_diag::learn(): EM algorithm failed"); init(orig); return false; }
     }
@@ -903,7 +903,7 @@ gmm_diag<eT>::kmeans_wrapper
     
     access::rw(means).zeros(X.n_rows, N_gaus);
     
-    if(print_mode)  { get_stream_err2() << "kmeans(): generating initial means\n"; }
+    if(print_mode)  { get_cerr_stream() << "kmeans(): generating initial means\n"; }
     
     generate_initial_means<1>(X, seed_mode);
     }
@@ -913,13 +913,13 @@ gmm_diag<eT>::kmeans_wrapper
   
   if(km_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cerr_stream());
     
     bool status = false;
     
     status = km_iterate<1>(X, km_iter, print_mode, "kmeans()");
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cerr_stream());
     
     if(status == false)  { arma_debug_warn("kmeans(): clustering failed; not enough data, or too many means requested"); return false; }
     }
@@ -1080,7 +1080,7 @@ gmm_diag<eT>::internal_gen_boundaries(const uword N) const
     static const uword n_threads = 1;
   #endif
   
-  // get_stream_err2() << "gmm_diag::internal_gen_boundaries(): n_threads: " << n_threads << '\n';
+  // get_cerr_stream() << "gmm_diag::internal_gen_boundaries(): n_threads: " << n_threads << '\n';
   
   umat boundaries(2, n_threads);
   
@@ -1106,7 +1106,7 @@ gmm_diag<eT>::internal_gen_boundaries(const uword N) const
     boundaries.zeros();
     }
   
-  // get_stream_err2() << "gmm_diag::internal_gen_boundaries(): boundaries: " << '\n' << boundaries << '\n';
+  // get_cerr_stream() << "gmm_diag::internal_gen_boundaries(): boundaries: " << '\n' << boundaries << '\n';
   
   return boundaries;
   }
@@ -1959,7 +1959,7 @@ gmm_diag<eT>::generate_initial_means(const Mat<eT>& X, const gmm_seed_mode& seed
       }
     }
   
-  // get_stream_err2() << "generate_initial_means():" << '\n';
+  // get_cerr_stream() << "generate_initial_means():" << '\n';
   // means.print();
   }
 
@@ -2128,13 +2128,13 @@ gmm_diag<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
   
   if(verbose)
     {
-    get_stream_err2().unsetf(ios::showbase);
-    get_stream_err2().unsetf(ios::uppercase);
-    get_stream_err2().unsetf(ios::showpos);
-    get_stream_err2().unsetf(ios::scientific);
+    get_cerr_stream().unsetf(ios::showbase);
+    get_cerr_stream().unsetf(ios::uppercase);
+    get_cerr_stream().unsetf(ios::showpos);
+    get_cerr_stream().unsetf(ios::scientific);
     
-    get_stream_err2().setf(ios::right);
-    get_stream_err2().setf(ios::fixed);
+    get_cerr_stream().setf(ios::right);
+    get_cerr_stream().setf(ios::fixed);
     }
   
   const uword X_n_cols = X.n_cols;
@@ -2166,7 +2166,7 @@ gmm_diag<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     const uword n_threads = 1;
   #endif
   
-  if(verbose)  { get_stream_err2() << signature << ": n_threads: " << n_threads  << '\n'; get_stream_err2().flush(); }
+  if(verbose)  { get_cerr_stream() << signature << ": n_threads: " << n_threads  << '\n'; get_cerr_stream().flush(); }
   
   for(uword iter=1; iter <= max_iter; ++iter)
     {
@@ -2282,7 +2282,7 @@ gmm_diag<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     
     if(dead_gs.n_elem > 0)
       {
-      if(verbose)  { get_stream_err2() << signature << ": recovering from dead means\n"; get_stream_err2().flush(); }
+      if(verbose)  { get_cerr_stream() << signature << ": recovering from dead means\n"; get_cerr_stream().flush(); }
       
       uword* last_indx_mem = last_indx.memptr();
     
@@ -2328,16 +2328,16 @@ gmm_diag<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     
     if(verbose)
       {
-      get_stream_err2() << signature << ": iteration: ";
-      get_stream_err2().unsetf(ios::scientific);
-      get_stream_err2().setf(ios::fixed);
-      get_stream_err2().width(std::streamsize(4));
-      get_stream_err2() << iter;
-      get_stream_err2() << "   delta: ";
-      get_stream_err2().unsetf(ios::fixed);
-      //get_stream_err2().setf(ios::scientific);
-      get_stream_err2() << rs_delta.mean() << '\n';
-      get_stream_err2().flush();
+      get_cerr_stream() << signature << ": iteration: ";
+      get_cerr_stream().unsetf(ios::scientific);
+      get_cerr_stream().setf(ios::fixed);
+      get_cerr_stream().width(std::streamsize(4));
+      get_cerr_stream() << iter;
+      get_cerr_stream() << "   delta: ";
+      get_cerr_stream().unsetf(ios::fixed);
+      //get_cerr_stream().setf(ios::scientific);
+      get_cerr_stream() << rs_delta.mean() << '\n';
+      get_cerr_stream().flush();
       }
     
     arma::swap(old_means, new_means);
@@ -2369,13 +2369,13 @@ gmm_diag<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
   
   if(verbose)
     {
-    get_stream_err2().unsetf(ios::showbase);
-    get_stream_err2().unsetf(ios::uppercase);
-    get_stream_err2().unsetf(ios::showpos);
-    get_stream_err2().unsetf(ios::scientific);
+    get_cerr_stream().unsetf(ios::showbase);
+    get_cerr_stream().unsetf(ios::uppercase);
+    get_cerr_stream().unsetf(ios::showpos);
+    get_cerr_stream().unsetf(ios::scientific);
     
-    get_stream_err2().setf(ios::right);
-    get_stream_err2().setf(ios::fixed);
+    get_cerr_stream().setf(ios::right);
+    get_cerr_stream().setf(ios::fixed);
     }
   
   const umat boundaries = internal_gen_boundaries(X.n_cols);
@@ -2402,7 +2402,7 @@ gmm_diag<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
   
   if(verbose)
     {
-    get_stream_err2() << "gmm_diag::learn(): EM: n_threads: " << n_threads  << '\n';
+    get_cerr_stream() << "gmm_diag::learn(): EM: n_threads: " << n_threads  << '\n';
     }
   
   eT old_avg_log_p = -Datum<eT>::inf;
@@ -2419,16 +2419,16 @@ gmm_diag<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
     
     if(verbose)
       {
-      get_stream_err2() << "gmm_diag::learn(): EM: iteration: ";
-      get_stream_err2().unsetf(ios::scientific);
-      get_stream_err2().setf(ios::fixed);
-      get_stream_err2().width(std::streamsize(4));
-      get_stream_err2() << iter;
-      get_stream_err2() << "   avg_log_p: ";
-      get_stream_err2().unsetf(ios::fixed);
-      //get_stream_err2().setf(ios::scientific);
-      get_stream_err2() << new_avg_log_p << '\n';
-      get_stream_err2().flush();
+      get_cerr_stream() << "gmm_diag::learn(): EM: iteration: ";
+      get_cerr_stream().unsetf(ios::scientific);
+      get_cerr_stream().setf(ios::fixed);
+      get_cerr_stream().width(std::streamsize(4));
+      get_cerr_stream() << iter;
+      get_cerr_stream() << "   avg_log_p: ";
+      get_cerr_stream().unsetf(ios::fixed);
+      //get_cerr_stream().setf(ios::scientific);
+      get_cerr_stream() << new_avg_log_p << '\n';
+      get_cerr_stream().flush();
       }
     
     if(arma_isfinite(new_avg_log_p) == false)  { return false; }

--- a/include/armadillo_bits/gmm_full_meat.hpp
+++ b/include/armadillo_bits/gmm_full_meat.hpp
@@ -832,7 +832,7 @@ gmm_full<eT>::learn
     
     reset(X.n_rows, N_gaus);
     
-    if(print_mode)  { get_stream_err2() << "gmm_full::learn(): generating initial means\n"; get_stream_err2().flush(); }
+    if(print_mode)  { get_cerr_stream() << "gmm_full::learn(): generating initial means\n"; get_cerr_stream().flush(); }
     
          if(dist_mode == eucl_dist)  { generate_initial_means<1>(X, seed_mode); }
     else if(dist_mode == maha_dist)  { generate_initial_means<2>(X, seed_mode); }
@@ -843,14 +843,14 @@ gmm_full<eT>::learn
   
   if(km_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cerr_stream());
     
     bool status = false;
     
          if(dist_mode == eucl_dist)  { status = km_iterate<1>(X, km_iter, print_mode); }
     else if(dist_mode == maha_dist)  { status = km_iterate<2>(X, km_iter, print_mode); }
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cerr_stream());
     
     if(status == false)  { arma_debug_warn("gmm_full::learn(): k-means algorithm failed; not enough data, or too many gaussians requested"); init(orig); return false; }
     }
@@ -862,7 +862,7 @@ gmm_full<eT>::learn
   
   if(seed_mode != keep_existing)
     {
-    if(print_mode)  { get_stream_err2() << "gmm_full::learn(): generating initial covariances\n"; get_stream_err2().flush(); }
+    if(print_mode)  { get_cerr_stream() << "gmm_full::learn(): generating initial covariances\n"; get_cerr_stream().flush(); }
     
          if(dist_mode == eucl_dist)  { generate_initial_params<1>(X, var_floor_actual); }
     else if(dist_mode == maha_dist)  { generate_initial_params<2>(X, var_floor_actual); }
@@ -873,11 +873,11 @@ gmm_full<eT>::learn
   
   if(em_iter > 0)
     {
-    const arma_ostream_state stream_state(get_stream_err2());
+    const arma_ostream_state stream_state(get_cerr_stream());
     
     const bool status = em_iterate(X, em_iter, var_floor_actual, print_mode);
     
-    stream_state.restore(get_stream_err2());
+    stream_state.restore(get_cerr_stream());
     
     if(status == false)  { arma_debug_warn("gmm_full::learn(): EM algorithm failed"); init(orig); return false; }
     }
@@ -1093,7 +1093,7 @@ gmm_full<eT>::internal_gen_boundaries(const uword N) const
     static const uword n_threads = 1;
   #endif
   
-  // get_stream_err2() << "gmm_full::internal_gen_boundaries(): n_threads: " << n_threads << '\n';
+  // get_cerr_stream() << "gmm_full::internal_gen_boundaries(): n_threads: " << n_threads << '\n';
   
   umat boundaries(2, n_threads);
   
@@ -1119,7 +1119,7 @@ gmm_full<eT>::internal_gen_boundaries(const uword N) const
     boundaries.zeros();
     }
   
-  // get_stream_err2() << "gmm_full::internal_gen_boundaries(): boundaries: " << '\n' << boundaries << '\n';
+  // get_cerr_stream() << "gmm_full::internal_gen_boundaries(): boundaries: " << '\n' << boundaries << '\n';
   
   return boundaries;
   }
@@ -1982,7 +1982,7 @@ gmm_full<eT>::generate_initial_means(const Mat<eT>& X, const gmm_seed_mode& seed
       }
     }
   
-  // get_stream_err2() << "generate_initial_means():" << '\n';
+  // get_cerr_stream() << "generate_initial_means():" << '\n';
   // means.print();
   }
 
@@ -2153,13 +2153,13 @@ gmm_full<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
   
   if(verbose)
     {
-    get_stream_err2().unsetf(ios::showbase);
-    get_stream_err2().unsetf(ios::uppercase);
-    get_stream_err2().unsetf(ios::showpos);
-    get_stream_err2().unsetf(ios::scientific);
+    get_cerr_stream().unsetf(ios::showbase);
+    get_cerr_stream().unsetf(ios::uppercase);
+    get_cerr_stream().unsetf(ios::showpos);
+    get_cerr_stream().unsetf(ios::scientific);
     
-    get_stream_err2().setf(ios::right);
-    get_stream_err2().setf(ios::fixed);
+    get_cerr_stream().setf(ios::right);
+    get_cerr_stream().setf(ios::fixed);
     }
   
   const uword X_n_cols = X.n_cols;
@@ -2191,7 +2191,7 @@ gmm_full<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     const uword n_threads = 1;
   #endif
   
-  if(verbose)  { get_stream_err2() << "gmm_full::learn(): k-means: n_threads: " << n_threads << '\n';  get_stream_err2().flush(); }
+  if(verbose)  { get_cerr_stream() << "gmm_full::learn(): k-means: n_threads: " << n_threads << '\n';  get_cerr_stream().flush(); }
   
   for(uword iter=1; iter <= max_iter; ++iter)
     {
@@ -2307,7 +2307,7 @@ gmm_full<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     
     if(dead_gs.n_elem > 0)
       {
-      if(verbose)  { get_stream_err2() << "gmm_full::learn(): k-means: recovering from dead means\n"; get_stream_err2().flush(); }
+      if(verbose)  { get_cerr_stream() << "gmm_full::learn(): k-means: recovering from dead means\n"; get_cerr_stream().flush(); }
       
       uword* last_indx_mem = last_indx.memptr();
     
@@ -2353,16 +2353,16 @@ gmm_full<eT>::km_iterate(const Mat<eT>& X, const uword max_iter, const bool verb
     
     if(verbose)
       {
-      get_stream_err2() << "gmm_full::learn(): k-means: iteration: ";
-      get_stream_err2().unsetf(ios::scientific);
-      get_stream_err2().setf(ios::fixed);
-      get_stream_err2().width(std::streamsize(4));
-      get_stream_err2() << iter;
-      get_stream_err2() << "   delta: ";
-      get_stream_err2().unsetf(ios::fixed);
-      //get_stream_err2().setf(ios::scientific);
-      get_stream_err2() << rs_delta.mean() << '\n';
-      get_stream_err2().flush();
+      get_cerr_stream() << "gmm_full::learn(): k-means: iteration: ";
+      get_cerr_stream().unsetf(ios::scientific);
+      get_cerr_stream().setf(ios::fixed);
+      get_cerr_stream().width(std::streamsize(4));
+      get_cerr_stream() << iter;
+      get_cerr_stream() << "   delta: ";
+      get_cerr_stream().unsetf(ios::fixed);
+      //get_cerr_stream().setf(ios::scientific);
+      get_cerr_stream() << rs_delta.mean() << '\n';
+      get_cerr_stream().flush();
       }
     
     arma::swap(old_means, new_means);
@@ -2392,13 +2392,13 @@ gmm_full<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
   
   if(verbose)
     {
-    get_stream_err2().unsetf(ios::showbase);
-    get_stream_err2().unsetf(ios::uppercase);
-    get_stream_err2().unsetf(ios::showpos);
-    get_stream_err2().unsetf(ios::scientific);
+    get_cerr_stream().unsetf(ios::showbase);
+    get_cerr_stream().unsetf(ios::uppercase);
+    get_cerr_stream().unsetf(ios::showpos);
+    get_cerr_stream().unsetf(ios::scientific);
     
-    get_stream_err2().setf(ios::right);
-    get_stream_err2().setf(ios::fixed);
+    get_cerr_stream().setf(ios::right);
+    get_cerr_stream().setf(ios::fixed);
     }
   
   const umat boundaries = internal_gen_boundaries(X.n_cols);
@@ -2425,7 +2425,7 @@ gmm_full<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
   
   if(verbose)
     {
-    get_stream_err2() << "gmm_full::learn(): EM: n_threads: " << n_threads  << '\n';
+    get_cerr_stream() << "gmm_full::learn(): EM: n_threads: " << n_threads  << '\n';
     }
   
   eT old_avg_log_p = -Datum<eT>::inf;
@@ -2444,16 +2444,16 @@ gmm_full<eT>::em_iterate(const Mat<eT>& X, const uword max_iter, const eT var_fl
     
     if(verbose)
       {
-      get_stream_err2() << "gmm_full::learn(): EM: iteration: ";
-      get_stream_err2().unsetf(ios::scientific);
-      get_stream_err2().setf(ios::fixed);
-      get_stream_err2().width(std::streamsize(4));
-      get_stream_err2() << iter;
-      get_stream_err2() << "   avg_log_p: ";
-      get_stream_err2().unsetf(ios::fixed);
-      //get_stream_err2().setf(ios::scientific);
-      get_stream_err2() << new_avg_log_p << '\n';
-      get_stream_err2().flush();
+      get_cerr_stream() << "gmm_full::learn(): EM: iteration: ";
+      get_cerr_stream().unsetf(ios::scientific);
+      get_cerr_stream().setf(ios::fixed);
+      get_cerr_stream().width(std::streamsize(4));
+      get_cerr_stream() << iter;
+      get_cerr_stream() << "   avg_log_p: ";
+      get_cerr_stream().unsetf(ios::fixed);
+      //get_cerr_stream().setf(ios::scientific);
+      get_cerr_stream() << new_avg_log_p << '\n';
+      get_cerr_stream().flush();
       }
     
     if(arma_isfinite(new_avg_log_p) == false)  { return false; }

--- a/include/armadillo_bits/hdf5_misc.hpp
+++ b/include/armadillo_bits/hdf5_misc.hpp
@@ -330,20 +330,55 @@ hdf5_search_callback
       // So if we count the number of forward slashes in names[string_pos],
       // and then simply take the last substring of name containing that number of slashes,
       // we can do the comparison.
+      std::cout << "search for '" << search_info->names[string_pos] << "' in '" << name << "'\n";
       
       // Count the number of forward slashes in names[string_pos].
-      uword count = 0;
+      uword name_count = 0;
       for (uword i = 0; i < search_info->names[string_pos].length(); ++i)
         {
-        if ((search_info->names[string_pos])[i] == '/') { ++count; }
+        if ((search_info->names[string_pos])[i] == '/') { ++name_count; }
         }
 
       // Count the number of forward slashes in the full name.
-      uword name_count = 0;
+      uword count = 0;
       const std::string str = std::string(name);
       for (uword i = 0; i < str.length(); ++i)
         {
         if (str[i] == '/') { ++count; }
+        }
+      std::cout << "slash counts: " << count << ", in name " << name_count << "\n";
+
+      // Is the full string the same?
+      if (str == search_info->names[string_pos])
+        {
+        // We found it exactly.
+        hid_t match_candidate = arma_H5Dopen(loc_id, name, H5P_DEFAULT);
+
+        if (match_candidate < 0)
+          {
+          return -1;
+          }
+
+        // Ensure that the dataset is valid and of the correct dimensionality.
+        hid_t filespace = arma_H5Dget_space(match_candidate);
+        int num_dims = arma_H5Sget_simple_extent_ndims(filespace);
+        
+        if (num_dims <= search_info->num_dims)
+          {
+          // Valid dataset -- we'll keep it.
+          // If we already have an existing match we have to close it.
+          if (search_info->best_match != -1)
+            {
+            arma_H5Dclose(search_info->best_match);
+            }
+
+          search_info->best_match_position = string_pos;
+          search_info->best_match          = match_candidate;
+          }
+        
+        arma_H5Sclose(filespace);
+        // There is no possibility of anything better, so terminate the search.
+        return 1;
         }
 
       // If we are asking for more slashes than we have, this can't be a match.
@@ -365,6 +400,8 @@ hdf5_search_callback
 
         // Now take the substring (this may end up being the full string).
         const std::string substring = str.substr(start_pos);
+
+        std::cout << "start_pos: " << start_pos << ", substring " << substring << "\n";
 
         // Are they the same?
         if (substring == search_info->names[string_pos])

--- a/include/armadillo_bits/hdf5_misc.hpp
+++ b/include/armadillo_bits/hdf5_misc.hpp
@@ -330,7 +330,6 @@ hdf5_search_callback
       // So if we count the number of forward slashes in names[string_pos],
       // and then simply take the last substring of name containing that number of slashes,
       // we can do the comparison.
-      std::cout << "search for '" << search_info->names[string_pos] << "' in '" << name << "'\n";
       
       // Count the number of forward slashes in names[string_pos].
       uword name_count = 0;
@@ -346,7 +345,6 @@ hdf5_search_callback
         {
         if (str[i] == '/') { ++count; }
         }
-      std::cout << "slash counts: " << count << ", in name " << name_count << "\n";
 
       // Is the full string the same?
       if (str == search_info->names[string_pos])
@@ -400,8 +398,6 @@ hdf5_search_callback
 
         // Now take the substring (this may end up being the full string).
         const std::string substring = str.substr(start_pos);
-
-        std::cout << "start_pos: " << start_pos << ", substring " << substring << "\n";
 
         // Are they the same?
         if (substring == search_info->names[string_pos])

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -1358,6 +1358,16 @@ extern "C"
       {
       return H5Fis_hdf5(name);
       }
+
+    hid_t arma_H5Gcreate(hid_t loc_id, const char* name, hid_t lcpl_id, hid_t gcpl_id, hid_t gapl_id)
+      {
+      return H5Gcreate(loc_id, name, lcpl_id, gcpl_id, gapl_id);
+      }
+
+    herr_t arma_H5Gclose(hid_t group_id)
+      {
+      return H5Gclose(group_id);
+      }
     
     // H5T_NATIVE_* types.  The rhs here expands to some macros.
     hid_t arma_H5T_NATIVE_UCHAR  = H5T_NATIVE_UCHAR;


### PR DESCRIPTION
This makes `hdf5_name()` work correctly with group arguments.  So now you can do:

```
X.save(hdf5_name("file.h5", "/myGroup/myDataset"), hdf5_binary);
```

and

```
X.load(hdf5_name("file.h5", "/myGroup/myDataset"), hdf5_binary);
```

I also fixed some deprecated warnings in gmm_diag_meat.cpp and gmm_full_meat.cpp; these changes assume that `get_stream_err2()` should be changed to `get_cerr_stream()`.  If that's not the case, let me know and I'll fix it.

I modified the documentation slightly to point out the group name functionality of `hdf5_name()`, and I think that I corrected the bit about linking with HDF5.  As far as I can tell, if `ARMA_USE_HDF5` is enabled and `ARMA_USE_WRAPPER` is also enabled, there's no need for `-lhdf5`.

(Related: is it time to make the default for `DETECT_HDF5` be `ON`?  No huge opinion from my side, but it might be nice, I haven't had any problems with `DETECT_HDF5` on in any of my testing over the years.)