### PR TITLE
Transpose for row_iterators

### DIFF
--- a/include/armadillo_bits/SpMat_bones.hpp
+++ b/include/armadillo_bits/SpMat_bones.hpp
@@ -457,7 +457,11 @@ class SpMat : public SpBase< eT, SpMat<eT> >
     //! once initialised, will be at the first nonzero value after the given position (using forward row-wise traversal)
     inline const_row_iterator(const SpMat& in_M, uword in_row, uword in_col);
     inline const_row_iterator(const const_row_iterator& other);
+    inline const_row_iterator(const_row_iterator&& other);
     inline const_row_iterator(const row_iterator& other);
+
+    inline const_row_iterator& operator=(const const_row_iterator& other);
+    inline const_row_iterator& operator=(const_row_iterator&& other);
     
     inline arma_hot         const_row_iterator& operator++();
     inline arma_warn_unused const_row_iterator  operator++(int);
@@ -506,6 +510,10 @@ class SpMat : public SpBase< eT, SpMat<eT> >
     //! once initialised, will be at the first nonzero value after the given position (using forward row-wise traversal)
     inline row_iterator(SpMat& in_M, uword in_row, uword in_col);
     inline row_iterator(const row_iterator& other);
+    inline row_iterator(row_iterator&& other);
+
+    inline row_iterator& operator=(const row_iterator& other);
+    inline row_iterator& operator=(row_iterator&& other);
     
     // overloads required for return type correctness
     inline arma_hot         row_iterator& operator++();

--- a/include/armadillo_bits/SpMat_iterators_meat.hpp
+++ b/include/armadillo_bits/SpMat_iterators_meat.hpp
@@ -95,6 +95,7 @@ SpMat<eT>::const_iterator::const_iterator(const SpMat<eT>& in_M, uword initial_p
   // Determine which column we should be in.
   while(iterator_base::M->col_ptrs[iterator_base::internal_col + 1] <= iterator_base::internal_pos)
     {
+    std::cout << "colptr for next col " << iterator_base::internal_col + 1 << " is " << iterator_base::M->col_ptrs[iterator_base::internal_col + 1] << ", target pos " << iterator_base::internal_pos << "\n";
     iterator_base::internal_col++;
     }
   }
@@ -459,9 +460,22 @@ inline
 SpMat<eT>::const_row_iterator::const_row_iterator(const typename SpMat<eT>::const_row_iterator& other)
   : orig_m(other.orig_m)
   , trans_m(other.trans_m)
-  , it(trans_m, other.it.row(), other.it.col())
   {
-  // Nothing to do.
+  it.M = &trans_m;
+  it.internal_pos = other.it.internal_pos;
+  it.internal_col = other.it.internal_col;
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>::const_row_iterator::const_row_iterator(typename SpMat<eT>::const_row_iterator&& other)
+  : orig_m(other.orig_m)
+  , trans_m(std::move(other.trans_m))
+  , it(std::move(other.it))
+  {
+  other.it.M = &trans_m;
   }
 
 
@@ -471,8 +485,47 @@ inline
 SpMat<eT>::const_row_iterator::const_row_iterator(const typename SpMat<eT>::row_iterator& other)
   : orig_m(other.orig_m)
   , trans_m(other.trans_m)
-  , it(trans_m, other.it.row(), other.it.col())
-  { /* Nothing to do. */ }
+  {
+  it.M = &trans_m;
+  it.internal_pos = other.it.internal_pos;
+  it.internal_col = other.it.internal_col;
+  }
+
+
+
+template<typename eT>
+inline
+typename SpMat<eT>::const_row_iterator&
+SpMat<eT>::const_row_iterator::operator=(const typename SpMat<eT>::const_row_iterator& other)
+  {
+  if (this == &other)
+    return *this;
+
+  orig_m = other.orig_m;
+  trans_m = other.trans_m;
+  it = other.it;
+  it.M = &trans_m;
+
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+typename SpMat<eT>::const_row_iterator&
+SpMat<eT>::const_row_iterator::operator=(typename SpMat<eT>::const_row_iterator&& other)
+  {
+  if (this == &other)
+    return *this;
+
+  orig_m = other.orig_m;
+  trans_m = std::move(other.trans_m);
+  it = std::move(other.it);
+  it.M = &trans_m;
+
+  return *this;
+  }
 
 
 
@@ -690,9 +743,58 @@ inline
 SpMat<eT>::row_iterator::row_iterator(const typename SpMat<eT>::row_iterator& other)
   : orig_m(other.orig_m)
   , trans_m(other.trans_m)
-  , it(trans_m, other.it.row(), other.it.col())
   {
-  // Nothing to do.
+  it.M = &trans_m;
+  it.internal_pos = other.it.internal_pos;
+  it.internal_col = other.it.internal_col;
+  }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>::row_iterator::row_iterator(typename SpMat<eT>::row_iterator&& other)
+  : orig_m(other.orig_m)
+  , trans_m(std::move(other.trans_m))
+  , it(std::move(other.it))
+  {
+  it.M = &trans_m;
+  }
+
+
+
+template<typename eT>
+inline
+typename SpMat<eT>::row_iterator&
+SpMat<eT>::row_iterator::operator=(const typename SpMat<eT>::row_iterator& other)
+  {
+  if (this == &other)
+    return *this;
+
+  orig_m = other.orig_m;
+  trans_m = other.trans_m;
+  it = other.it;
+  it.M = &trans_m;
+
+  return *this;
+  }
+
+
+
+template<typename eT>
+inline
+typename SpMat<eT>::row_iterator&
+SpMat<eT>::row_iterator::operator=(typename SpMat<eT>::row_iterator&& other)
+  {
+  if (this == &other)
+    return *this;
+
+  orig_m = other.orig_m;
+  trans_m = std::move(other.trans_m);
+  it = std::move(other.it);
+  it.M = &trans_m;
+
+  return *this;
   }
 
 

--- a/include/armadillo_bits/SpMat_iterators_meat.hpp
+++ b/include/armadillo_bits/SpMat_iterators_meat.hpp
@@ -95,7 +95,6 @@ SpMat<eT>::const_iterator::const_iterator(const SpMat<eT>& in_M, uword initial_p
   // Determine which column we should be in.
   while(iterator_base::M->col_ptrs[iterator_base::internal_col + 1] <= iterator_base::internal_pos)
     {
-    std::cout << "colptr for next col " << iterator_base::internal_col + 1 << " is " << iterator_base::M->col_ptrs[iterator_base::internal_col + 1] << ", target pos " << iterator_base::internal_pos << "\n";
     iterator_base::internal_col++;
     }
   }

--- a/include/armadillo_bits/SpMat_iterators_meat.hpp
+++ b/include/armadillo_bits/SpMat_iterators_meat.hpp
@@ -115,10 +115,26 @@ SpMat<eT>::const_iterator::const_iterator(const SpMat<eT>& in_M, uword in_row, u
     iterator_base::internal_col++;
     }
 
-  // Now we have to get to the right row.
-  while((iterator_base::M->row_indices[iterator_base::internal_pos] < in_row) && (iterator_base::internal_col == in_col))
+  // Do we have to search for an element?  We only do this if we are in the
+  // right column.
+  if (iterator_base::internal_col == in_col)
     {
-    ++(*this); // Increment iterator.
+    const uword      col_offset = iterator_base::M->col_ptrs[iterator_base::internal_col];
+    const uword next_col_offset = iterator_base::M->col_ptrs[iterator_base::internal_col + 1];
+
+    const uword* start_ptr = &iterator_base::M->row_indices[     col_offset];
+    const uword* end_ptr   = &iterator_base::M->row_indices[next_col_offset];
+
+    // Perform a binary search.
+    const uword* pos_ptr = std::lower_bound(start_ptr, end_ptr, in_row);
+
+    const uword offset = pos_ptr - start_ptr;
+
+    // We have to increment the column if the element was the first of the next
+    // column.
+    if (pos_ptr == end_ptr)
+      ++iterator_base::internal_col;
+    iterator_base::internal_pos = col_offset + offset;
     }
   }
 
@@ -190,22 +206,13 @@ arma_hot
 typename SpMat<eT>::const_iterator&
 SpMat<eT>::const_iterator::operator--()
   {
-  //iterator_base::M.print("M");
-  
-  // printf("decrement from %d, %d, %d\n", iterator_base::internal_pos, iterator_base::internal_col, iterator_base::row());
-  
   --iterator_base::internal_pos;
-  
-  // printf("now pos %d\n", iterator_base::internal_pos);
 
   // First, see if we moved back a column.
   while (iterator_base::internal_pos < iterator_base::M->col_ptrs[iterator_base::internal_col])
     {
-    // printf("colptr %d (col %d)\n", iterator_base::M.col_ptrs[iterator_base::internal_col], iterator_base::internal_col);
-    
     --iterator_base::internal_col;
     }
-
 
   return *this;
   }
@@ -287,6 +294,28 @@ inline
 arma_hot
 bool
 SpMat<eT>::const_iterator::operator!=(const const_row_iterator& rhs) const
+  {
+  return (rhs.row() != (*this).row()) || (rhs.col() != iterator_base::internal_col);
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::const_iterator::operator==(const row_iterator& rhs) const
+  {
+  return (rhs.row() == (*this).row()) && (rhs.col() == iterator_base::internal_col);
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::const_iterator::operator!=(const row_iterator& rhs) const
   {
   return (rhs.row() != (*this).row()) || (rhs.col() != iterator_base::internal_col);
   }
@@ -398,110 +427,27 @@ SpMat<eT>::iterator::operator--(int)
 
 template<typename eT>
 inline
-SpMat<eT>::const_row_iterator::const_row_iterator()
-  : iterator_base()
-  , internal_row(0)
-  , actual_pos(0)
-  {
-  }
+SpMat<eT>::const_row_iterator::const_row_iterator() { }
 
 
 
 template<typename eT>
 inline
 SpMat<eT>::const_row_iterator::const_row_iterator(const SpMat<eT>& in_M, uword initial_pos)
-  : iterator_base(in_M, 0, initial_pos)
-  , internal_row(0)
-  , actual_pos(0)
-  {
-  // Corner case for empty matrix.
-  if(in_M.n_nonzero == 0)
-    {
-    iterator_base::internal_col = 0;
-    internal_row = in_M.n_rows;
-    return;
-    }
-
-  // We don't count zeros in our position count, so we have to find the nonzero
-  // value corresponding to the given initial position.  We assume initial_pos
-  // is valid.
-
-  // This is irritating because we don't know where the elements are in each
-  // row.  What we will do is loop across all columns looking for elements in
-  // row 0 (and add to our sum), then in row 1, and so forth, until we get to
-  // the desired position.
-  uword cur_pos = std::numeric_limits<uword>::max(); // Invalid value.
-  uword cur_row = 0;
-  uword cur_col = 0;
-
-  while(true) // This loop is terminated from the inside.
-    {
-    // Is there anything in the column we are looking at?
-    for (uword ind = 0; ((iterator_base::M->col_ptrs[cur_col] + ind < iterator_base::M->col_ptrs[cur_col + 1]) && (iterator_base::M->row_indices[iterator_base::M->col_ptrs[cur_col] + ind] <= cur_row)); ind++)
-      {
-      // There is something in this column.  Is it in the row we are looking at?
-      const uword row_index = iterator_base::M->row_indices[iterator_base::M->col_ptrs[cur_col] + ind];
-      if (row_index == cur_row)
-        {
-        // Yes, it is what we are looking for.  Increment our current position.
-        if (++cur_pos == iterator_base::internal_pos)   // TODO: HACK: if cur_pos is std::numeric_limits<uword>::max(), ++cur_pos relies on a wraparound/overflow, which is not portable
-          {
-          actual_pos = iterator_base::M->col_ptrs[cur_col] + ind;
-          internal_row = cur_row;
-          iterator_base::internal_col = cur_col;
-
-          return;
-          }
-
-        // We are done with this column.  Break to the column incrementing code (directly below).
-        break;
-        }
-      else if(row_index > cur_row)
-        {
-        break; // Can't be in this column.
-        }
-      }
-
-    cur_col++; // Done with the column.  Move on.
-    if (cur_col == iterator_base::M->n_cols)
-      {
-      // We are out of columns.  Loop back to the beginning and look on the
-      // next row.
-      cur_col = 0;
-      cur_row++;
-      }
-    }
-  }
+  : orig_m(&in_M)
+  , trans_m(in_M.st())
+  , it(trans_m, initial_pos)
+  { /* Nothing to do. */ }
 
 
 
 template<typename eT>
 inline
 SpMat<eT>::const_row_iterator::const_row_iterator(const SpMat<eT>& in_M, uword in_row, uword in_col)
-  : iterator_base(in_M, in_col, 0)
-  , internal_row(0)
-  , actual_pos(0)
-  {
-  // TODO: replace with more efficient implementation
-  
-  // So we have a destination we want to be just after,
-  // but don't know what position that is.
-  // Make another iterator to find out.
-  
-  const_row_iterator it(in_M, 0);
-  
-  while((it.row() < in_row) || ((it.row() == in_row) && (it.col() < in_col)))
-    {
-    ++it;
-    }
-  
-  // Now that it is at the right place, take its position.
-  iterator_base::internal_col = it.internal_col;
-  iterator_base::internal_pos = it.internal_pos;
-  
-  internal_row = it.internal_row;
-  actual_pos   = it.actual_pos;
-  }
+  : orig_m(&in_M)
+  , trans_m(in_M.st())
+  , it(trans_m, in_col, in_row)
+  { }
 
 
 
@@ -511,12 +457,22 @@ SpMat<eT>::const_row_iterator::const_row_iterator(const SpMat<eT>& in_M, uword i
 template<typename eT>
 inline
 SpMat<eT>::const_row_iterator::const_row_iterator(const typename SpMat<eT>::const_row_iterator& other)
-  : iterator_base(*other.M, other.internal_col, other.internal_pos)
-  , internal_row(other.internal_row)
-  , actual_pos(other.actual_pos)
+  : orig_m(other.orig_m)
+  , trans_m(other.trans_m)
+  , it(trans_m, other.it.row(), other.it.col())
   {
   // Nothing to do.
   }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>::const_row_iterator::const_row_iterator(const typename SpMat<eT>::row_iterator& other)
+  : orig_m(other.orig_m)
+  , trans_m(other.trans_m)
+  , it(trans_m, other.it.row(), other.it.col())
+  { /* Nothing to do. */ }
 
 
 
@@ -529,51 +485,14 @@ arma_hot
 typename SpMat<eT>::const_row_iterator&
 SpMat<eT>::const_row_iterator::operator++()
   {
-  // We just need to find the next nonzero element.
-  iterator_base::internal_pos++;
-
-  if(iterator_base::internal_pos == iterator_base::M->n_nonzero)
-    {
-    internal_row = iterator_base::M->n_rows;
-    iterator_base::internal_col = 0;
-    actual_pos = iterator_base::M->n_nonzero;
-
-    return *this;
-    }
-
-  // Otherwise, we need to search.
-  uword cur_col = iterator_base::internal_col;
-  uword cur_row = internal_row;
-
-  while (true) // This loop is terminated from the inside.
-    {
-    // Increment the current column and see if we are now on a new row.
-    if (++cur_col == iterator_base::M->n_cols)
-      {
-      cur_col = 0;
-      cur_row++;
-      }
-
-    // Is there anything in this new column?
-    for (uword ind = 0; ((iterator_base::M->col_ptrs[cur_col] + ind < iterator_base::M->col_ptrs[cur_col + 1]) && (iterator_base::M->row_indices[iterator_base::M->col_ptrs[cur_col] + ind] <= cur_row)); ind++)
-      {
-      if (iterator_base::M->row_indices[iterator_base::M->col_ptrs[cur_col] + ind] == cur_row)
-        {
-        // We have successfully incremented.
-        internal_row = cur_row;
-        iterator_base::internal_col = cur_col;
-        actual_pos = iterator_base::M->col_ptrs[cur_col] + ind;
-
-        return *this; // Now we are done.
-        }
-      }
-    }
+  ++it;
+  return *this;
   }
 
 
 
 /**
- * Increment the row_iterator (but do not return anything.
+ * Increment the row_iterator (but do not return anything).
  */
 template<typename eT>
 inline
@@ -599,35 +518,8 @@ arma_hot
 typename SpMat<eT>::const_row_iterator&
 SpMat<eT>::const_row_iterator::operator--()
   {
-  iterator_base::internal_pos--;
-
-  // We have to search backwards.
-  uword cur_col = iterator_base::internal_col;
-  uword cur_row = internal_row;
-
-  while (true) // This loop is terminated from the inside.
-    {
-    // Decrement the current column and see if we are now on a new row.  This is a uword so a negativity check won't work.
-    if (--cur_col > iterator_base::M->n_cols /* this means it underflew */)
-      {
-      cur_col = iterator_base::M->n_cols - 1;
-      cur_row--;
-      }
-
-    // Is there anything in this new column?
-    for (uword ind = 0; ((iterator_base::M->col_ptrs[cur_col] + ind < iterator_base::M->col_ptrs[cur_col + 1]) && (iterator_base::M->row_indices[iterator_base::M->col_ptrs[cur_col] + ind] <= cur_row)); ind++)
-      {
-      if (iterator_base::M->row_indices[iterator_base::M->col_ptrs[cur_col] + ind] == cur_row)
-        {
-        // We have successfully decremented.
-        iterator_base::internal_col = cur_col;
-        internal_row = cur_row;
-        actual_pos = iterator_base::M->col_ptrs[cur_col] + ind;
-
-        return *this; // Now we are done.
-        }
-      }
-    }
+  --it;
+  return *this;
   }
 
 
@@ -656,7 +548,7 @@ arma_hot
 bool
 SpMat<eT>::const_row_iterator::operator==(const const_iterator& rhs) const
   {
-  return (rhs.row() == row()) && (rhs.col() == iterator_base::internal_col);
+  return (rhs.row() == row()) && (rhs.col() == col());
   }
 
 
@@ -667,7 +559,7 @@ arma_hot
 bool
 SpMat<eT>::const_row_iterator::operator!=(const const_iterator& rhs) const
   {
-  return (rhs.row() != row()) || (rhs.col() != iterator_base::internal_col);
+  return (rhs.row() != row()) || (rhs.col() != col());
   }
 
 
@@ -678,7 +570,7 @@ arma_hot
 bool
 SpMat<eT>::const_row_iterator::operator==(const typename SpSubview<eT>::const_iterator& rhs) const
   {
-  return (rhs.row() == row()) && (rhs.col() == iterator_base::internal_col);
+  return (rhs.row() == row()) && (rhs.col() == col());
   }
 
 
@@ -689,7 +581,7 @@ arma_hot
 bool
 SpMat<eT>::const_row_iterator::operator!=(const typename SpSubview<eT>::const_iterator& rhs) const
   {
-  return (rhs.row() != row()) || (rhs.col() != iterator_base::internal_col);
+  return (rhs.row() != row()) || (rhs.col() != col());
   }
 
 
@@ -700,7 +592,7 @@ arma_hot
 bool
 SpMat<eT>::const_row_iterator::operator==(const const_row_iterator& rhs) const
   {
-  return (rhs.row() == row()) && (rhs.col() == iterator_base::internal_col);
+  return (rhs.row() == row()) && (rhs.col() == col());
   }
 
 
@@ -711,7 +603,29 @@ arma_hot
 bool
 SpMat<eT>::const_row_iterator::operator!=(const const_row_iterator& rhs) const
   {
-  return (rhs.row() != row()) || (rhs.col() != iterator_base::internal_col);
+  return (rhs.row() != row()) || (rhs.col() != col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::const_row_iterator::operator==(const row_iterator& rhs) const
+  {
+  return (rhs.row() == row()) && (rhs.col() == col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::const_row_iterator::operator!=(const row_iterator& rhs) const
+  {
+  return (rhs.row() != row()) || (rhs.col() != col());
   }
 
 
@@ -722,7 +636,7 @@ arma_hot
 bool
 SpMat<eT>::const_row_iterator::operator==(const typename SpSubview<eT>::const_row_iterator& rhs) const
   {
-  return (rhs.row() == row()) && (rhs.col() == iterator_base::internal_col);
+  return (rhs.row() == row()) && (rhs.col() == col());
   }
 
 
@@ -733,7 +647,7 @@ arma_hot
 bool
 SpMat<eT>::const_row_iterator::operator!=(const typename SpSubview<eT>::const_row_iterator& rhs) const
   {
-  return (rhs.row() != row()) || (rhs.col() != iterator_base::internal_col);
+  return (rhs.row() != row()) || (rhs.col() != col());
   }
 
 
@@ -744,15 +658,41 @@ SpMat<eT>::const_row_iterator::operator!=(const typename SpSubview<eT>::const_ro
 
 template<typename eT>
 inline
-arma_hot
-SpValProxy<SpMat<eT> >
-SpMat<eT>::row_iterator::operator*()
+SpMat<eT>::row_iterator::row_iterator() { }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>::row_iterator::row_iterator(SpMat<eT>& in_M, uword initial_pos)
+  : orig_m(&in_M)
+  , trans_m(in_M.st())
+  , it(trans_m, initial_pos)
+  { /* Nothing to do. */ }
+
+
+
+template<typename eT>
+inline
+SpMat<eT>::row_iterator::row_iterator(SpMat<eT>& in_M, uword in_row, uword in_col)
+  : orig_m(&in_M)
+  , trans_m(in_M.st())
+  , it(trans_m, in_col, in_row)
+  { }
+
+
+
+/**
+ * Initialize the const_row_iterator from another const_row_iterator.
+ */
+template<typename eT>
+inline
+SpMat<eT>::row_iterator::row_iterator(const typename SpMat<eT>::row_iterator& other)
+  : orig_m(other.orig_m)
+  , trans_m(other.trans_m)
+  , it(trans_m, other.it.row(), other.it.col())
   {
-  return SpValProxy<SpMat<eT> >(
-    const_row_iterator::internal_row,
-    iterator_base::internal_col,
-    access::rw(*iterator_base::M),
-    &access::rw(iterator_base::M->values[const_row_iterator::actual_pos]));
+  // Nothing to do.
   }
 
 
@@ -763,7 +703,7 @@ arma_hot
 typename SpMat<eT>::row_iterator&
 SpMat<eT>::row_iterator::operator++()
   {
-  const_row_iterator::operator++();
+  ++it;
   return *this;
   }
 
@@ -777,7 +717,7 @@ SpMat<eT>::row_iterator::operator++(int)
   {
   typename SpMat<eT>::row_iterator tmp(*this);
 
-  const_row_iterator::operator++();
+  ++it;
 
   return tmp;
   }
@@ -790,7 +730,7 @@ arma_hot
 typename SpMat<eT>::row_iterator&
 SpMat<eT>::row_iterator::operator--()
   {
-  const_row_iterator::operator--();
+  --it;
   return *this;
   }
 
@@ -804,9 +744,121 @@ SpMat<eT>::row_iterator::operator--(int)
   {
   typename SpMat<eT>::row_iterator tmp(*this);
 
-  const_row_iterator::operator--();
+  --it;
 
   return tmp;
   }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator==(const const_iterator& rhs) const
+  {
+  return (rhs.row() == row()) && (rhs.col() == col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator!=(const const_iterator& rhs) const
+  {
+  return (rhs.row() != row()) || (rhs.col() != col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator==(const typename SpSubview<eT>::const_iterator& rhs) const
+  {
+  return (rhs.row() == row()) && (rhs.col() == col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator!=(const typename SpSubview<eT>::const_iterator& rhs) const
+  {
+  return (rhs.row() != row()) || (rhs.col() != col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator==(const const_row_iterator& rhs) const
+  {
+  return (rhs.row() == row()) && (rhs.col() == col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator!=(const const_row_iterator& rhs) const
+  {
+  return (rhs.row() != row()) || (rhs.col() != col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator==(const row_iterator& rhs) const
+  {
+  return (rhs.row() == row()) && (rhs.col() == col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator!=(const row_iterator& rhs) const
+  {
+  return (rhs.row() != row()) || (rhs.col() != col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator==(const typename SpSubview<eT>::const_row_iterator& rhs) const
+  {
+  return (rhs.row() == row()) && (rhs.col() == col());
+  }
+
+
+
+template<typename eT>
+inline
+arma_hot
+bool
+SpMat<eT>::row_iterator::operator!=(const typename SpSubview<eT>::const_row_iterator& rhs) const
+  {
+  return (rhs.row() != row()) || (rhs.col() != col());
+  }
+
+
 
 //! @}

--- a/include/armadillo_bits/SpMat_meat.hpp
+++ b/include/armadillo_bits/SpMat_meat.hpp
@@ -3566,6 +3566,8 @@ SpMat<eT>::reshape(const uword in_rows, const uword in_cols, const uword dim)
     
     for(const_row_iterator it = begin_row(); it.pos() < n_nonzero; ++it)
       {
+      std::cout << "iterator " << it.row() << ", " << it.col() << ", pos " <<
+it.pos() << "\n";
       uword vector_position = (it.row() * n_cols) + it.col();
       
       tmp((vector_position / in_cols), (vector_position % in_cols)) = (*it);


### PR DESCRIPTION
This is related to #53.  I sat down to start applying `std::lower_bound()` to the code but then I thought for a little while and wondered if it's quicker to just transpose a matrix then use a regular iterator than to use a row_iterator.  So I wrote some simple example code.  (All compiled with `-O3 -DARMA_NO_DEBUG`)

First, how long do transposes take for different sparsity levels?

```
  s.sprandu(5000, 5000, 0.001);

  wall_clock timer;
  timer.tic();
  sp_mat t = s.t();
  double n = timer.toc();
```

This gives us:

```
sparsity of 0.1%: 0.00461312
sparsity of 1%: 0.0300855
sparsity of 5%: 0.161841
sparsity of 10%: 0.31695
```

Ok... next, how long does it take to simply create a row iterator with `begin_row()` and an arbitrary row?

```
  timer.tic();
  sp_mat::const_row_iterator it = s.begin_row(1000);
  double n = timer.toc();
```

Results:

```
sparsity of 0.1%: 0.045683
sparsity of 1%: 0.0866051
sparsity of 5%: 0.218077
sparsity of 10%: 0.27383
```

Hm, not so promising... next, how long does it take to use a row iterator to sum the values in a row?

```
  timer.tic();
  sp_mat::const_row_iterator it = s.begin_row(1000);
  sp_mat::const_row_iterator it_end = s.end_row(1000);
  double sum = 0.0;
  while (it != it_end)
    {
    sum += (*it);
    ++it;
    }
  double n = timer.toc();
```

Results:

```
sparsity of 0.1%: 0.0656389
sparsity of 1%: 0.174493
sparsity of 5%: 0.323036
sparsity of 10%: 0.520427
```

And what happens if we transpose the matrix and sum the same column?

```
  timer.tic();
  t = s.t();
  it = s.begin_col(1000);
  it_end = s.end_col(1000);
  sum = 0.0;
  while (it != it_end)
    {
    sum += (*it);
    ++it;
    }
  n = timer.toc();
```

Results:

```
sparsity of 0.1%: 0.00377716
sparsity of 1%: 0.0296671
sparsity of 5%: 0.146927
sparsity of 10%: 0.270471
```

So, based on that, it looks like it is generally way better to just transpose the matrix and then iterate through it.  Thus I made this PR.  With the new code, the example code above that sums all the elements in a row runs faster for low sparsity levels:

```
sparsity of 0.1%: 0.00998318 (3.1285)
sparsity of 1%: 0.0648671 (25.6474)
sparsity of 5%: 0.334096 (130.64)
sparsity of 10%: 0.565849 (263.864)
```

There is some additional slowdown here because each iterator holds its own transposed matrix, so if I do

```
auto it = m.begin_row();
auto it_end = m.end_row();
```

this copies and transposes the matrix twice.  I don't currently have a great idea to solve this without adding a lot of complexity---all I can think of at the moment is holding an extra `SpMat<eT>` pointer inside the `SpMat<eT>` that can hold a transposed version.  Alternately we issue a warning every time someone calls begin_row() and tell them to transpose instead, but I don't like that much.

Before I apply this to the SpSubview row iterators (where I'll just extract and transpose the submatrix), I wanted to see what you thought.  So before any merge here there are still two things to do (at least):

 - [ ] work out extra copies of transposed matrix issue
 - [ ] apply to SpSubview row iterators