### PR TITLE
Allow custom locations for OpenBLAS and SuperLU

### DIFF
--- a/cmake_aux/Modules/ARMA_FindOpenBLAS.cmake
+++ b/cmake_aux/Modules/ARMA_FindOpenBLAS.cmake
@@ -6,15 +6,20 @@ set(OpenBLAS_NAMES ${OpenBLAS_NAMES} openblas )
 set(OpenBLAS_TMP_LIBRARY)
 set(OpenBLAS_TMP_LIBRARIES)
 
+set(OpenBLAS_SEARCH_PATH ${CMAKE_SYSTEM_LIBRARY_PATH} /lib64 /lib /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib /opt/local/lib64 /opt/local/lib)
+
+if(DEFINED ENV{OpenBLAS_DIR})
+  set(OpenBLAS_SEARCH_PATH $ENV{OpenBLAS_DIR} $ENV{OpenBLAS_DIR}/build/lib)
+endif()
 
 foreach (OpenBLAS_NAME ${OpenBLAS_NAMES})
   find_library(${OpenBLAS_NAME}_LIBRARY
     NAMES ${OpenBLAS_NAME}
-    PATHS ${CMAKE_SYSTEM_LIBRARY_PATH} /lib64 /lib /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib /opt/local/lib64 /opt/local/lib
-    )
-  
+    PATHS ${OpenBLAS_SEARCH_PATH}
+  )
+
   set(OpenBLAS_TMP_LIBRARY ${${OpenBLAS_NAME}_LIBRARY})
-  
+
   if(OpenBLAS_TMP_LIBRARY)
     set(OpenBLAS_TMP_LIBRARIES ${OpenBLAS_TMP_LIBRARIES} ${OpenBLAS_TMP_LIBRARY})
   endif()

--- a/cmake_aux/Modules/ARMA_FindSuperLU5.cmake
+++ b/cmake_aux/Modules/ARMA_FindSuperLU5.cmake
@@ -5,22 +5,34 @@
 #  SuperLU_LIBRARY      - Link this to use SuperLU
 #  SuperLU_INCLUDE_DIR  - directory of SuperLU headers
 
-find_path(SuperLU_INCLUDE_DIR slu_ddefs.h
-  /usr/include/superlu/
-  /usr/include/SuperLU/
-  /usr/include/
-  /usr/local/include/superlu/
-  /usr/local/include/SuperLU/
-  /usr/local/include/
-  /opt/local/include/superlu/
-  /opt/local/include/SuperLU/
-  /opt/local/include/
-)
+if(DEFINED ENV{SuperLU_DIR})
+    find_path(SuperLU_INCLUDE_DIR slu_ddefs.h $ENV{SuperLU_DIR}/SRC)
+    find_library(SuperLU_LIBRARY NAMES superlu PATHS $ENV{SuperLU_DIR}/SRC $ENV{SuperLU_DIR}/build/SRC)
+else()
+    find_path(SuperLU_INCLUDE_DIR slu_ddefs.h
+      /usr/include/superlu/
+      /usr/include/SuperLU/
+      /usr/include/
+      /usr/local/include/superlu/
+      /usr/local/include/SuperLU/
+      /usr/local/include/
+      /opt/local/include/superlu/
+      /opt/local/include/SuperLU/
+      /opt/local/include/
+    )
 
-find_library(SuperLU_LIBRARY
-  NAMES superlu
-  PATHS ${CMAKE_SYSTEM_LIBRARY_PATH} /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib /opt/local/lib64 /opt/local/lib
-)
+    find_library(SuperLU_LIBRARY
+      NAMES superlu
+      PATHS
+        ${CMAKE_SYSTEM_LIBRARY_PATH}
+        /usr/lib64
+        /usr/lib
+        /usr/local/lib64
+        /usr/local/lib
+        /opt/local/lib64
+        /opt/local/lib
+    )
+endif()
 
 set(SuperLU_FOUND NO)
 


### PR DESCRIPTION
this is useful if you use these libraries from their build directories instead of installing them.