### PR TITLE
making public two member functoins to synchronize/invalidate cache.

### DIFF
--- a/include/armadillo_bits/SpMat_bones.hpp
+++ b/include/armadillo_bits/SpMat_bones.hpp
@@ -580,6 +580,11 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   inline SpMat(const arma_vec_indicator&, const uword in_vec_state);
   inline SpMat(const arma_vec_indicator&, const uword in_n_rows, const uword in_n_cols, const uword in_vec_state);
   
+  arma_inline void invalidate_cache() const;
+  arma_inline void invalidate_csc()   const;
+  
+  arma_inline void sync_cache() const;
+  arma_inline void sync_csc()   const;
   
   private:
   
@@ -606,13 +611,7 @@ class SpMat : public SpBase< eT, SpMat<eT> >
   // 1: CSC needs to be updated from cache
   // 2: no update required
   
-  arma_inline void invalidate_cache() const;
-  arma_inline void invalidate_csc()   const;
-  
-  arma_inline void sync_cache() const;
-  arma_inline void sync_csc()   const;
-  
-  
+
   friend class SpValProxy< SpMat<eT> >;  // allow SpValProxy to call insert_element() and delete_element()
   friend class SpSubview<eT>;
   friend class SpRow<eT>;

--- a/include/armadillo_bits/SpMat_meat.hpp
+++ b/include/armadillo_bits/SpMat_meat.hpp
@@ -5733,7 +5733,7 @@ SpMat<eT>::sync_cache() const
 
 
 template<typename eT>
-inline
+arma_inline
 void
 SpMat<eT>::sync_csc() const
   {


### PR DESCRIPTION
This is necessary otherwise the access to SpMat from an external library cannot be guaranteed
to be thread safe even in read only