### PR TITLE
Use CSC representation for MapMat conversion instead of iterators

### DIFF
--- a/include/armadillo_bits/MapMat_meat.hpp
+++ b/include/armadillo_bits/MapMat_meat.hpp
@@ -145,24 +145,22 @@ MapMat<eT>::operator=(const SpMat<eT>& x)
   
   if(x.n_nonzero == 0)  { return; }
   
-  typename SpMat<eT>::const_iterator it     = x.begin();
-  typename SpMat<eT>::const_iterator it_end = x.end();
-  
-  map_type& map_ref = (*map_ptr);
-  
   const uword local_n_rows = n_rows;
-  
-  for(; it != it_end; ++it)
+
+  map_type& map_ref = (*map_ptr);
+
+  for(uword c = 0; c < x.n_cols; ++c)
     {
-    const eT val = (*it);
-    
-    if(val != eT(0))
+    const uword start = x.col_ptrs[c];
+    const uword end = x.col_ptrs[c + 1];
+
+    for(uword i = start; i < end; ++i)
       {
-      const uword row = it.row();
-      const uword col = it.col();
-      
-      const uword index = (local_n_rows * col) + row;
-      
+      const uword row = x.row_indices[i];
+      const eT val = x.values[i];
+
+      const uword index = (local_n_rows * c) + row;
+
       #if defined(ARMA_USE_CXX11)
         map_ref.emplace_hint(map_ref.cend(), index, val);
       #else


### PR DESCRIPTION
This was an idea I had for acceleration.  When I test it on large matrices, it does seem to provide some marginal amount of speedup, so I decided to submit the PR.  On small matrices it's tough to know whether the speedup is system noise.

On a 50k x 50k 10% nonzero matrix before these changes:

```
$ for i in `seq 1 10`; do ./sync_test_old; done
time: 12.3898s
time: 12.3186s
time: 12.2556s
time: 12.3431s
time: 12.4928s
time: 12.3564s
time: 12.3539s
time: 12.2802s
time: 12.2992s
time: 12.3316s
```

After these changes:

```
$ for i in `seq 1 10`; do ./sync_test; done
time: 11.326s
time: 11.6969s
time: 11.3423s
time: 11.3821s
time: 11.4991s
time: 11.4344s
time: 11.4052s
time: 11.3239s
time: 11.3405s
time: 11.3131s
```

And the program in question:

```
$ cat sync_test.cpp
#include <armadillo>

using namespace arma;

int main()
{
  sp_mat m(50000, 50000);
  m.sprandu(50000, 50000, 0.1);

  wall_clock cl;
  cl.tic();
  MapMat<double> mm(m);
  double result = cl.toc();
  std::cout << "time: " << result << "s" << std::endl;
}
```

So, a minor improvement, still better than nothing. :)