### PR TITLE
Corrected codes for function "hess"

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -432,20 +432,21 @@ Conrad Sanderson and Ryan Curtin.
 <tr style="background-color: #F5F5F5;"><td><a href="#eig_sym">eig_sym</a></td><td>&nbsp;</td><td>eigen decomposition of dense symmetric/hermitian matrix</td></tr>
 <tr style="background-color: #F5F5F5;"><td><a href="#eig_gen">eig_gen</a></td><td>&nbsp;</td><td>eigen decomposition of dense general square matrix</td></tr>
 <tr><td><a href="#eig_pair">eig_pair</a></td><td>&nbsp;</td><td>eigen decomposition for pair of general dense square matrices</td></tr>
+<tr><td><a href="#hess">hess</a></td><td>&nbsp;</td><td>upper Hessenberg decomposition</td></tr>
 <tr><td><a href="#inv">inv</a></td><td>&nbsp;</td><td>inverse of general square matrix</td></tr>
-<tr><td><a href="#inv_sympd">inv_sympd</a></td><td>&nbsp;</td><td>inverse of symmetric positive definite matrix</td></tr>
+<tr style="background-color: #F5F5F5;"><td><a href="#inv_sympd">inv_sympd</a></td><td>&nbsp;</td><td>inverse of symmetric positive definite matrix</td></tr>
 <tr style="background-color: #F5F5F5;"><td><a href="#lu">lu&nbsp;&nbsp;</a></td><td>&nbsp;</td><td>lower-upper decomposition</td></tr>
 <tr style="background-color: #F5F5F5;"><td><a href="#null">null</a></td><td>&nbsp;</td><td>orthonormal basis of null space</td></tr>
-<tr style="background-color: #F5F5F5;"><td><a href="#orth">orth</a></td><td>&nbsp;</td><td>orthonormal basis of range space</td></tr>
+<tr><td><a href="#orth">orth</a></td><td>&nbsp;</td><td>orthonormal basis of range space</td></tr>
 <tr><td><a href="#pinv">pinv</a></td><td>&nbsp;</td><td>pseudo-inverse</td></tr>
 <tr><td><a href="#qr">qr&nbsp;&nbsp;</a></td><td>&nbsp;</td><td>QR decomposition</td></tr>
-<tr><td><a href="#qr_econ">qr_econ</a></td><td>&nbsp;</td><td>economical QR decomposition</td></tr>
+<tr style="background-color: #F5F5F5;"><td><a href="#qr_econ">qr_econ</a></td><td>&nbsp;</td><td>economical QR decomposition</td></tr>
 <tr style="background-color: #F5F5F5;"><td><a href="#qz">qz&nbsp;&nbsp;</a></td><td>&nbsp;</td><td>generalised Schur decomposition</td></tr>
 <tr style="background-color: #F5F5F5;"><td><a href="#schur">schur</a></td><td>&nbsp;</td><td>Schur decomposition</td></tr>
-<tr style="background-color: #F5F5F5;"><td><a href="#solve">solve</a></td><td>&nbsp;</td><td>solve systems of linear equations</td></tr>
+<tr><td><a href="#solve">solve</a></td><td>&nbsp;</td><td>solve systems of linear equations</td></tr>
 <tr><td><a href="#svd">svd</a></td><td>&nbsp;</td><td>singular value decomposition</td></tr>
 <tr><td><a href="#svd_econ">svd_econ</a></td><td>&nbsp;</td><td>economical singular value decomposition</td></tr>
-<tr><td><a href="#syl">syl</a></td><td>&nbsp;</td><td>Sylvester equation solver</td></tr>
+<tr style="background-color: #F5F5F5;"><td><a href="#syl">syl</a></td><td>&nbsp;</td><td>Sylvester equation solver</td></tr>
 </tbody>
 </table>
 </ul>
@@ -11358,6 +11359,60 @@ See also:
 </ul>
 
 <div class="pagebreak"></div><div class="noprint"><hr class="greyline"><br></div>
+<a name="hess"></a>
+<b>H = hess( X )</b>
+<br>
+<br><b>hess( H,  X )</b>
+<br>
+<br><b>hess( U, H, X )</b>
+<ul>
+<li>Upper Hessenberg decomposition of square matrix <i>X</i>, such that <i>X = U*H*U.t()</i></li>
+<br>
+<li><i>U</i> is a unitary matrix containing the Hessenberg vectors</li>
+<br>
+<li><i>H</i> is a square matrix called Upper Hessenberg Matrix. It has zero entries below the first subdiagonal</li>
+<br>
+<li>If <i>X</i> is not square sized, a <i>std::logic_error</i> exception is thrown</li>
+<br>
+<li>If the decomposition fails:
+<ul>
+<li><i>H = hess(X)</i> resets <i>H</i> and throws a <i>std::runtime_error</i> exception</li>
+<li><i>hess(H,X)</i> resets <i>H</i> and returns a bool set to <i>false</i> (exception is not thrown)</li>
+<li><i>hess(U,H,X)</i> resets <i>U</i> &amp; <i>H</i> and returns a bool set to <i>false</i> (exception is not thrown)</li>
+</ul>
+</li>
+<br>
+<li>
+<b>Caveat:</b> in general, upper Hessenberg decomposition is not unique
+</li>
+<br>
+<li>
+Examples:
+<ul>
+<pre>
+mat X(20,20, fill::randu);
+
+mat U;
+mat H;
+
+hess(U, H, X);
+</pre>
+</ul>
+</li>
+<br>
+<li>
+See also:
+<ul>
+<li><a href="#qz">qz()</a></li>
+<li><a href="#schur">schur()</a></li>
+<li><a href="http://mathworld.wolfram.com/HessenbergDecomposition.html">Hessenberg decomposition in MathWorld</a></li>
+<li><a href="https://en.wikipedia.org/wiki/Hessenberg_matrix">Hessenberg matrix in Wikipedia</a></li>
+</ul>
+</li>
+<br>
+</ul>
+
+<div class="pagebreak"></div><div class="noprint"><hr class="greyline"><br></div>
 <a name="inv"></a>
 <b>B = inv( A )</b>
 <br><b>inv( B, A )</b>
@@ -11922,6 +11977,7 @@ schur(U, S, X);
 <li>
 See also:
 <ul>
+<li><a href="#hess">hess()</a></li>
 <li><a href="#qz">qz()</a></li>
 <li><a href="#eig_gen">eig_gen()</a></li>
 <li><a href="http://mathworld.wolfram.com/SchurDecomposition.html">Schur decomposition in MathWorld</a></li>

--- a/include/armadillo
+++ b/include/armadillo
@@ -529,6 +529,7 @@ namespace arma
   #include "armadillo_bits/fn_interp1.hpp"
   #include "armadillo_bits/fn_qz.hpp"
   #include "armadillo_bits/fn_diff.hpp"
+  #include "armadillo_bits/fn_hess.hpp"
   #include "armadillo_bits/fn_schur.hpp"
   #include "armadillo_bits/fn_kmeans.hpp"
   #include "armadillo_bits/fn_sqrtmat.hpp"

--- a/include/armadillo_bits/auxlib_bones.hpp
+++ b/include/armadillo_bits/auxlib_bones.hpp
@@ -160,6 +160,14 @@ class auxlib
   template<typename eT>
   inline static bool chol_band_common(Mat<eT>& X, const uword KD, const uword layout);
   
+
+  //
+  // hessenberg decomposition
+
+  template<typename eT, typename T1>
+  inline static bool hess(Mat<eT>& H, const Base<eT,T1>& X, Col<eT>& tao);
+
+
   //
   // qr
   

--- a/include/armadillo_bits/auxlib_meat.hpp
+++ b/include/armadillo_bits/auxlib_meat.hpp
@@ -1883,6 +1883,60 @@ auxlib::chol_band_common(Mat<eT>& X, const uword KD, const uword layout)
   }
 
 
+//
+// hessenberg decomposition
+template<typename eT, typename T1>
+inline
+bool
+auxlib::hess(Mat<eT>& H, const Base<eT,T1>& X, Col<eT>& tao)
+  {
+  arma_extra_debug_sigprint();
+  
+  #if defined(ARMA_USE_LAPACK)
+    {
+    H = X.get_ref();
+    
+    arma_debug_check( (H.is_square() == false), "hess(): given matrix must be square sized" );
+    
+    if(H.is_empty())
+      {
+      H.reset();
+      return true;
+      }
+    
+    arma_debug_assert_blas_size(H);
+    
+    const uword H_n_rows = H.n_rows;
+    if (H_n_rows>2) {
+      tao.set_size(H_n_rows-1);
+    
+      blas_int  n      = blas_int(H_n_rows);
+      blas_int  ilo    = 1;
+      blas_int  ihi    = blas_int(H_n_rows);
+      blas_int  lda    = blas_int(H_n_rows);
+      blas_int  lwork  = 64*blas_int(H_n_rows);
+      blas_int  info   = 0;
+    
+      podarray<eT> work(static_cast<uword>(lwork));
+    
+      arma_extra_debug_print("lapack::gehrd()");
+      lapack::gehrd(&n, &ilo, &ihi, H.memptr(), &lda, tao.memptr(), work.memptr(), &lwork, &info);
+    
+      return (info == 0);
+      }
+    else return true;
+    }
+  #else
+    {
+    arma_ignore(H);
+    arma_ignore(X);
+    arma_stop_logic_error("hess(): use of LAPACK must be enabled");
+    return false;
+    }
+  #endif
+  }
+
+
 
 template<typename eT, typename T1>
 inline

--- a/include/armadillo_bits/def_lapack.hpp
+++ b/include/armadillo_bits/def_lapack.hpp
@@ -23,7 +23,11 @@
 #endif
 
 #if !defined(ARMA_BLAS_CAPITALS)
-  
+  #define arma_sgehrd sgehrd
+  #define arma_dgehrd dgehrd
+  #define arma_cgehrd cgehrd
+  #define arma_zgehrd zgehrd
+
   #define arma_sgetrf sgetrf
   #define arma_dgetrf dgetrf
   #define arma_cgetrf cgetrf
@@ -194,6 +198,11 @@
   #define arma_dlarnv dlarnv
   
 #else
+
+  #define arma_sgehrd SGEHRD
+  #define arma_dgehrd DGEHRD
+  #define arma_cgehrd CGEHRD
+  #define arma_zgehrd ZGEHRD
   
   #define arma_sgetrf SGETRF
   #define arma_dgetrf DGETRF
@@ -370,6 +379,12 @@
 
 extern "C"
   {
+  // hessenberg decomposition
+  void arma_fortran(arma_sgehrd)(blas_int* n, blas_int* ilo, blas_int* ihi, float* a, blas_int* lda, float* tao, float* work, blas_int* lwork, blas_int* info);
+  void arma_fortran(arma_dgehrd)(blas_int* n, blas_int* ilo, blas_int* ihi, double* a, blas_int* lda, double* tao, double* work, blas_int* lwork, blas_int* info);
+  void arma_fortran(arma_cgehrd)(blas_int* n, blas_int* ilo, blas_int* ihi, void* a, blas_int* lda, void* tao, void* work, blas_int* lwork, blas_int* info);
+  void arma_fortran(arma_zgehrd)(blas_int* n, blas_int* ilo, blas_int* ihi, void* a, blas_int* lda, void* tao, void* work, blas_int* lwork, blas_int* info);
+
   // LU factorisation
   void arma_fortran(arma_sgetrf)(blas_int* m, blas_int* n,  float* a, blas_int* lda, blas_int* ipiv, blas_int* info);
   void arma_fortran(arma_dgetrf)(blas_int* m, blas_int* n, double* a, blas_int* lda, blas_int* ipiv, blas_int* info);

--- a/include/armadillo_bits/fn_hess.hpp
+++ b/include/armadillo_bits/fn_hess.hpp
@@ -1,0 +1,157 @@
+// Copyright 2008-2016 Conrad Sanderson (http://conradsanderson.id.au)
+// Copyright 2008-2016 National ICT Australia (NICTA)
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// ------------------------------------------------------------------------
+
+
+//! \addtogroup fn_hess
+//! @{
+
+
+template<typename T1>
+inline
+bool
+hess
+  (
+         Mat<typename T1::elem_type>&    H,
+  const Base<typename T1::elem_type,T1>& X,
+  const typename arma_blas_type_only<typename T1::elem_type>::result* junk = 0
+  )
+  {
+  arma_extra_debug_sigprint();
+  arma_ignore(junk);
+  
+  typedef typename T1::elem_type eT;
+
+  Col<eT> tao;
+  const bool status = auxlib::hess(H, X.get_ref(), tao);
+  if (H.n_rows>2) {
+  	for (uword i=0; i<H.n_rows-2; i++) {
+    	H(span(i+2, H.n_rows-1), i).zeros();
+  	}
+  }
+  
+  if(status == false)
+    {
+    H.soft_reset();
+    arma_debug_warn("hess(): decomposition failed");
+    }
+
+  return status;
+  }
+
+
+
+template<typename T1>
+arma_warn_unused
+inline
+Mat<typename T1::elem_type>
+hess
+  (
+  const Base<typename T1::elem_type,T1>& X,
+  const typename arma_blas_type_only<typename T1::elem_type>::result* junk = 0
+  )
+  {
+  arma_extra_debug_sigprint();
+  arma_ignore(junk);
+  
+  typedef typename T1::elem_type eT;
+  
+  Mat<eT> H;
+  Col<eT> tao;
+  
+  const bool status = auxlib::hess(H, X.get_ref(), tao);
+  if (H.n_rows>2) {
+  	for (uword i=0; i<H.n_rows-2; i++) {
+    	H(span(i+2, H.n_rows-1), i).zeros();
+  	}
+  }
+  
+  if(status == false)
+    {
+    H.soft_reset();
+    arma_stop_runtime_error("hess(): decomposition failed");
+    }
+  
+  return H;
+  }
+
+
+
+template<typename T1> 
+inline
+bool
+hess
+  (
+         Mat<typename T1::elem_type>&    U,
+         Mat<typename T1::elem_type>&    H,
+  const Base<typename T1::elem_type,T1>& X,
+  const typename arma_blas_type_only<typename T1::elem_type>::result* junk = 0
+  )
+  {
+  arma_extra_debug_sigprint();
+  arma_ignore(junk);
+  
+  arma_debug_check( void_ptr(&U) == void_ptr(&H), "hess(): 'U' is an alias of 'H'" );
+  
+  typedef typename T1::elem_type eT;
+
+  Col<eT> tao;
+
+  const bool status = auxlib::hess(H, X.get_ref(), tao);
+  
+  if (H.n_rows==0) {
+  	U.reset();
+  }
+
+  else if (H.n_rows==1) {
+  	U.set_size(1, 1);
+  	U.ones();
+  }
+
+  else if (H.n_rows==2) {
+  	U.set_size(2, 2);
+  	U.eye();
+  }
+
+  else {
+		U.set_size(size(H));
+  	U.eye();
+
+  	for (uword i=0; i<H.n_rows-2; i++) {
+    	Col<eT> v(H.n_rows-i-1, fill::ones);
+    	v(span(1, H.n_rows-i-2)) = H(span(i+2, H.n_rows-1), i);
+    	U(span::all, span(i+1, H.n_rows-1)) = U(span::all, span(i+1, H.n_rows-1))-tao(i)*U(span::all, span(i+1, H.n_rows-1))*v*v.t();
+  	}
+
+  	Col<eT> yi(1, fill::ones);
+  	U(span::all, H.n_rows-1) = U(span::all, H.n_rows-1)*(yi-tao(H.n_rows-2));
+
+  	for (uword i=0; i<H.n_rows-2; i++){
+    	H(span(i+2, H.n_rows-1), i).zeros();
+  	}
+  }
+
+  if(status == false)
+    {
+    U.soft_reset();
+    H.soft_reset();
+    arma_debug_warn("hess(): decomposition failed");
+    }
+  
+  return status;
+  }
+
+
+
+//! @}

--- a/include/armadillo_bits/wrapper_lapack.hpp
+++ b/include/armadillo_bits/wrapper_lapack.hpp
@@ -26,6 +26,39 @@ namespace lapack
   template<typename eT>
   inline
   void
+  gehrd(blas_int* n, blas_int* ilo, blas_int* ihi, eT* a, blas_int* lda, eT* tao, eT* work, blas_int* lwork, blas_int* info)
+    {
+    arma_type_check(( is_supported_blas_type<eT>::value == false ));
+    
+    if(is_float<eT>::value)
+      {
+      typedef float T;
+      arma_fortran(arma_sgehrd)(n, ilo, ihi, (T*)a, lda, (T*)tao, (T*)work, lwork, info);
+      }
+    else
+    if(is_double<eT>::value)
+      {
+      typedef double T;
+      arma_fortran(arma_dgehrd)(n, ilo, ihi, (T*)a, lda, (T*)tao, (T*)work, lwork, info);
+      }
+    else
+    if(is_supported_complex_float<eT>::value)
+      {
+      typedef std::complex<float> T;
+      arma_fortran(arma_cgehrd)(n, ilo, ihi, (T*)a, lda, (T*)tao, (T*)work, lwork, info);
+      }
+    else
+    if(is_supported_complex_double<eT>::value)
+      {
+      typedef std::complex<double> T;
+      arma_fortran(arma_zgehrd)(n, ilo, ihi, (T*)a, lda, (T*)tao, (T*)work, lwork, info);
+      }
+    }
+
+
+  template<typename eT>
+  inline
+  void
   getrf(blas_int* m, blas_int* n, eT* a, blas_int* lda, blas_int* ipiv, blas_int* info)
     {
     arma_type_check(( is_supported_blas_type<eT>::value == false ));


### PR DESCRIPTION
Hi~ 
In the corrected codes:
1. All "int" are replaced by "uword" and "blas_int" type convertion is done.
2. Avoid to do operations on "X.get_ref()" and new codes can accept expressions like "A+B".
3. Overflows about "H.n_rows-2" is put into conditional statement to avoid aliasing and a test of square 
    matrix make sure that "H.n_rows=H.n_cols".
4. Empty matrix and 1 by 1 matrix are taken into account respectively.
5. Omissive definition about LAPACK is added.