### PR TITLE
Refactor row iterators to use lower_bound() directly

### DIFF
--- a/include/armadillo_bits/SpMat_bones.hpp
+++ b/include/armadillo_bits/SpMat_bones.hpp
@@ -460,8 +460,8 @@ class SpMat : public SpBase< eT, SpMat<eT> >
     inline arma_hot         const_row_iterator& operator--();
     inline arma_warn_unused const_row_iterator  operator--(int);
     
-    uword internal_row; // hold row internally because we use internal_pos differently
-    uword actual_pos;   // actual position in matrix
+    uword internal_row; // hold row internally
+    uword actual_pos; // this holds the true position we are at in the matrix, as column-major indexing
     
     arma_inline eT operator*() const { return iterator_base::M->values[actual_pos]; }
     


### PR DESCRIPTION
This is a follow-up to #56.  I like this one more.  Here are the benchmarkings for the following code snippet at different sparsity levels:

```
  s.sprandu(5000, 5000, 0.001); // (and other sparsity levels)
  sp_mat::const_row_iterator it = s.begin_row(1000);
  sp_mat::const_row_iterator it_end = s.end_row(1000);
  double sum = 0.0;
  while (it != it_end)
    {
    sum += (*it);
    ++it;
    }
```

Current unstable branch:

```
sparsity of 0.1%: 0.0752465
sparsity of 1%: 0.173384
sparsity of 5%: 0.421302
sparsity of 10%: 0.594542
```

Code from #56:

```
sparsity of 0.1%: 0.0104494
sparsity of 1%: 0.0608715
sparsity of 5%: 0.332878
sparsity of 10%: 0.6015
```

This PR:

```
sparsity of 0.1%: 0.000437068
sparsity of 1%: 0.000606475
sparsity of 5%: 0.000658733
sparsity of 10%: 0.000763851
```

Now we're talkin'.

You would think that I wouldn't overlook the speedups given by binary search algorithms given that I wrote an entire thesis on how branch-and-bound-type algorithms can be used to solve all sorts of interesting problems.  But hey, life is full of surprises...