### PR TITLE
Add some tests for trace() speedups.

### DIFF
--- a/tests/fn_trace.cpp
+++ b/tests/fn_trace.cpp
@@ -62,3 +62,41 @@ TEST_CASE("fn_trace_spmat")
 
   REQUIRE( trace(a.submat(2, 2, 4, 4)) == Approx(7.3) );
   }
+
+
+
+TEST_CASE("fn_trace_spmat_mul")
+  {
+  // Test trace(SpMat * SpMat) and ensure the result is the same as if we
+  // pre-multiplied the matrices.
+  sp_mat a;
+  a.sprandu(20, 20, 0.1);
+  sp_mat b;
+  b.sprandu(20, 20, 0.1);
+
+  sp_mat c = a * b;
+
+  const double trc = trace(c);
+  const double trab = trace(a * b);
+
+  REQUIRE( trc == Approx(trab) );
+  }
+
+
+
+TEST_CASE("fn_trace_spmat_t_mul")
+  {
+  // Test trace(SpMat.t() * SpMat) and ensure the result is the same as if we
+  // pre-multiplied the matrices.
+  sp_mat a;
+  a.sprandu(20, 20, 0.1);
+  sp_mat b;
+  b.sprandu(20, 20, 0.1);
+
+  sp_mat c = a.t() * b;
+
+  const double trc = trace(c);
+  const double trab = trace(a.t() * b);
+
+  REQUIRE( trc == Approx(trab) );
+  }


### PR DESCRIPTION
Pretty simple tests that just ensure that the `trace()` speedups work the same as the regular trace implementation.  I didn't see any other tests for the speedup, so let me know if I missed something.