### PR TITLE
fix use of rpath on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ if(APPLE)
     message(STATUS "Clang compiler on MacOS X detected. Added '-stdlib=libc++' to compiler flags")
   endif()
   
+  set(CMAKE_MACOSX_RPATH 1)
+  
 else()
   
   set(ARMA_OS unix)


### PR DESCRIPTION
On MacOS, armadillo's cmake generates a warning (see below) about rpath. If the install prefix is not /usr/local, then applications linked against armadillo will not be able to find it, because its install name is not set. A simple modification of the CMakeLists.txt removes the warning and enables use of rpath. See discussion at
https://blog.kitware.com/upcoming-in-cmake-2-8-12-osx-rpath-support/

```
In directory 'armadillo-code':

>> cmake -DCMAKE_INSTALL_PREFIX=/usr/local/armadillo .
-- Configuring Armadillo 8.399.0
-- CMAKE_SYSTEM_NAME          = Darwin
-- CMAKE_CXX_COMPILER_ID      = Clang
-- CMAKE_CXX_COMPILER_VERSION = 8.0.0.8000042
-- CMAKE_COMPILER_IS_GNUCXX   = 
-- BUILD_SHARED_LIBS          = ON
-- DETECT_HDF5                = ON
-- MacOS X detected. Added '-framework Accelerate' to compiler flags
-- Clang compiler on MacOS X detected. Added '-stdlib=libc++' to compiler flags
-- Checking for module 'hdf5'
--   No package 'hdf5' found
-- HDF5_FOUND = 
-- ARPACK_FOUND = NO
-- Looking for SuperLU version 5
-- Could not find SuperLU
-- SuperLU_FOUND = NO
-- 
-- *** Armadillo wrapper library will use the following libraries:
-- *** ARMA_LIBS = -framework Accelerate
-- 
-- Copying armadillo-code/include/ to armadillo-code/tmp/include/
-- Generating armadillo-code/tmp/include/config.hpp
-- Generating armadillo-code/examples/Makefile
-- CMAKE_CXX_FLAGS           =  -stdlib=libc++
-- CMAKE_SHARED_LINKER_FLAGS = 
-- CMAKE_REQUIRED_INCLUDES   = 
-- 
-- CMAKE_INSTALL_PREFIX     = /usr/local/armadillo
-- CMAKE_INSTALL_LIBDIR     = lib
-- CMAKE_INSTALL_INCLUDEDIR = include
-- CMAKE_INSTALL_DATADIR    = share
-- CMAKE_INSTALL_BINDIR     = bin
-- Generating 'armadillo-code/ArmadilloConfig.cmake'
-- Generating 'armadillo-code/ArmadilloConfigVersion.cmake'
-- Generating 'armadillo-code/InstallFiles/ArmadilloConfig.cmake'
-- Generating 'armadillo-code/InstallFiles/ArmadilloConfigVersion.cmake'
-- Copying armadillo-code/misc/ to armadillo-code/tmp/misc/
-- Generating 'armadillo-code/tmp/misc/armadillo.pc'
-- Configuring done
CMake Warning (dev):
  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake
  --help-policy CMP0042" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  MACOSX_RPATH is not specified for the following targets:

   armadillo

This warning is for project developers.  Use -Wno-dev to suppress it.

-- Generating done
-- Build files have been written to: armadillo-code



User code:

>> make
g++ -Wall -std=c++11 -c -o hello.o hello.cc
g++  -o hello hello.o -L/usr/local/armadillo/lib -Wl,-rpath,/usr/local/armadillo/lib -larmadillo

>> ./hello 
dyld: Library not loaded: libarmadillo.8.dylib
  Referenced from: ./hello
  Reason: image not found
Abort

## notice no @rpath/ before libarmadillo
>> otool -L hello
hello:
	libarmadillo.8.dylib (compatibility version 8.0.0, current version 8.39.0)
	/usr/local/lib/libstdc++.6.dylib (compatibility version 7.0.0, current version 7.22.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
	/usr/local/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 1.0.0)

>> otool -L /usr/local/armadillo/lib/libarmadillo.dylib
/usr/local/armadillo/lib/libarmadillo.dylib:
	libarmadillo.8.dylib (compatibility version 8.0.0, current version 8.39.0)
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate (compatibility version 1.0.0, current version 4.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)


After installing armadillo with CMakeLists.txt modification:

>> make
g++ -Wall -std=c++11 -c -o hello.o hello.cc
g++  -o hello hello.o -L/usr/local/armadillo/lib -Wl,-rpath,/usr/local/armadillo/lib -larmadillo

>> ./hello 
hello

## notice the @rpath/ before libarmadillo
>> otool -L hello
hello:
	@rpath/libarmadillo.8.dylib (compatibility version 8.0.0, current version 8.39.0)
	/usr/local/lib/libstdc++.6.dylib (compatibility version 7.0.0, current version 7.22.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
	/usr/local/lib/libgcc_s.1.dylib (compatibility version 1.0.0, current version 1.0.0)

>> otool -L /usr/local/armadillo/lib/libarmadillo.dylib 
/usr/local/armadillo/lib/libarmadillo.dylib:
	@rpath/libarmadillo.8.dylib (compatibility version 8.0.0, current version 8.39.0)
	/System/Library/Frameworks/Accelerate.framework/Versions/A/Accelerate (compatibility version 1.0.0, current version 4.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 307.4.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1238.0.0)
```