### PR TITLE
Save multiple datasets into one hdf5 file.

### DIFF
--- a/include/armadillo_bits/arma_forward.hpp
+++ b/include/armadillo_bits/arma_forward.hpp
@@ -280,17 +280,19 @@ struct hdf5_name
   {
   const std::string filename;
   const std::string dsname;
-  const bool append = false;
+  const bool append;
   
   inline
   hdf5_name(const std::string& in_filename)
     : filename(in_filename)
+    , append  (false      )
     {}
   
   inline
   hdf5_name(const std::string& in_filename, const std::string& in_dsname)
     : filename(in_filename)
     , dsname  (in_dsname  )
+    , append  (false      )
     {}
   inline
   hdf5_name(const std::string& in_filename, const std::string& in_dsname, const bool& in_append)

--- a/include/armadillo_bits/arma_forward.hpp
+++ b/include/armadillo_bits/arma_forward.hpp
@@ -280,6 +280,7 @@ struct hdf5_name
   {
   const std::string filename;
   const std::string dsname;
+  const bool append = false;
   
   inline
   hdf5_name(const std::string& in_filename)
@@ -290,6 +291,12 @@ struct hdf5_name
   hdf5_name(const std::string& in_filename, const std::string& in_dsname)
     : filename(in_filename)
     , dsname  (in_dsname  )
+    {}
+  inline
+  hdf5_name(const std::string& in_filename, const std::string& in_dsname, const bool& in_append)
+    : filename(in_filename)
+    , dsname  (in_dsname  )
+    , append  (in_append  )
     {}
   };
 

--- a/include/armadillo_bits/diskio_meat.hpp
+++ b/include/armadillo_bits/diskio_meat.hpp
@@ -1269,8 +1269,19 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const hdf5_name& spec)
     
     const std::string tmp_name = diskio::gen_tmp_name(spec.filename);
     
+    //Check if file exists and is HDF5
+    int file_is_hdf5 = arma_H5Fis_hdf5(spec.filename.c_str());
+
     // Set up the file according to HDF5's preferences
-    hid_t file = arma_H5Fcreate(tmp_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+    hid_t file;
+    if ((file_is_hdf5 == 1) & (spec.append == true))
+      {
+      file = arma_H5Fopen(spec.filename.c_str(), H5F_ACC_RDWR, H5P_DEFAULT);
+      }
+    else
+      {
+      file = arma_H5Fcreate(tmp_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+      }
     
     // We need to create a dataset, datatype, and dataspace
     hsize_t dims[2];
@@ -1305,7 +1316,8 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const hdf5_name& spec)
     const std::string dataset_name = (full_name.empty() == false) ? full_name : std::string("dataset");
 
     hid_t dataset = arma_H5Dcreate(groups.size() == 0 ? file : groups[groups.size() - 1], dataset_name.c_str(), datatype, dataspace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    
+    if (dataset < 0) { arma_debug_warn("Mat::save(): dataset ", dataset_name.c_str(), std::string(" already exists in ") + spec.filename.c_str());} //can never happen if file is overwritten, so no need to use tmp_name.c_str()
+
     // H5Dwrite does not make a distinction between row-major and column-major;
     // it just writes the memory.  MATLAB and Octave store HDF5 matrices as
     // column-major, though, so we can save ours like that too and not need to
@@ -1319,7 +1331,10 @@ diskio::save_hdf5_binary(const Mat<eT>& x, const hdf5_name& spec)
     for (size_t i = 0; i < groups.size(); ++i)  { arma_H5Gclose(groups[i]); }
     arma_H5Fclose(file);
     
-    if(save_okay == true) { save_okay = diskio::safe_rename(tmp_name, spec.filename); }
+    if (save_okay == true)
+      {
+      if ((file_is_hdf5 != 1) || (spec.append == false)) { save_okay = diskio::safe_rename(tmp_name, spec.filename); }
+      }
     
     return save_okay;
     }

--- a/tests/hdf5.cpp
+++ b/tests/hdf5.cpp
@@ -716,4 +716,96 @@ TEST_CASE("hdf5_complex_double_test")
   remove("file.h5");
   }
 
+
+
+TEST_CASE("hdf5_dataset_append_test")
+  {
+  arma::Mat<double> a;
+  a.randu(20, 20);
+
+  // Save first dataset.
+  a.save(hdf5_name("file.h5", "dataset1"), hdf5_binary);
+
+  arma::Mat<double> b;
+  b.randu(10,10);
+
+  // Save second dataset.
+  b.save(hdf5_name("file.h5", "dataset2", true), hdf5_binary);
+
+  // Load first dataset as different matrix.
+  arma::Mat<double> c;
+  c.load(hdf5_name("file.h5", "dataset1"), hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  // Load second dataset as different matrix.
+  arma::Mat<double> d;
+  d.load(hdf5_name("file.h5", "dataset2"), hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < b.n_elem; ++i)
+    {
+    REQUIRE( b[i] == d[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_dataset_append-overwrite-test")
+  {
+  arma::Mat<double> a;
+  a.randu(20, 20);
+
+  // Save first dataset.
+  a.save(hdf5_name("file.h5", "dataset1"), hdf5_binary);
+
+  arma::Mat<double> b;
+  b.randu(10,10);
+
+  // Save second dataset.
+  b.save(hdf5_name("file.h5", "dataset2", false), hdf5_binary);
+
+  // Load first dataset as different matrix.
+  arma::Mat<double> c;
+  // Chech that first dataset has been overwritten.
+  REQUIRE_FALSE(c.load(hdf5_name("file.h5", "dataset1"), hdf5_binary));
+
+  // Load second dataset as different matrix.
+  arma::Mat<double> d;
+  d.load(hdf5_name("file.h5", "dataset2"), hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < b.n_elem; ++i)
+    {
+    REQUIRE( b[i] == d[i] );
+    }
+
+  remove("file.h5");
+  }
+
+
+
+TEST_CASE("hdf5_dataset_same_dataset_twice_test")
+  {
+  arma::Mat<double> a;
+  a.randu(20, 20);
+
+  // Save first dataset.
+  a.save(hdf5_name("file.h5", "dataset1"), hdf5_binary);
+
+  arma::Mat<double> b;
+  b.randu(10,10);
+
+  // Append second dataset with same name, causing warning message.
+  REQUIRE_FALSE(b.save(hdf5_name("file.h5", "dataset1", true), hdf5_binary));
+
+  remove("file.h5");
+  }
+
 #endif

--- a/tests/hdf5.cpp
+++ b/tests/hdf5.cpp
@@ -727,7 +727,7 @@ TEST_CASE("hdf5_dataset_append_test")
   a.save(hdf5_name("file.h5", "dataset1"), hdf5_binary);
 
   arma::Mat<double> b;
-  b.randu(10,10);
+  b.randu(10, 10);
 
   // Save second dataset.
   b.save(hdf5_name("file.h5", "dataset2", true), hdf5_binary);
@@ -755,6 +755,42 @@ TEST_CASE("hdf5_dataset_append_test")
   remove("file.h5");
   }
 
+TEST_CASE("hdf5_cube_dataset_append_test")
+  {
+  arma::Mat<double> a;
+  a.randu(20, 20);
+
+  // Save first dataset.
+  a.save(hdf5_name("file.h5", "dataset1"), hdf5_binary);
+
+  arma::Cube<double> b;
+  b.randu(10, 10, 10);
+
+  // Save second dataset.
+  b.save(hdf5_name("file.h5", "dataset2", true), hdf5_binary);
+
+  // Load first dataset as different matrix.
+  arma::Mat<double> c;
+  c.load(hdf5_name("file.h5", "dataset1"), hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < a.n_elem; ++i)
+    {
+    REQUIRE( a[i] == c[i] );
+    }
+
+  // Load second dataset as different matrix.
+  arma::Cube<double> d;
+  d.load(hdf5_name("file.h5", "dataset2"), hdf5_binary);
+
+  // Check that they are the same.
+  for (uword i = 0; i < b.n_elem; ++i)
+    {
+    REQUIRE( b[i] == d[i] );
+    }
+
+  remove("file.h5");
+  }
 
 
 TEST_CASE("hdf5_dataset_append-overwrite-test")
@@ -766,7 +802,7 @@ TEST_CASE("hdf5_dataset_append-overwrite-test")
   a.save(hdf5_name("file.h5", "dataset1"), hdf5_binary);
 
   arma::Mat<double> b;
-  b.randu(10,10);
+  b.randu(10, 10);
 
   // Save second dataset.
   b.save(hdf5_name("file.h5", "dataset2", false), hdf5_binary);
@@ -800,7 +836,7 @@ TEST_CASE("hdf5_dataset_same_dataset_twice_test")
   a.save(hdf5_name("file.h5", "dataset1"), hdf5_binary);
 
   arma::Mat<double> b;
-  b.randu(10,10);
+  b.randu(10, 10);
 
   // Append second dataset with same name, causing warning message.
   REQUIRE_FALSE(b.save(hdf5_name("file.h5", "dataset1", true), hdf5_binary));


### PR DESCRIPTION
This pull request adds the possibility to save multiple datasets in one hdf5 file.
The change is implemented such that old code is not affected.
Note: Autoload can not reliably be used for hdf5 files containing multiple datasets. Autoload works, but I am not sure how it determines which dataset to load. However, loading individual datasets from a hdf5 file works if the dataset name is provided.
Tests are included.
See also [issue 41](https://github.com/conradsnicta/armadillo-code/issues/41).

Remaining question: How should I provide documentation?